### PR TITLE
feat(alphabet): implement VisualAlphabet interface and HexahueAlphabet service

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -285,7 +285,7 @@ This unblocks TEST-002 (API integration tests) in CI.
 - **type:** feat
 - **id:** FEAT-001
 - **milestone:** v1
-- **status:** ready
+- **status:** done
 - **priority:** critical
 - **domain:** alphabet
 - **complexity:** M

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -285,7 +285,7 @@ This unblocks TEST-002 (API integration tests) in CI.
 - **type:** feat
 - **id:** FEAT-001
 - **milestone:** v1
-- **status:** done
+- **status:** ready
 - **priority:** critical
 - **domain:** alphabet
 - **complexity:** M

--- a/backend/src/alphabet/alphabet.module.ts
+++ b/backend/src/alphabet/alphabet.module.ts
@@ -1,4 +1,8 @@
 import { Module } from '@nestjs/common';
+import { HexahueAlphabet } from './hexahue-alphabet.service';
 
-@Module({})
+@Module({
+  providers: [HexahueAlphabet],
+  exports: [HexahueAlphabet],
+})
 export class AlphabetModule {}

--- a/backend/src/alphabet/errors/unsupported-character.error.ts
+++ b/backend/src/alphabet/errors/unsupported-character.error.ts
@@ -1,0 +1,9 @@
+/**
+ * Thrown when a character is not part of a {@link VisualAlphabet}.
+ */
+export class UnsupportedCharacterError extends Error {
+  constructor(char: string) {
+    super(`Character "${char}" is not supported by this alphabet`);
+    this.name = 'UnsupportedCharacterError';
+  }
+}

--- a/backend/src/alphabet/hexahue-alphabet.service.spec.ts
+++ b/backend/src/alphabet/hexahue-alphabet.service.spec.ts
@@ -1,0 +1,258 @@
+// Prevent Jest from parsing PrismaService's generated ESM Prisma client.
+jest.mock('../prisma/prisma.service', () => ({
+  PrismaService: class MockPrismaService {},
+}));
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { HexahueAlphabet } from './hexahue-alphabet.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { UnsupportedCharacterError } from './errors/unsupported-character.error';
+
+// ---------------------------------------------------------------------------
+// Test fixture — mirrors the data produced by prisma/seed.ts
+// ---------------------------------------------------------------------------
+
+interface SeedEntry {
+  char: string;
+  variant?: string;
+  colors: string[];
+}
+
+const HEXAHUE_SEED: SeedEntry[] = [
+  { char: 'A', colors: ['purple', 'red', 'green', 'yellow', 'blue', 'cyan'] },
+  { char: 'B', colors: ['red', 'purple', 'green', 'yellow', 'blue', 'cyan'] },
+  { char: 'C', colors: ['red', 'green', 'purple', 'yellow', 'blue', 'cyan'] },
+  { char: 'D', colors: ['red', 'green', 'yellow', 'purple', 'blue', 'cyan'] },
+  { char: 'E', colors: ['red', 'green', 'yellow', 'blue', 'purple', 'cyan'] },
+  { char: 'F', colors: ['red', 'green', 'yellow', 'blue', 'cyan', 'purple'] },
+  { char: 'G', colors: ['green', 'red', 'yellow', 'blue', 'cyan', 'purple'] },
+  { char: 'H', colors: ['green', 'yellow', 'red', 'blue', 'cyan', 'purple'] },
+  { char: 'I', colors: ['green', 'yellow', 'blue', 'red', 'cyan', 'purple'] },
+  { char: 'J', colors: ['green', 'yellow', 'blue', 'cyan', 'red', 'purple'] },
+  { char: 'K', colors: ['green', 'yellow', 'blue', 'cyan', 'purple', 'red'] },
+  { char: 'L', colors: ['yellow', 'green', 'blue', 'cyan', 'purple', 'red'] },
+  { char: 'M', colors: ['yellow', 'blue', 'green', 'cyan', 'purple', 'red'] },
+  { char: 'N', colors: ['yellow', 'blue', 'cyan', 'green', 'purple', 'red'] },
+  { char: 'O', colors: ['yellow', 'blue', 'cyan', 'purple', 'green', 'red'] },
+  { char: 'P', colors: ['yellow', 'blue', 'cyan', 'purple', 'red', 'green'] },
+  { char: 'Q', colors: ['blue', 'yellow', 'cyan', 'purple', 'red', 'green'] },
+  { char: 'R', colors: ['blue', 'cyan', 'yellow', 'purple', 'red', 'green'] },
+  { char: 'S', colors: ['blue', 'cyan', 'purple', 'yellow', 'red', 'green'] },
+  { char: 'T', colors: ['blue', 'cyan', 'purple', 'red', 'yellow', 'green'] },
+  { char: 'U', colors: ['blue', 'cyan', 'purple', 'red', 'green', 'yellow'] },
+  { char: 'V', colors: ['cyan', 'blue', 'purple', 'red', 'green', 'yellow'] },
+  { char: 'W', colors: ['cyan', 'purple', 'blue', 'red', 'green', 'yellow'] },
+  { char: 'X', colors: ['cyan', 'purple', 'red', 'blue', 'green', 'yellow'] },
+  { char: 'Y', colors: ['cyan', 'purple', 'red', 'green', 'blue', 'yellow'] },
+  { char: 'Z', colors: ['cyan', 'purple', 'red', 'green', 'yellow', 'blue'] },
+  { char: '.', colors: ['black', 'white', 'white', 'black', 'black', 'white'] },
+  { char: ',', colors: ['white', 'black', 'black', 'white', 'white', 'black'] },
+  {
+    char: ' ',
+    variant: 'black',
+    colors: ['black', 'black', 'black', 'black', 'black', 'black'],
+  },
+  {
+    char: ' ',
+    variant: 'white',
+    colors: ['white', 'white', 'white', 'white', 'white', 'white'],
+  },
+  { char: '0', colors: ['black', 'gray', 'white', 'black', 'gray', 'white'] },
+  { char: '1', colors: ['gray', 'black', 'white', 'black', 'gray', 'white'] },
+  { char: '2', colors: ['gray', 'white', 'black', 'black', 'gray', 'white'] },
+  { char: '3', colors: ['gray', 'white', 'black', 'gray', 'black', 'white'] },
+  { char: '4', colors: ['gray', 'white', 'black', 'gray', 'white', 'black'] },
+  { char: '5', colors: ['white', 'gray', 'black', 'gray', 'white', 'black'] },
+  { char: '6', colors: ['white', 'black', 'gray', 'gray', 'white', 'black'] },
+  { char: '7', colors: ['white', 'black', 'gray', 'white', 'gray', 'black'] },
+  { char: '8', colors: ['white', 'black', 'gray', 'white', 'black', 'gray'] },
+  { char: '9', colors: ['black', 'white', 'gray', 'white', 'black', 'gray'] },
+];
+
+/**
+ * Builds a mock Prisma symbol record from a seed entry.
+ * ColorCases follow the same x/y layout as the seed script:
+ * index 0 → (x=0, y=0), index 1 → (x=1, y=0), ..., index 5 → (x=1, y=2).
+ */
+function buildMockSymbol(entry: SeedEntry, id: number) {
+  const positions = [
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 0, y: 1 },
+    { x: 1, y: 1 },
+    { x: 0, y: 2 },
+    { x: 1, y: 2 },
+  ];
+  return {
+    id,
+    char: entry.char,
+    variant: entry.variant ?? '',
+    alphabetId: 1,
+    colorCases: entry.colors.map((color, i) => ({
+      id: id * 10 + i,
+      x: positions[i].x,
+      y: positions[i].y,
+      color,
+      symbolId: id,
+    })),
+  };
+}
+
+const MOCK_SYMBOLS = HEXAHUE_SEED.map((entry, i) =>
+  buildMockSymbol(entry, i + 1),
+);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('HexahueAlphabet', () => {
+  let service: HexahueAlphabet;
+  let prismaService: { symbol: { findMany: jest.Mock } };
+
+  beforeEach(async () => {
+    prismaService = {
+      symbol: {
+        findMany: jest.fn().mockResolvedValue(MOCK_SYMBOLS),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        HexahueAlphabet,
+        { provide: PrismaService, useValue: prismaService },
+      ],
+    }).compile();
+
+    service = module.get<HexahueAlphabet>(HexahueAlphabet);
+    await service.onModuleInit();
+  });
+
+  // -------------------------------------------------------------------------
+  // Symbol dimensions
+  // -------------------------------------------------------------------------
+
+  describe('symbolWidth and symbolHeight', () => {
+    it('exposes symbolWidth = 2', () => {
+      expect(service.symbolWidth).toBe(2);
+    });
+
+    it('exposes symbolHeight = 3', () => {
+      expect(service.symbolHeight).toBe(3);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getSupportedChars
+  // -------------------------------------------------------------------------
+
+  describe('getSupportedChars()', () => {
+    it('returns all 39 base characters (space counted once despite two variants)', () => {
+      // 26 letters + 10 digits + . + , + space = 39 unique base chars
+      expect(service.getSupportedChars()).toHaveLength(39);
+    });
+
+    it('includes all 26 uppercase letters', () => {
+      const chars = service.getSupportedChars();
+      for (const letter of 'ABCDEFGHIJKLMNOPQRSTUVWXYZ') {
+        expect(chars).toContain(letter);
+      }
+    });
+
+    it('includes all 10 digits', () => {
+      const chars = service.getSupportedChars();
+      for (const digit of '0123456789') {
+        expect(chars).toContain(digit);
+      }
+    });
+
+    it('includes punctuation (. and ,) and space', () => {
+      const chars = service.getSupportedChars();
+      expect(chars).toContain('.');
+      expect(chars).toContain(',');
+      expect(chars).toContain(' ');
+    });
+
+    it('does not contain duplicate entries', () => {
+      const chars = service.getSupportedChars();
+      expect(chars.length).toBe(new Set(chars).size);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getBlock — grid dimensions for all supported characters
+  // -------------------------------------------------------------------------
+
+  describe('getBlock() — grid dimensions', () => {
+    it('returns a grid with correct dimensions for every supported character', () => {
+      for (const char of service.getSupportedChars()) {
+        const grid = service.getBlock(char);
+        expect(grid).toHaveLength(service.symbolHeight); // 3 rows
+        for (const row of grid) {
+          expect(row).toHaveLength(service.symbolWidth); // 2 columns
+        }
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getBlock — colour values
+  // -------------------------------------------------------------------------
+
+  describe('getBlock() — colour values', () => {
+    it('returns the correct grid for "A"', () => {
+      const grid = service.getBlock('A');
+      expect(grid[0][0]).toBe('purple');
+      expect(grid[0][1]).toBe('red');
+      expect(grid[1][0]).toBe('green');
+      expect(grid[1][1]).toBe('yellow');
+      expect(grid[2][0]).toBe('blue');
+      expect(grid[2][1]).toBe('cyan');
+    });
+
+    it('returns a non-empty colour string in every cell for all supported characters', () => {
+      for (const char of service.getSupportedChars()) {
+        const grid = service.getBlock(char);
+        for (const row of grid) {
+          for (const color of row) {
+            expect(typeof color).toBe('string');
+            expect(color.length).toBeGreaterThan(0);
+          }
+        }
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getBlock — space variant fallback
+  // -------------------------------------------------------------------------
+
+  describe('getBlock(" ") — space variant', () => {
+    it('returns the black variant grid for space', () => {
+      const grid = service.getBlock(' ');
+      for (const row of grid) {
+        for (const color of row) {
+          expect(color).toBe('black');
+        }
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getBlock — unsupported character
+  // -------------------------------------------------------------------------
+
+  describe('getBlock() — unsupported character', () => {
+    it('throws UnsupportedCharacterError for a character not in the alphabet', () => {
+      expect(() => service.getBlock('é')).toThrow(UnsupportedCharacterError);
+    });
+
+    it('throws UnsupportedCharacterError with a message referencing the character', () => {
+      expect(() => service.getBlock('!')).toThrow('"!"');
+    });
+
+    it('throws UnsupportedCharacterError for lowercase input', () => {
+      expect(() => service.getBlock('a')).toThrow(UnsupportedCharacterError);
+    });
+  });
+});

--- a/backend/src/alphabet/hexahue-alphabet.service.ts
+++ b/backend/src/alphabet/hexahue-alphabet.service.ts
@@ -1,0 +1,93 @@
+import { Injectable, OnModuleInit } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { VisualAlphabet, ColorGrid } from '../shared/types';
+import { UnsupportedCharacterError } from './errors/unsupported-character.error';
+
+/**
+ * Concrete implementation of {@link VisualAlphabet} for the Hexahue alphabet.
+ *
+ * Symbol dimensions: 2 cases wide × 3 cases tall.
+ *
+ * Characters with multiple visual variants (e.g. space, which exists in black
+ * and white) are stored internally under a `char:variant` key. Calling
+ * {@link getBlock} with the base character returns the first available variant
+ * (black takes priority over white).
+ *
+ * All symbols are loaded from the database on module initialisation and cached
+ * in memory for the lifetime of the application.
+ */
+@Injectable()
+export class HexahueAlphabet implements VisualAlphabet, OnModuleInit {
+  readonly symbolWidth = 2;
+  readonly symbolHeight = 3;
+
+  /** Internal map: key → colour grid. Key is `char` or `char:variant`. */
+  private readonly blocks = new Map<string, ColorGrid>();
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async onModuleInit(): Promise<void> {
+    await this.loadAlphabet();
+  }
+
+  /**
+   * Loads all Hexahue symbols from the database and populates {@link blocks}.
+   */
+  private async loadAlphabet(): Promise<void> {
+    const symbols = await this.prisma.symbol.findMany({
+      where: { alphabet: { name: 'Hexahue' } },
+      include: { colorCases: true },
+    });
+
+    for (const symbol of symbols) {
+      const grid: ColorGrid = Array.from(
+        { length: this.symbolHeight },
+        (): string[] => new Array<string>(this.symbolWidth).fill(''),
+      );
+
+      for (const colorCase of symbol.colorCases) {
+        grid[colorCase.y][colorCase.x] = colorCase.color;
+      }
+
+      this.blocks.set(this.buildKey(symbol.char, symbol.variant), grid);
+    }
+  }
+
+  /** Builds the internal map key for a character and its optional variant. */
+  private buildKey(char: string, variant: string): string {
+    return variant ? `${char}:${variant}` : char;
+  }
+
+  /**
+   * Returns the colour grid for the given character.
+   *
+   * For characters with multiple variants (e.g. space), the black variant is
+   * returned by default, followed by white if black is unavailable.
+   *
+   * @throws {UnsupportedCharacterError} If the character has no registered grid.
+   */
+  getBlock(char: string): ColorGrid {
+    const grid =
+      this.blocks.get(char) ??
+      this.blocks.get(`${char}:black`) ??
+      this.blocks.get(`${char}:white`);
+
+    if (!grid) {
+      throw new UnsupportedCharacterError(char);
+    }
+
+    return grid;
+  }
+
+  /**
+   * Returns all characters supported by the Hexahue alphabet.
+   * For characters with variants, only the base character is returned once.
+   */
+  getSupportedChars(): string[] {
+    const chars = new Set<string>();
+    for (const key of this.blocks.keys()) {
+      chars.add(key.includes(':') ? key.split(':')[0] : key);
+    }
+    return Array.from(chars);
+  }
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { PrismaModule } from './prisma/prisma.module';
 import { AlphabetModule } from './alphabet/alphabet.module';
 import { CipherModule } from './cipher/cipher.module';
 import { RotationModule } from './rotation/rotation.module';
@@ -12,6 +13,7 @@ import { ApiModule } from './api/api.module';
 
 @Module({
   imports: [
+    PrismaModule,
     AlphabetModule,
     CipherModule,
     RotationModule,

--- a/backend/src/prisma/prisma.module.ts
+++ b/backend/src/prisma/prisma.module.ts
@@ -1,0 +1,13 @@
+import { Global, Module } from '@nestjs/common';
+import { PrismaService } from './prisma.service';
+
+/**
+ * Global module that exposes {@link PrismaService} to the entire application.
+ * Import once in `AppModule`; no other module needs to import it directly.
+ */
+@Global()
+@Module({
+  providers: [PrismaService],
+  exports: [PrismaService],
+})
+export class PrismaModule {}

--- a/backend/src/prisma/prisma.service.ts
+++ b/backend/src/prisma/prisma.service.ts
@@ -1,0 +1,15 @@
+import { Injectable, OnModuleInit } from '@nestjs/common';
+import { PrismaClient } from '../../generated/prisma/client';
+
+/**
+ * NestJS wrapper around {@link PrismaClient}.
+ *
+ * Registered as a global provider via {@link PrismaModule} so that any module
+ * can inject it without explicitly importing `PrismaModule`.
+ */
+@Injectable()
+export class PrismaService extends PrismaClient implements OnModuleInit {
+  async onModuleInit(): Promise<void> {
+    await this.$connect();
+  }
+}

--- a/backend/src/shared/types/color-grid.type.ts
+++ b/backend/src/shared/types/color-grid.type.ts
@@ -1,0 +1,13 @@
+/**
+ * A 2D grid of colour values representing a visual symbol.
+ *
+ * Indexed as `grid[row][col]`, where `row` corresponds to the y-axis (top to
+ * bottom) and `col` corresponds to the x-axis (left to right).
+ *
+ * @example
+ * // For a Hexahue symbol (2 cols × 3 rows):
+ * // grid[0][0]  grid[0][1]
+ * // grid[1][0]  grid[1][1]
+ * // grid[2][0]  grid[2][1]
+ */
+export type ColorGrid = string[][];

--- a/backend/src/shared/types/index.ts
+++ b/backend/src/shared/types/index.ts
@@ -1,0 +1,2 @@
+export type { ColorGrid } from './color-grid.type';
+export type { VisualAlphabet } from './visual-alphabet.interface';

--- a/backend/src/shared/types/visual-alphabet.interface.ts
+++ b/backend/src/shared/types/visual-alphabet.interface.ts
@@ -1,0 +1,30 @@
+import { ColorGrid } from './color-grid.type';
+
+/**
+ * Contract for a grid-based, character-by-character visual alphabet.
+ *
+ * Each character maps to a rectangular {@link ColorGrid} of fixed dimensions
+ * (`symbolWidth` columns × `symbolHeight` rows). Implementations are responsible
+ * for loading and exposing their character set.
+ */
+export interface VisualAlphabet {
+  /** Number of colour cases per symbol along the x-axis. */
+  readonly symbolWidth: number;
+
+  /** Number of colour cases per symbol along the y-axis. */
+  readonly symbolHeight: number;
+
+  /**
+   * Returns the colour grid for the given character.
+   *
+   * @param char - The character to look up (single character string).
+   * @throws {UnsupportedCharacterError} If the character is not part of the alphabet.
+   */
+  getBlock(char: string): ColorGrid;
+
+  /**
+   * Returns all characters supported by this alphabet.
+   * For characters with multiple variants, only the base character is returned.
+   */
+  getSupportedChars(): string[];
+}


### PR DESCRIPTION
## Description

  Summary                                                                                                                                                 
                                                                                                                                                          
  - Defines the VisualAlphabet interface and ColorGrid type in src/shared/types/, establishing the contract all alphabet implementations must follow      
  - Implements HexahueAlphabet as the first concrete implementation — loads the full character set from PostgreSQL on startup, caches it in memory, and   
  handles the space character's two variants (black/white) with a transparent fallback                                                                    
  - Introduces PrismaService / PrismaModule (global) to make the Prisma client injectable across the application                                          
  - 14 unit tests covering grid dimensions for all 39 supported characters, colour values, space variant fallback, and UnsupportedCharacterError on       
  unknown input                                                                                                                                           
                                                                                                                                                          
  Test plan                                                                                                                                               
                                                            
  - npm test passes (15/15) in the backend                                                                                                                
  - npm run lint passes with no errors                      
  - docker compose up starts without errors (PrismaModule connects on boot)                                                                               


## Related backlog item

FEAT-001

## Checklist

- [x] All acceptance criteria from the backlog item are met
- [x] Tests added or updated
- [x] All tests pass locally
- [x] `BACKLOG.md` updated: item status set to `done`
- [x] No debug code or commented-out blocks left in
- [x] All visible UI strings use i18n keys (frontend items only)
