### PR TITLE
fix: Corrected BACKLOG.md statut of item TEST-004

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -887,7 +887,7 @@ All UI strings are routed through vue-i18n keys.
 - **type:** test
 - **id:** TEST-004
 - **milestone:** v1
-- **status:** ready
+- **status:** backlog
 - **priority:** high
 - **domain:** alphabet
 - **complexity:** S


### PR DESCRIPTION
## Description

Fixed Backlog statut of TEST-004

## Related backlog item

TEST-004

## Checklist

- [x] All acceptance criteria from the backlog item are met
- [x] Tests added or updated
- [x] All tests pass locally
- [x] `BACKLOG.md` updated: item status set to `done`
- [x] No debug code or commented-out blocks left in
- [x] All visible UI strings use i18n keys (frontend items only)
