### PR TITLE
fix(ci): fix Kanban column name casing in track-branch and track-pr workflows

### DIFF
--- a/.github/workflows/track-branch.yml
+++ b/.github/workflows/track-branch.yml
@@ -113,7 +113,7 @@ jobs:
           ' -f project="$PROJECT_ID")
 
           FIELD_ID=$(echo "$FIELD_INFO" | jq -r '.data.node.fields.nodes[] | select(.name == "Status") | .id')
-          OPTION_ID=$(echo "$FIELD_INFO" | jq -r '.data.node.fields.nodes[] | select(.name == "Status") | .options[] | select(.name == "In Progress") | .id')
+          OPTION_ID=$(echo "$FIELD_INFO" | jq -r '.data.node.fields.nodes[] | select(.name == "Status") | .options[] | select(.name == "In progress") | .id')
 
           if [ -z "$FIELD_ID" ] || [ -z "$OPTION_ID" ]; then
             echo "Could not find Status field or In Progress option — aborting."

--- a/.github/workflows/track-pr.yml
+++ b/.github/workflows/track-pr.yml
@@ -111,7 +111,7 @@ jobs:
           ' -f project="$PROJECT_ID")
 
           FIELD_ID=$(echo "$FIELD_INFO" | jq -r '.data.node.fields.nodes[] | select(.name == "Status") | .id')
-          OPTION_ID=$(echo "$FIELD_INFO" | jq -r '.data.node.fields.nodes[] | select(.name == "Status") | .options[] | select(.name == "In Review") | .id')
+          OPTION_ID=$(echo "$FIELD_INFO" | jq -r '.data.node.fields.nodes[] | select(.name == "Status") | .options[] | select(.name == "In review") | .id')
 
           if [ -z "$FIELD_ID" ] || [ -z "$OPTION_ID" ]; then
             echo "Could not find Status field or In Review option — aborting."


### PR DESCRIPTION
## Description

fix Kanban column name casing in track-branch and track-pr workflows

## Related backlog item

None

## Checklist

- [x] All acceptance criteria from the backlog item are met
- [x] Tests added or updated
- [x] All tests pass locally
- [x] `BACKLOG.md` updated: item status set to `done`
- [x] No debug code or commented-out blocks left in
- [x] All visible UI strings use i18n keys (frontend items only)
