### PR TITLE
ci(CI-003): add PostgreSQL service to backend CI job for integration …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,25 @@ jobs:
   backend:
     name: Backend — install, lint, test
     runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: hexarot
+          POSTGRES_PASSWORD: hexarot_password
+          POSTGRES_DB: hexarot_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URL: postgresql://hexarot:hexarot_password@localhost:5432/hexarot_test
+
     defaults:
       run:
         working-directory: backend
@@ -27,6 +46,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Run Prisma migrations
+        run: npx prisma migrate deploy
+
+      - name: Run database seed
+        run: npx prisma db seed
+
       - name: Lint
         run: npm run lint
 
@@ -36,6 +61,7 @@ jobs:
   frontend:
     name: Frontend — install, lint, test
     runs-on: ubuntu-latest
+
     defaults:
       run:
         working-directory: frontend

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -2,7 +2,7 @@
 
 ## Meta
 sync-version: 1
-last-updated: 2026-03-20
+last-updated: 2026-03-23
 
 ---
 
@@ -243,6 +243,40 @@ Sync logic:
 - Conflict between GitHub-side edit and backlog.md is logged; backlog.md wins
 - Invalid backlog (missing field, bad value, unknown dependency ID) aborts sync with
   a clear error message referencing the offending item ID
+<!-- ITEM:END -->
+
+<!-- ITEM:BEGIN -->
+### [CI-003] Add PostgreSQL service to CI pipeline for integration tests
+
+- **type:** ci
+- **id:** CI-003
+- **milestone:** v1
+- **status:** ready
+- **priority:** high
+- **domain:** infra
+- **complexity:** S
+- **parent:** ~
+- **depends-on:** CI-001
+- **learning:** [GitHub Actions services, Docker service containers in CI, environment variable injection in GitHub Actions, database seeding in CI pipelines]
+- **labels:** [ci, domain:infra, priority:high, milestone:v1]
+
+#### Description
+
+Amend the CI workflow to support integration tests that require a live PostgreSQL
+database. The backend job must declare a `services:` block with a PostgreSQL container,
+inject the `DATABASE_URL` environment variable, wait for the service to be healthy,
+run Prisma migrations, and execute the database seed before running tests.
+
+This unblocks TEST-002 (API integration tests) in CI.
+
+#### Acceptance criteria
+
+- CI backend job declares a `services:` block with a PostgreSQL image
+- `DATABASE_URL` is injected as an environment variable in the backend job
+- Job waits for PostgreSQL to be healthy before running any commands
+- Prisma migrations are applied before tests run
+- Seed script runs successfully before tests run
+- TEST-002 integration tests pass in CI
 <!-- ITEM:END -->
 
 <!-- ITEM:BEGIN -->
@@ -848,6 +882,49 @@ All UI strings are routed through vue-i18n keys.
 <!-- ITEM:END -->
 
 <!-- ITEM:BEGIN -->
+### [TEST-004] Shared MockAlphabet for contract testing
+
+- **type:** test
+- **id:** TEST-004
+- **milestone:** v1
+- **status:** ready
+- **priority:** high
+- **domain:** alphabet
+- **complexity:** S
+- **parent:** ~
+- **depends-on:** FEAT-001
+- **learning:** [test doubles vocabulary (stub vs mock vs fake), interface contract testing in TypeScript, shared test fixtures]
+- **labels:** [test, domain:alphabet, priority:high, milestone:v1]
+
+#### Description
+
+Implement a `MockAlphabet` — a minimal, self-contained implementation of `VisualAlphabet`
+intended exclusively for use in tests. It must be defined independently of `HexahueAlphabet`
+and must use deliberately different symbol dimensions (e.g. 3×2 instead of Hexahue's 2×3)
+to ensure that tests exercising the `VisualAlphabet` contract are not accidentally coupled
+to Hexahue-specific dimensions.
+
+`MockAlphabet` must be placed in a shared test utilities module, importable by any test
+suite in the backend. It supports a small, fixed character set (e.g. A–F) with hardcoded
+colour grids.
+
+This item also formalises the `symbolWidth` and `symbolHeight` properties as required
+members of the `VisualAlphabet` interface, so that consumers (validator, grid constructor)
+can query dimensions without knowing the concrete implementation.
+
+#### Acceptance criteria
+
+- `MockAlphabet` implements `VisualAlphabet` fully
+- Symbol dimensions differ from Hexahue (width ≠ 2 or height ≠ 3)
+- `symbolWidth` and `symbolHeight` are exposed as required properties on `VisualAlphabet`
+- `MockAlphabet` is importable from a shared test utilities path (e.g. `test/utils/mock-alphabet`)
+- `HexahueAlphabet` exposes `symbolWidth: 2` and `symbolHeight: 3` in conformance with
+  the updated interface
+- At least one existing test (FEAT-001 unit tests) is updated to use `MockAlphabet`
+  for contract-level assertions, separate from Hexahue-specific assertions
+<!-- ITEM:END -->
+
+<!-- ITEM:BEGIN -->
 ### [TEST-001] Backend unit test suite — cipher and key modules
 
 - **type:** test
@@ -888,7 +965,7 @@ these modules. Tests must be deterministic and isolated (no database, no filesys
 - **domain:** api
 - **complexity:** M
 - **parent:** ~
-- **depends-on:** FEAT-011, FEAT-012, FEAT-013, TEST-001
+- **depends-on:** FEAT-011, FEAT-012, FEAT-013, TEST-001, CI-003
 - **learning:** [NestJS testing module, supertest for HTTP integration tests, test database setup and teardown, fixture patterns]
 - **labels:** [test, domain:api, priority:high, milestone:v1]
 

--- a/docs/tests/api.md
+++ b/docs/tests/api.md
@@ -1,0 +1,124 @@
+# HexaRot — Test Spec: API Domain
+
+Covers: FEAT-011 (POST /encode), FEAT-012 (POST /decode), FEAT-013 (POST /key/generate,
+GET /key/parse).
+
+All tests in this document are **integration tests**. They use the NestJS testing module
+and supertest. They require a seeded PostgreSQL test database (full Hexahue alphabet).
+
+Each test run must be isolated: no state leakage between tests. Strategy: wrap each
+test in a transaction that is rolled back, or truncate mutable tables in `afterEach`.
+The Hexahue alphabet seed data is read-only and does not need cleanup.
+
+> ⚠️ **Pending**: CI-001 must provision a PostgreSQL service in the CI environment
+> before these tests can run in CI. See `index.md` — Open Points.
+
+---
+
+## 1. POST /encode (FEAT-011)
+
+```
+describe('POST /encode')
+```
+
+**Happy path**
+- it returns 200 with a valid base64 PNG string in `png`
+- it returns 200 with a valid SVG string in `svg` (starts with '\<svg')
+- it returns 200 with a valid HR key string in `key`
+- it returns 200 with an empty `warnings` array when params are strong
+- it returns 200 with an empty `unknownChars` array for a clean ASCII message
+- it generates a key from individual params when no `key` field is provided
+- it uses the provided `key` and ignores individual params when `key` is present
+- it encodes the same message with all three size options without error
+
+**Weakness warning**
+- it returns 200 with a non-empty `warnings` array when pivotBlockSize=2
+- it returns 200 and does not block encoding when a weakness warning is present
+- it returns 200 with an empty `warnings` array when `overrideWeaknessWarning=true`
+  and pivotBlockSize=2 (warning suppressed)
+
+**Unknown characters**
+- it returns 200 with the unknown character listed in `unknownChars` for a message
+  containing an unsupported symbol
+- it encodes the remaining supported characters when unknown chars are present
+
+**Validation errors**
+- it returns 400 when `message` is missing
+- it returns 400 when `message` is an empty string
+- it returns 400 when `key` is provided but malformed
+- it returns 400 when `rotationDirection` is not 'cw' or 'ccw'
+- it returns 400 when `size` is not 'small', 'medium', or 'large'
+- it returns 400 when extra fields are present in the body (strict DTO)
+
+---
+
+## 2. POST /decode (FEAT-012)
+
+```
+describe('POST /decode')
+```
+
+**Round-trip**
+- it decodes a PNG cryptogram produced by POST /encode and recovers the original message
+- it decodes an SVG cryptogram produced by POST /encode and recovers the original message
+- it recovers the message for all four reading orders
+- it recovers the message for both rotation directions
+- it recovers the message for a multi-word message with spaces (if supported by alphabet)
+
+**Validation errors**
+- it returns 400 when `cryptogram` is missing
+- it returns 400 when `key` is missing
+- it returns 400 when `key` is malformed
+- it returns 400 when `format` is not 'png' or 'svg'
+- it returns 400 when `cryptogram` is not valid base64 (for PNG format)
+- it returns 400 when `cryptogram` is not valid SVG (for SVG format)
+
+---
+
+## 3. POST /key/generate (FEAT-013)
+
+```
+describe('POST /key/generate')
+```
+
+- it returns 200 with a valid HR key string for a fully specified parameter set
+- it returns 200 with a valid HR key string when no body is provided (default params)
+- it returns 200 with a valid HR key string for each of the four reading orders
+- it returns 200 with a valid HR key string for both rotation directions
+- it returns 400 when `rotationDirection` is an invalid value
+- it returns 400 when `readingOrder` is an unknown value
+- it returns 400 when `pivotBlockSize` is not a positive integer
+
+**Round-trip with GET /key/parse**
+- it generates a key and parses it back to recover the original params without data loss
+
+---
+
+## 4. GET /key/parse (FEAT-013)
+
+```
+describe('GET /key/parse')
+```
+
+- it returns 200 with all decoded params for a valid HR key
+- it returns the correct pivotBlockSize
+- it returns the correct rotationSequence as an array of angles
+- it returns the correct rotationDirection ('cw' or 'ccw')
+- it returns the correct readingOrder string
+- it returns 400 for a malformed key string
+- it returns 400 for an empty `key` query param
+- it returns 400 when the `key` query param is missing
+
+---
+
+## Fixtures
+
+The following shared fixtures must be defined in `test/fixtures/api.fixtures.ts`:
+
+- `VALID_ENCODE_BODY` — a minimal valid POST /encode request body
+- `VALID_ENCODE_BODY_WITH_KEY` — same, with a pre-built HR key instead of individual params
+- `WEAK_ENCODE_BODY` — a valid body with pivotBlockSize=2 (triggers weakness warning)
+- `ENCODE_BODY_WITH_UNKNOWN_CHARS` — a valid body whose message contains unsupported characters
+- `VALID_KEY_STRING` — a pre-computed valid HR key string (matches DEFAULT_KEY_PARAMS
+  from key.fixtures.ts)
+- `MALFORMED_KEY_STRINGS` — array of strings that are structurally invalid HR keys

--- a/docs/tests/cipher.md
+++ b/docs/tests/cipher.md
@@ -1,0 +1,209 @@
+# HexaRot — Test Spec: Cipher Domain
+
+Covers: FEAT-001 (VisualAlphabet / HexahueAlphabet), FEAT-002 (pre-processing),
+FEAT-003 (parameter validation), FEAT-006 (grid construction), FEAT-008 (metadata header).
+
+All tests in this document are **unit tests**. No database access.
+
+Tests that exercise the `VisualAlphabet` contract (pre-processing, parameter validation,
+grid construction) use `MockAlphabet` — the shared test double defined by TEST-004,
+located at `test/utils/mock-alphabet`. `MockAlphabet` uses dimensions **3×2** (width×height)
+and supports characters A–F with hardcoded colour grids.
+
+`HexahueAlphabet` is tested separately against its own data, using a mock data source
+that reproduces the Hexahue structure (dimensions 2×3).
+
+---
+
+## 1. VisualAlphabet / HexahueAlphabet (FEAT-001)
+
+### Contract tests — via MockAlphabet (TEST-004)
+
+These tests verify the `VisualAlphabet` interface contract independently of any real
+alphabet. They use `MockAlphabet` (dimensions 3×2, characters A–F).
+
+```
+describe('VisualAlphabet contract — MockAlphabet')
+```
+
+- it returns a ColorGrid of the correct dimensions (symbolWidth × symbolHeight) for a supported character
+- it returns a grid where every cell contains a value from the alphabet's colour set
+- it throws a typed `UnsupportedCharacterError` for a character not in the supported set
+- it throws for an empty string input
+- it throws for a multi-character string input
+- it returns no duplicate entries from `getSupportedChars`
+- it returns only single-character strings from `getSupportedChars`
+- it exposes `symbolWidth` as a required numeric property
+- it exposes `symbolHeight` as a required numeric property
+
+### HexahueAlphabet-specific tests
+
+```
+describe('HexahueAlphabet.getBlock')
+```
+
+- it returns a **2×3** ColorGrid for every supported character
+- it returns a grid where each cell contains a valid Hexahue palette colour
+- it is case-insensitive (input is pre-processed upstream, but defensive handling is acceptable)
+- it exposes `symbolWidth: 2` and `symbolHeight: 3`
+
+```
+describe('HexahueAlphabet.getSupportedChars')
+```
+
+- it returns an array containing all 26 uppercase letters
+- it returns an array containing all 10 digits
+- it returns an array containing all special characters defined in the Hexahue spec
+
+---
+
+## 2. Text pre-processing (FEAT-002)
+
+All `preprocess` tests use `MockAlphabet` (characters A–F, dimensions 3×2) as the
+alphabet argument. This decouples the pre-processing logic from Hexahue specifics.
+
+### `preprocess(input, alphabet)`
+
+```
+describe('preprocess')
+```
+
+**Uppercasing**
+- it converts a lowercase ASCII string to uppercase
+- it converts a mixed-case string to uppercase
+- it leaves an already-uppercase string unchanged
+
+**Transliteration**
+- it converts French accented characters: é→E, è→E, ê→E, à→A, â→A, ù→U, û→U, î→I, ô→O, ç→C, œ→OE, æ→AE
+- it converts Spanish accented characters: ñ→N, á→A, í→I, ó→O, ú→U, ü→U
+- it converts German accented characters: ä→A, ö→O, ü→U, ß→SS
+- it converts Portuguese accented characters: ã→A, õ→O, ç→C
+- it applies transliteration before checking against the alphabet
+
+**Unknown character reporting**
+- it returns an empty `unknownChars` array when all characters are supported
+- it collects characters that remain unsupported after transliteration
+- it does not silently drop unknown characters from the processed string
+- it reports each distinct unknown character only once (no duplicates in the report)
+- it preserves the relative position logic: unknown chars are excluded from the
+  output string but listed in `unknownChars`
+
+**Edge cases**
+- it returns an empty processed string and empty `unknownChars` for an empty input
+- it returns an empty processed string and all chars in `unknownChars` for a string
+  composed entirely of unsupported characters
+- it handles a string of length 1 correctly for both supported and unsupported input
+
+**Purity**
+- it does not mutate the input string
+- it returns the same result for the same input (deterministic)
+
+---
+
+## 3. Parameter validation (FEAT-003)
+
+All `validateParams` tests use `MockAlphabet` (symbolWidth=3, symbolHeight=2) unless
+otherwise noted. GCD weak/valid thresholds are computed against these dimensions.
+
+### `validateParams(pivotBlockSize, alphabet)`
+
+```
+describe('validateParams')
+```
+
+**Valid configurations**
+- it returns `{ status: 'valid' }` for T=5 (GCD(5,3)=1, GCD(5,2)=1) with MockAlphabet
+- it returns `{ status: 'valid' }` for T=7
+- it returns `{ status: 'valid' }` for T=11
+
+**Weak configurations**
+- it returns `{ status: 'weak' }` for T=3 (GCD(3,3)=3, shares factor with symbolWidth)
+- it returns `{ status: 'weak' }` for T=2 (GCD(2,2)=2, shares factor with symbolHeight)
+- it returns `{ status: 'weak' }` for T=6 (GCD(6,3)=3 and GCD(6,2)=2, both dimensions)
+- it includes a human-readable explanation in the `weak` result
+- it identifies which dimension(s) caused the weakness in the explanation
+
+**Override**
+- it returns `{ status: 'overridden' }` for a weak T when override flag is true
+- it returns `{ status: 'valid' }` for a valid T even when override flag is true
+  (override does not change a valid result)
+
+**GCD utility**
+- it computes GCD(0, n) = n
+- it computes GCD(n, 0) = n
+- it computes GCD(12, 8) = 4
+- it computes GCD(7, 3) = 1
+
+---
+
+## 4. Grid construction (FEAT-006)
+
+`buildGrid` tests use `MockAlphabet` (symbolWidth=3, symbolHeight=2, characters A–F).
+T values are chosen to be coprime with both 3 and 2 (e.g. T=5, T=7) unless the test
+specifically targets a dimension relationship.
+
+### `buildGrid(processedString, alphabet, pivotBlockSize)`
+
+```
+describe('buildGrid')
+```
+
+**Dimensions**
+- it produces a grid whose width in cases is a multiple of pivotBlockSize
+- it produces a grid whose height in cases is a multiple of pivotBlockSize
+- it satisfies both dimension constraints for T=5, T=7, T=11
+
+**Symbol layout**
+- it places the first symbol of the message at position (0,0)
+- it lays out symbols left-to-right, top-to-bottom within the message area
+- it places all N symbols of the message in the grid (no symbol omitted)
+- it places no message symbol in the padding area
+
+**Padding**
+- it fills trailing positions with valid colour values from the alphabet's palette
+- it places padding only after the last message symbol
+- it uses random padding (two calls with the same input may differ in padding content)
+
+**Edge cases**
+- it handles a message that fills the grid exactly (zero padding needed)
+- it handles a single-character message
+- it handles an empty string (grid contains only padding)
+
+---
+
+## 5. Metadata header (FEAT-008)
+
+### `encodeHeader(messageLength)` / `decodeHeader(encoded)`
+
+```
+describe('encodeHeader / decodeHeader')
+```
+
+**Round-trip**
+- it recovers messageLength=1 after encode→decode
+- it recovers messageLength=100 after encode→decode
+- it recovers the maximum supported message length after encode→decode
+
+**encodeHeader**
+- it returns a value of the documented fixed size (byte count or case count)
+- it is deterministic for the same input
+- it does not embed any key-related information
+
+**decodeHeader**
+- it throws or returns an error for a malformed header input
+- it throws or returns an error for a truncated header input
+
+---
+
+## Fixtures
+
+**`MockAlphabet`** — imported from `test/utils/mock-alphabet` (defined by TEST-004).
+This is the canonical shared test double for `VisualAlphabet`. Do not redefine it here.
+Properties: `symbolWidth: 3`, `symbolHeight: 2`, supported characters: A–F.
+
+The following additional fixtures must be defined in `__fixtures__/cipher.fixtures.ts`:
+
+- `VALID_PIVOT_SIZES` — `[5, 7, 11]` (coprime with both 3 and 2)
+- `WEAK_PIVOT_SIZES_MOCK` — `[2, 3, 6]` (share a factor with MockAlphabet dimensions)
+- `SAMPLE_MESSAGES` — a set of short strings using MockAlphabet's character set (A–F),
+  covering: all supported chars, empty string, single char, string with unsupported chars.

--- a/docs/tests/frontend.md
+++ b/docs/tests/frontend.md
@@ -1,0 +1,177 @@
+# HexaRot — Test Spec: Frontend Domain
+
+Covers: FEAT-014 (encode view), FEAT-015 (decode view), FEAT-016 (key view),
+and their associated Pinia stores.
+
+All tests in this document are **unit tests** using Vitest and Vue Test Utils.
+API calls are mocked with `vi.mock` — no real HTTP requests are made.
+
+---
+
+## 1. Encode view (FEAT-014)
+
+```
+describe('EncodeView')
+```
+
+**Initial state**
+- it renders the message input field
+- it renders all parameter controls (pivotBlockSize, rotationDirection, readingOrder,
+  size, rotationSequence)
+- it renders the submit button
+- it does not display a cryptogram preview on initial render
+- it does not display warnings or unknown chars on initial render
+
+**Form submission**
+- it calls the encode API with the correct payload when the form is submitted
+- it passes the message value from the input field in the API call
+- it passes the selected size option in the API call
+- it shows a loading indicator while the API call is in progress
+- it hides the loading indicator after the API call resolves
+
+**Successful response**
+- it displays the PNG preview after a successful encode response
+- it displays the SVG preview after a successful encode response
+- it displays the HR key returned by the API
+- it makes the HR key copyable (copy button present)
+- it shows a PNG download link/button
+- it shows an SVG download link/button
+
+**Warnings and unknown chars**
+- it displays weakness warnings when the API response includes them
+- it displays the list of unknown characters when the API response includes them
+- it does not display warning or unknown char sections when arrays are empty
+
+**Error handling**
+- it displays an error message when the API call returns a 4xx or 5xx response
+- it does not display a cryptogram preview after an API error
+- it clears the previous result when a new submission is made
+
+**i18n**
+- it renders no raw string literals — all visible text comes from i18n keys
+  (verified by checking that no hardcoded English strings appear outside the locale file)
+
+---
+
+## 2. Encode store (Pinia)
+
+```
+describe('useEncodeStore')
+```
+
+- it initialises with null result and no errors
+- it sets loading=true when encode action is dispatched
+- it sets loading=false after encode action resolves (success or error)
+- it stores the PNG, SVG, key, warnings, and unknownChars from a successful response
+- it stores the error message from a failed response
+- it clears the previous result when a new encode action is dispatched
+
+---
+
+## 3. Decode view (FEAT-015)
+
+```
+describe('DecodeView')
+```
+
+**Initial state**
+- it renders the file upload area
+- it renders the HR key input field
+- it renders the submit button
+- it does not display a decoded message on initial render
+
+**File upload**
+- it accepts a PNG file via the file input
+- it accepts an SVG file via the file input
+- it rejects files with unsupported extensions and shows an error
+- it displays the uploaded filename after selection
+- it supports drag-and-drop (dragover and drop events are handled)
+
+**Form submission**
+- it calls the decode API with the file content (base64 for PNG, string for SVG)
+  and the key when submitted
+- it shows a loading indicator while the API call is in progress
+
+**Successful response**
+- it displays the decoded message after a successful decode response
+
+**Error handling**
+- it displays an error when the key format is invalid (client-side, before API call)
+- it displays an error when the API call fails
+- it does not display a decoded message after an API error
+
+**i18n**
+- it renders no raw string literals outside the locale file
+
+---
+
+## 4. Decode store (Pinia)
+
+```
+describe('useDecodeStore')
+```
+
+- it initialises with null result and no errors
+- it sets loading=true when decode action is dispatched
+- it sets loading=false after decode action resolves
+- it stores the decoded message from a successful response
+- it stores the error from a failed response
+- it clears the previous result when a new decode action is dispatched
+
+---
+
+## 5. Key view (FEAT-016)
+
+```
+describe('KeyView')
+```
+
+**Key generator section**
+- it renders all parameter controls
+- it renders the generate button
+- it calls the key generate API when the generate button is clicked
+- it displays the returned HR key after a successful generate response
+- it renders a copy-to-clipboard button next to the key
+- it provides visual feedback after clipboard copy (button state change or toast)
+
+**Key parser section**
+- it renders the key input field
+- it renders the parse button
+- it calls the key parse API when the parse button is clicked
+- it displays all decoded parameters after a successful parse response
+- it displays a clear error message for a malformed key (client-side validation)
+- it displays a clear error message when the API returns 400
+
+**i18n**
+- it renders no raw string literals outside the locale file
+
+---
+
+## 6. Key store (Pinia)
+
+```
+describe('useKeyStore')
+```
+
+- it initialises with null generated key and null parsed params
+- it stores the generated key from a successful generate response
+- it stores the parsed params from a successful parse response
+- it stores the error from a failed generate response
+- it stores the error from a failed parse response
+- it clears the previous generated key when a new generate action is dispatched
+- it clears the previous parsed params when a new parse action is dispatched
+
+---
+
+## Fixtures
+
+The following shared fixtures must be defined in `src/__fixtures__/frontend.fixtures.ts`:
+
+- `MOCK_ENCODE_RESPONSE` — a realistic successful encode API response object
+- `MOCK_ENCODE_RESPONSE_WITH_WARNINGS` — encode response including warnings and unknownChars
+- `MOCK_DECODE_RESPONSE` — a successful decode API response object
+- `MOCK_KEY_GENERATE_RESPONSE` — a successful key generate response
+- `MOCK_KEY_PARSE_RESPONSE` — a successful key parse response with all fields populated
+- `MOCK_PNG_FILE` — a minimal File object with type 'image/png'
+- `MOCK_SVG_FILE` — a minimal File object with type 'image/svg+xml'
+- `MALFORMED_KEY` — a string that fails HR key client-side validation

--- a/docs/tests/index.md
+++ b/docs/tests/index.md
@@ -1,0 +1,92 @@
+# HexaRot — Test Strategy Index
+
+## 1. Philosophy
+
+Tests are written **before implementation** (spec-first). Each spec document in this
+folder defines the expected behaviour of a module from the outside — inputs, outputs,
+edge cases, and error conditions. The Implementation thread must honour these specs.
+Tests are the contract; implementation is the fulfilment.
+
+Unit tests must be **pure and isolated**: no database access, no filesystem, no network.
+Dependencies are mocked at the module boundary.
+
+Integration tests (API layer) are the only layer allowed to hit a real database, and
+only in a dedicated test environment.
+
+---
+
+## 2. Coverage Thresholds
+
+| Scope | Threshold | Metric |
+|---|---|---|
+| Algorithmic core (cipher, rotation, key, reading-order) | **90%** | branch coverage |
+| Peripheral modules (renderer, validation, API controllers) | **75%** | branch coverage |
+| Global (backend + frontend combined) | **> 75%** | branch coverage |
+
+These thresholds are enforced in CI (Jest `--coverage` with `coverageThreshold` in
+`jest.config.ts`, Vitest equivalent for the frontend).
+
+---
+
+## 3. Test Layers
+
+### Unit tests (Jest — backend)
+- Scope: pure functions and classes, no I/O
+- Location: co-located with source files (`*.spec.ts`)
+- Mocking: Jest mocks for any injected dependency (PrismaClient, etc.)
+- Must run in under 30 seconds total
+
+### Integration tests (Jest — backend)
+- Scope: HTTP endpoints via NestJS testing module + supertest
+- Location: `test/` directory at backend root
+- Requires: seeded PostgreSQL test database
+- Must clean up state between runs (transactions or truncation)
+
+### Unit tests (Vitest — frontend)
+- Scope: Vue components and Pinia stores
+- Location: co-located with source files (`*.spec.ts`)
+- Mocking: `vi.mock` for API calls (fetch/axios)
+
+---
+
+## 4. Conventions
+
+- Test file naming: `<module>.spec.ts`
+- Each `describe` block maps to one class or function
+- Each `it` block describes one behaviour, written as a sentence:
+  `it('returns an empty array when input is an empty string')`
+- No logic in tests: no loops, no conditionals — one assertion path per `it`
+- Shared fixtures go in a `__fixtures__` directory adjacent to the spec file
+
+---
+
+## 5. Backlog Correspondence
+
+| Backlog item | Spec document | Layer |
+|---|---|---|
+| FEAT-001 (VisualAlphabet / Hexahue) | [cipher.md](./cipher.md) | Unit |
+| FEAT-002 (Pre-processing) | [cipher.md](./cipher.md) | Unit |
+| FEAT-003 (Parameter validation) | [cipher.md](./cipher.md) | Unit |
+| FEAT-004 (Key codec) | [key.md](./key.md) | Unit |
+| FEAT-005 (Reading order strategies) | [reading-order.md](./reading-order.md) | Unit |
+| FEAT-006 (Grid construction) | [cipher.md](./cipher.md) | Unit |
+| FEAT-007 (Block rotation engine) | [rotation.md](./rotation.md) | Unit |
+| FEAT-008 (Metadata header) | [cipher.md](./cipher.md) | Unit |
+| FEAT-009 (PNG renderer) | [renderer.md](./renderer.md) | Unit + Integration |
+| FEAT-010 (SVG renderer) | [renderer.md](./renderer.md) | Unit + Integration |
+| FEAT-011 (Encode endpoint) | [api.md](./api.md) | Integration |
+| FEAT-012 (Decode endpoint) | [api.md](./api.md) | Integration |
+| FEAT-013 (Key endpoints) | [api.md](./api.md) | Integration |
+| FEAT-014/015/016 (Frontend views) | [frontend.md](./frontend.md) | Unit (Vitest) |
+| TEST-001 | cipher.md, key.md, rotation.md, reading-order.md | Consolidation |
+| TEST-002 | api.md | Consolidation |
+| TEST-003 | frontend.md | Consolidation |
+
+---
+
+## 6. Open Points
+
+- **PostgreSQL in CI**: TEST-002 requires a live database in the CI environment.
+  CI-001 is `done` but it is not confirmed whether a PostgreSQL service is provisioned.
+  If not, a CI amendment or a new CI item is required before TEST-002 can run.
+  → **Pending confirmation from project owner.**

--- a/docs/tests/key.md
+++ b/docs/tests/key.md
@@ -1,0 +1,90 @@
+# HexaRot — Test Spec: Key Domain
+
+Covers: FEAT-004 (KeyCodec — encode, decode, validate).
+
+All tests in this document are **unit tests**. No database access, no filesystem.
+
+---
+
+## 1. KeyCodec (FEAT-004)
+
+### `encode(params)` / `decode(key)`
+
+```
+describe('KeyCodec — round-trip')
+```
+
+**Round-trip correctness**
+- it recovers the original params after encode→decode for the default parameter set
+- it recovers pivotBlockSize correctly for values: 2, 3, 5, 7, 11
+- it recovers rotationDirection 'cw' after round-trip
+- it recovers rotationDirection 'ccw' after round-trip
+- it recovers all four base reading orders after round-trip: LR-TB, RL-TB, TB-LR, BT-LR
+- it recovers all four reading orders with the alternate modifier after round-trip
+- it recovers all 24 rotation sequence permutations after round-trip
+
+**Key format**
+- it produces a string prefixed with 'HR'
+- it produces a string containing only base36 characters after the 'HR' prefix
+- it produces a string of the documented fixed length (or within the documented range)
+- it does not embed message content or message length
+
+```
+describe('KeyCodec.encode')
+```
+
+- it is deterministic: same params always produce the same key string
+- it encodes rotation sequence as a permutation index (0–23), not as raw angle values
+
+```
+describe('KeyCodec.decode')
+```
+
+- it throws a typed `InvalidKeyError` for a key that does not start with 'HR'
+- it throws a typed `InvalidKeyError` for a key with an unknown version byte
+- it throws a typed `InvalidKeyError` for a truncated key string
+- it throws a typed `InvalidKeyError` for a key containing non-base36 characters
+
+### `validate(key)`
+
+```
+describe('KeyCodec.validate')
+```
+
+- it returns true for a key produced by `encode`
+- it returns false for an empty string
+- it returns false for a string not starting with 'HR'
+- it returns false for a key with incorrect length
+- it returns false for a key containing non-base36 characters after the prefix
+- it returns false for a key with an unknown version identifier
+- it does not throw — it always returns a boolean
+
+---
+
+## 2. Rotation sequence encoding
+
+```
+describe('KeyCodec — rotation sequence permutations')
+```
+
+The 24 permutations of [0°, 90°, 180°, 270°] must each map to a unique index (0–23)
+and be fully recoverable.
+
+- it assigns a unique index to each of the 24 permutations
+- it recovers permutation [0, 90, 180, 270] (identity order)
+- it recovers permutation [270, 180, 90, 0] (reverse order)
+- it recovers permutation [90, 0, 270, 180]
+- it recovers permutation [180, 270, 0, 90]
+- it produces no two permutations with the same index
+
+---
+
+## Fixtures
+
+The following shared fixtures must be defined in `__fixtures__/key.fixtures.ts`:
+
+- `ALL_24_PERMUTATIONS` — exhaustive array of all 24 permutations of [0, 90, 180, 270]
+- `DEFAULT_KEY_PARAMS` — a valid `KeyParams` object using default values
+- `ALL_READING_ORDERS` — array of all V1 reading order values including alternate variants
+- `VALID_ENCODED_KEY` — a pre-computed valid key string matching `DEFAULT_KEY_PARAMS`,
+  used to test `decode` and `validate` without relying on `encode`

--- a/docs/tests/reading-order.md
+++ b/docs/tests/reading-order.md
@@ -1,0 +1,123 @@
+# HexaRot — Test Spec: Reading Order Domain
+
+Covers: FEAT-005 (ReadingOrderStrategy — LR-TB, RL-TB, TB-LR, BT-LR, alternate modifier).
+
+All tests in this document are **unit tests**. No database access, no filesystem.
+Each strategy is a pure function: given grid dimensions (in blocks), it returns an
+ordered sequence of `{x, y}` coordinates.
+
+---
+
+## 1. Common invariants (all strategies)
+
+These invariants apply to every strategy and every variant (base + alternate).
+They are tested for each strategy individually — do not rely on a shared loop in tests.
+
+```
+describe('<StrategyName> — invariants')
+```
+
+- it covers every block exactly once for a 3×3 grid
+- it covers every block exactly once for a 1×5 grid
+- it covers every block exactly once for a 5×1 grid
+- it covers every block exactly once for a 1×1 grid
+- it returns a sequence of length `gridWidth × gridHeight`
+- it returns no coordinate outside the grid bounds
+- it returns no duplicate coordinates
+
+---
+
+## 2. LR-TB (left-right, top-bottom)
+
+```
+describe('LrTbStrategy')
+```
+
+- it starts at (0, 0)
+- it traverses row 0 left to right before moving to row 1
+- it ends at (gridWidth-1, gridHeight-1) for a 3×3 grid
+- it produces [(0,0),(1,0),(2,0),(0,1),(1,1),(2,1),(0,2),(1,2),(2,2)] for a 3×3 grid
+
+**Alternate modifier**
+- it reverses direction on row 1: row 0 goes L→R, row 1 goes R→L
+- it reverses again on row 2: row 2 goes L→R
+- it produces [(0,0),(1,0),(2,0),(2,1),(1,1),(0,1),(0,2),(1,2),(2,2)] for a 3×3 grid
+- it satisfies the common invariants with alternate active
+
+---
+
+## 3. RL-TB (right-left, top-bottom)
+
+```
+describe('RlTbStrategy')
+```
+
+- it starts at (gridWidth-1, 0)
+- it traverses row 0 right to left before moving to row 1
+- it ends at (0, gridHeight-1) for a 3×3 grid
+- it produces [(2,0),(1,0),(0,0),(2,1),(1,1),(0,1),(2,2),(1,2),(0,2)] for a 3×3 grid
+
+**Alternate modifier**
+- it reverses direction on row 1: row 0 goes R→L, row 1 goes L→R
+- it satisfies the common invariants with alternate active
+
+---
+
+## 4. TB-LR (top-bottom, left-right)
+
+```
+describe('TbLrStrategy')
+```
+
+- it starts at (0, 0)
+- it traverses column 0 top to bottom before moving to column 1
+- it ends at (gridWidth-1, gridHeight-1) for a 3×3 grid
+- it produces [(0,0),(0,1),(0,2),(1,0),(1,1),(1,2),(2,0),(2,1),(2,2)] for a 3×3 grid
+
+**Alternate modifier**
+- it reverses direction on column 1: column 0 goes T→B, column 1 goes B→T
+- it satisfies the common invariants with alternate active
+
+---
+
+## 5. BT-LR (bottom-top, left-right)
+
+```
+describe('BtLrStrategy')
+```
+
+- it starts at (0, gridHeight-1)
+- it traverses column 0 bottom to top before moving to column 1
+- it ends at (gridWidth-1, 0) for a 3×3 grid
+- it produces [(0,2),(0,1),(0,0),(1,2),(1,1),(1,0),(2,2),(2,1),(2,0)] for a 3×3 grid
+
+**Alternate modifier**
+- it reverses direction on column 1: column 0 goes B→T, column 1 goes T→B
+- it satisfies the common invariants with alternate active
+
+---
+
+## 6. Padding placement
+
+Padding blocks are always placed at the **end of the traversal sequence**, regardless
+of strategy. This is tested via the grid construction layer (see cipher.md), but the
+reading order strategy must expose a stable "end" position that grid construction
+can rely on.
+
+- it returns the last position in the sequence as the start of the padding zone
+  for LR-TB on a 3×3 grid (no padding in a perfectly sized grid, but the end
+  position must be deterministic)
+
+---
+
+## Fixtures
+
+The following shared fixtures must be defined in `__fixtures__/reading-order.fixtures.ts`:
+
+- `GRID_3x3` — `{ width: 3, height: 3 }`
+- `GRID_1x5` — `{ width: 1, height: 5 }`
+- `GRID_5x1` — `{ width: 5, height: 1 }`
+- `GRID_1x1` — `{ width: 1, height: 1 }`
+- `EXPECTED_LR_TB_3x3` — hardcoded expected sequence for LR-TB on a 3×3 grid
+- `EXPECTED_LR_TB_ALT_3x3` — hardcoded expected sequence for LR-TB alternate on a 3×3 grid
+- (and equivalents for the other three strategies)

--- a/docs/tests/renderer.md
+++ b/docs/tests/renderer.md
@@ -1,0 +1,115 @@
+# HexaRot — Test Spec: Renderer Domain
+
+Covers: FEAT-009 (PngRenderer), FEAT-010 (SvgRenderer).
+
+Renderer tests are split into two layers:
+- **Unit tests**: verify structure and logic without producing full images (mocked grid input)
+- **Integration tests**: encode a known short message end-to-end and verify output
+  properties (dimensions, element count). These may use the filesystem temporarily.
+
+---
+
+## 1. PngRenderer — unit tests (FEAT-009)
+
+```
+describe('PngRenderer')
+```
+
+**Interface compliance**
+- it implements the `Renderer` interface
+- it exposes a `render(grid, size)` method returning a Promise\<Buffer\>
+
+**Output validity**
+- it returns a Buffer (not null, not undefined)
+- it returns a buffer whose first bytes match the PNG magic number (0x89 0x50 0x4E 0x47)
+
+**Dimensions — case size: small (8px per case)**
+- it produces an image of width = gridWidthInCases × 8 for a known grid
+- it produces an image of height = (gridHeightInCases + headerRows) × 8 for a known grid
+
+**Dimensions — case size: medium (16px per case)**
+- it produces an image of width = gridWidthInCases × 16
+- it produces an image of height = (gridHeightInCases + headerRows) × 16
+
+**Dimensions — case size: large (32px per case)**
+- it produces an image of width = gridWidthInCases × 32
+- it produces an image of height = (gridHeightInCases + headerRows) × 32
+
+**Colour accuracy**
+- it maps each Hexahue palette colour to the correct RGB value
+- it does not introduce colours outside the Hexahue palette for non-padding cells
+
+**Header row**
+- it renders the header above the grid (not below, not overlapping)
+- it renders the header at the correct pixel height
+
+---
+
+## 2. SvgRenderer — unit tests (FEAT-010)
+
+```
+describe('SvgRenderer')
+```
+
+**Interface compliance**
+- it implements the `Renderer` interface
+- it exposes a `render(grid, size)` method returning a string
+
+**Output validity**
+- it returns a string starting with '\<svg'
+- it returns a well-formed SVG (parseable by a standard XML parser)
+- it is self-contained: no external `href`, `src`, or `xlink` references
+
+**viewBox**
+- it sets viewBox width = gridWidthInCases × caseSize for size: small
+- it sets viewBox height = (gridHeightInCases + headerRows) × caseSize for size: small
+- it sets correct viewBox for size: medium
+- it sets correct viewBox for size: large
+
+**rect elements**
+- it produces exactly gridWidthInCases × gridHeightInCases `<rect>` elements for the grid
+- it produces the correct number of additional `<rect>` elements for the header
+- it sets the `fill` attribute of each `<rect>` to the correct Hexahue hex colour value
+- it sets `x`, `y`, `width`, `height` attributes on every `<rect>`
+
+**Colour accuracy**
+- it maps each Hexahue palette colour to the correct hex colour string (e.g. '#FF0000')
+
+---
+
+## 3. Integration tests (both renderers)
+
+These tests run the full encoding pipeline on a known short message and verify
+output properties. They require the `HexahueAlphabet` backed by the seeded test
+database (or a complete in-memory fixture).
+
+```
+describe('PngRenderer — integration')
+```
+
+- it encodes the message 'AB' with T=5, LR-TB, sequence [0,90,180,270], CW, size medium
+  and produces a PNG whose width equals the expected pixel value
+- it encodes the message 'AB' with the same params and produces a PNG whose height
+  equals the expected pixel value
+
+```
+describe('SvgRenderer — integration')
+```
+
+- it encodes the message 'AB' with T=5, LR-TB, sequence [0,90,180,270], CW, size medium
+  and produces an SVG with the correct viewBox
+- it encodes the message 'AB' with the same params and produces an SVG with the
+  correct total number of `<rect>` elements (grid cells + header cells)
+
+---
+
+## Fixtures
+
+The following shared fixtures must be defined in `__fixtures__/renderer.fixtures.ts`:
+
+- `MOCK_ROTATED_GRID_4x6` — a hardcoded 4-column × 6-row ColorGrid (all cells with
+  known palette colours), representing a pre-rotated grid ready for rendering.
+- `HEXAHUE_PALETTE_MAP` — map of colour name → expected RGB tuple and hex string,
+  covering all colours in the Hexahue palette.
+- `EXPECTED_PNG_DIMENSIONS` — map of size option → `{ casePixels, headerRows }` for
+  computing expected output dimensions.

--- a/docs/tests/rotation.md
+++ b/docs/tests/rotation.md
@@ -1,0 +1,105 @@
+# HexaRot — Test Spec: Rotation Domain
+
+Covers: FEAT-007 (block rotation engine).
+
+All tests in this document are **unit tests**. No database access, no filesystem.
+The rotation engine operates on pure 2D colour grids — no alphabet or key dependency
+at test time (those are resolved upstream).
+
+---
+
+## 1. Single block rotation
+
+```
+describe('rotateBlock')
+```
+
+For all tests in this section, a known T×T block with distinct colour values per cell
+is used as input, so that rotation correctness can be verified by cell position.
+
+**0° rotation**
+- it returns a grid identical to the input for 0° clockwise
+- it returns a grid identical to the input for 0° counter-clockwise
+
+**90° rotation**
+- it places the top-left cell at the top-right position for 90° clockwise
+- it places the top-right cell at the bottom-right position for 90° clockwise
+- it places the bottom-right cell at the bottom-left position for 90° clockwise
+- it places the bottom-left cell at the top-left position for 90° clockwise
+- it produces the correct full output for a 2×2 block at 90° clockwise
+- it produces the correct full output for a 3×3 block at 90° clockwise
+- it produces the correct full output for a 5×5 block at 90° clockwise
+- it produces the mirror result for 90° counter-clockwise vs 90° clockwise
+
+**180° rotation**
+- it produces the correct full output for a known block at 180° (direction-agnostic)
+- it is equivalent to two successive 90° clockwise rotations
+
+**270° rotation**
+- it is equivalent to three successive 90° clockwise rotations
+- it is equivalent to one 90° counter-clockwise rotation
+
+**Immutability**
+- it does not mutate the input block
+- it returns a new grid object
+
+---
+
+## 2. Full grid rotation engine
+
+```
+describe('RotationEngine.encode')
+```
+
+- it applies the rotation sequence to blocks in the order defined by the
+  ReadingOrderStrategy
+- it cycles through the rotation sequence when there are more blocks than
+  sequence entries (e.g. 5 blocks, sequence of length 4: rotations applied are
+  seq[0], seq[1], seq[2], seq[3], seq[0])
+- it applies rotation direction (CW vs CCW) consistently to all blocks
+- it leaves a block unchanged when the sequence entry is 0°
+- it produces a grid of the same dimensions as the input
+
+```
+describe('RotationEngine.decode')
+```
+
+- it applies the inverse rotation sequence in reverse block order
+- it recovers the original grid after encode→decode for a single block
+- it recovers the original grid after encode→decode for a multi-block grid
+- it recovers the original grid for all four rotation angles
+- it recovers the original grid for both rotation directions
+
+**Round-trip (encode → decode)**
+- it recovers the original grid for a 2×2 block grid, sequence [90, 180, 270, 0], CW
+- it recovers the original grid for a 3×3 block grid, sequence [180, 0, 90, 270], CCW
+- it recovers the original grid for a non-square grid (wider than tall)
+- it recovers the original grid for a non-square grid (taller than wide)
+- it recovers the original grid when sequence cycling occurs
+
+---
+
+## 3. Rotation direction
+
+```
+describe('rotateBlock — direction symmetry')
+```
+
+- it produces different results for CW vs CCW at 90° for a non-uniform block
+- it produces the same result for CW vs CCW at 0°
+- it produces the same result for CW vs CCW at 180°
+
+---
+
+## Fixtures
+
+The following shared fixtures must be defined in `__fixtures__/rotation.fixtures.ts`:
+
+- `KNOWN_2x2_BLOCK` — a 2×2 ColorGrid with four distinct colours, plus the expected
+  outputs for each of the four rotation angles (CW and CCW).
+- `KNOWN_3x3_BLOCK` — same for a 3×3 grid.
+- `KNOWN_5x5_BLOCK` — same for a 5×5 grid.
+- `SAMPLE_FULL_GRID` — a small full grid (e.g. 10×6 cases = 2×2 blocks of T=5)
+  with known content, used for round-trip tests.
+- `ALL_ROTATION_SEQUENCES` — a representative subset of rotation sequences
+  (at minimum: all-zeros, all-90, [0,90,180,270], [270,180,90,0]).


### PR DESCRIPTION
…tests

## Description

Amends the backend CI job to support integration tests requiring a live PostgreSQL database:

- Adds a services: block with a PostgreSQL 16 container
- Injects DATABASE_URL as an environment variable
- Waits for the service to be healthy before running any commands
- Runs Prisma migrations (prisma migrate deploy) before tests
- Runs the database seed before tests

The frontend job is unchanged.

## Related backlog item

CI-003

## Checklist

- [x] All acceptance criteria from the backlog item are met
- [x] Tests added or updated
- [x] All tests pass locally
- [x] `BACKLOG.md` updated: item status set to `done`
- [x] No debug code or commented-out blocks left in
- [x] All visible UI strings use i18n keys (frontend items only)
