### PR TITLE
feat(validation): implement GCD-based parameter validator

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -358,7 +358,7 @@ where `PreprocessResult` contains the processed string and an array of unknown c
 - **type:** feat
 - **id:** FEAT-003
 - **milestone:** v1
-- **status:** ready
+- **status:** done
 - **priority:** high
 - **domain:** validation
 - **complexity:** S

--- a/backend/src/validation/validate-params.spec.ts
+++ b/backend/src/validation/validate-params.spec.ts
@@ -1,0 +1,144 @@
+import { gcd, validateParams } from './validate-params';
+import { VisualAlphabet } from '../shared/types';
+
+// ---------------------------------------------------------------------------
+// Mock alphabet — Hexahue dimensions (symbolWidth=2, symbolHeight=3)
+// ---------------------------------------------------------------------------
+
+function mockAlphabet(
+  symbolWidth: number,
+  symbolHeight: number,
+): VisualAlphabet {
+  return {
+    symbolWidth,
+    symbolHeight,
+    getBlock: () => [],
+    getSupportedChars: () => [],
+  };
+}
+
+const HEXAHUE = mockAlphabet(2, 3);
+
+// ---------------------------------------------------------------------------
+// gcd()
+// ---------------------------------------------------------------------------
+
+describe('gcd()', () => {
+  it('returns the larger number when one operand is 0', () => {
+    expect(gcd(6, 0)).toBe(6);
+    expect(gcd(0, 6)).toBe(6);
+  });
+
+  it('returns 1 for coprime pairs', () => {
+    expect(gcd(5, 2)).toBe(1);
+    expect(gcd(5, 3)).toBe(1);
+    expect(gcd(7, 6)).toBe(1);
+  });
+
+  it('returns the GCD for non-coprime pairs', () => {
+    expect(gcd(6, 3)).toBe(3);
+    expect(gcd(4, 2)).toBe(2);
+    expect(gcd(12, 8)).toBe(4);
+  });
+
+  it('is commutative', () => {
+    expect(gcd(9, 6)).toBe(gcd(6, 9));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateParams() — valid cases
+// ---------------------------------------------------------------------------
+
+describe('validateParams() — valid', () => {
+  it('returns valid for T=5 (coprime with 2 and 3)', () => {
+    const result = validateParams(5, HEXAHUE);
+    expect(result.status).toBe('valid');
+  });
+
+  it('returns valid for T=7', () => {
+    const result = validateParams(7, HEXAHUE);
+    expect(result.status).toBe('valid');
+  });
+
+  it('returns valid for T=1', () => {
+    const result = validateParams(1, HEXAHUE);
+    expect(result.status).toBe('valid');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateParams() — weak cases
+// ---------------------------------------------------------------------------
+
+describe('validateParams() — weak', () => {
+  it('returns weak for T=2 (GCD with symbolWidth=2 is 2)', () => {
+    const result = validateParams(2, HEXAHUE);
+    expect(result.status).toBe('weak');
+  });
+
+  it('returns weak for T=3 (GCD with symbolHeight=3 is 3)', () => {
+    const result = validateParams(3, HEXAHUE);
+    expect(result.status).toBe('weak');
+  });
+
+  it('returns weak for T=6 (shares factor with both width and height)', () => {
+    const result = validateParams(6, HEXAHUE);
+    expect(result.status).toBe('weak');
+  });
+
+  it('includes a warning mentioning symbolWidth for T=2', () => {
+    const result = validateParams(2, HEXAHUE);
+    if (result.status !== 'weak') throw new Error('Expected weak');
+    expect(result.warnings.some((w) => w.includes('symbolWidth'))).toBe(true);
+  });
+
+  it('includes a warning mentioning symbolHeight for T=3', () => {
+    const result = validateParams(3, HEXAHUE);
+    if (result.status !== 'weak') throw new Error('Expected weak');
+    expect(result.warnings.some((w) => w.includes('symbolHeight'))).toBe(true);
+  });
+
+  it('includes two warnings for T=6 (shares factor with both dimensions)', () => {
+    const result = validateParams(6, HEXAHUE);
+    if (result.status !== 'weak') throw new Error('Expected weak');
+    expect(result.warnings).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateParams() — override
+// ---------------------------------------------------------------------------
+
+describe('validateParams() — override', () => {
+  it('returns overridden instead of weak when override=true', () => {
+    const result = validateParams(2, HEXAHUE, true);
+    expect(result.status).toBe('overridden');
+  });
+
+  it('preserves the warnings in the overridden result', () => {
+    const result = validateParams(2, HEXAHUE, true);
+    if (result.status !== 'overridden') throw new Error('Expected overridden');
+    expect(result.warnings.length).toBeGreaterThan(0);
+  });
+
+  it('returns valid (not overridden) when T is already valid and override=true', () => {
+    const result = validateParams(5, HEXAHUE, true);
+    expect(result.status).toBe('valid');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateParams() — custom alphabet dimensions
+// ---------------------------------------------------------------------------
+
+describe('validateParams() — custom alphabet dimensions', () => {
+  it('uses the alphabet symbolWidth and symbolHeight, not hardcoded Hexahue values', () => {
+    const custom = mockAlphabet(3, 4);
+    // T=3 shares factor with symbolWidth=3
+    const result = validateParams(3, custom);
+    expect(result.status).toBe('weak');
+    if (result.status !== 'weak') throw new Error('Expected weak');
+    expect(result.warnings.some((w) => w.includes('symbolWidth=3'))).toBe(true);
+  });
+});

--- a/backend/src/validation/validate-params.ts
+++ b/backend/src/validation/validate-params.ts
@@ -1,0 +1,64 @@
+import { VisualAlphabet } from '../shared/types';
+
+/**
+ * Result of parameter validation.
+ *
+ * - `valid` — pivot block size T is coprime with both symbol dimensions
+ * - `weak` — GCD(T, symbolWidth) or GCD(T, symbolHeight) is not 1; rotations
+ *   may preserve partial symbol alignment, weakening the cryptogram
+ * - `overridden` — same as `weak` but the user explicitly bypassed the warning
+ */
+export type ValidationResult =
+  | { status: 'valid' }
+  | { status: 'weak'; warnings: string[] }
+  | { status: 'overridden'; warnings: string[] };
+
+/**
+ * Computes the greatest common divisor of two positive integers using the
+ * Euclidean algorithm.
+ */
+export function gcd(a: number, b: number): number {
+  return b === 0 ? a : gcd(b, a % b);
+}
+
+/**
+ * Validates the pivot block size against the symbol dimensions of the given alphabet.
+ *
+ * A pivot block size T weakens the cryptogram when GCD(T, symbolWidth) or
+ * GCD(T, symbolHeight) is not 1, because rotations of T×T blocks will
+ * realign with symbol boundaries, reducing visual entropy.
+ *
+ * The validator never blocks execution — it only informs via the returned result.
+ *
+ * @param pivotBlockSize - The T×T block size to validate.
+ * @param alphabet - The visual alphabet providing symbol dimensions.
+ * @param override - When true, returns `overridden` instead of `weak`, allowing
+ *   the caller to proceed despite the warning.
+ */
+export function validateParams(
+  pivotBlockSize: number,
+  alphabet: VisualAlphabet,
+  override = false,
+): ValidationResult {
+  const warnings: string[] = [];
+
+  const gcdWidth = gcd(pivotBlockSize, alphabet.symbolWidth);
+  if (gcdWidth !== 1) {
+    warnings.push(
+      `GCD(T=${pivotBlockSize}, symbolWidth=${alphabet.symbolWidth}) = ${gcdWidth} ≠ 1` +
+        ` — rotations may realign with symbol boundaries along the x-axis`,
+    );
+  }
+
+  const gcdHeight = gcd(pivotBlockSize, alphabet.symbolHeight);
+  if (gcdHeight !== 1) {
+    warnings.push(
+      `GCD(T=${pivotBlockSize}, symbolHeight=${alphabet.symbolHeight}) = ${gcdHeight} ≠ 1` +
+        ` — rotations may realign with symbol boundaries along the y-axis`,
+    );
+  }
+
+  if (warnings.length === 0) return { status: 'valid' };
+  if (override) return { status: 'overridden', warnings };
+  return { status: 'weak', warnings };
+}


### PR DESCRIPTION
## Description

Summary

  - Implements gcd(a, b) (Euclidean algorithm) and validateParams(pivotBlockSize, alphabet, override?) in the validation module
  - Returns a typed ValidationResult discriminated union: valid, weak (with warnings), or overridden
  - Validation checks GCD(T, symbolWidth) and GCD(T, symbolHeight) — warns when either is not 1, signalling that rotations may realign with symbol
  boundaries
  - Validator is non-blocking by design: it informs, never prevents encoding

  Test plan

  - npm test passes (52/52) in the backend
  - npm run lint passes with no errors
  - sync-backlog se déclenche au merge et ferme l'issue FEAT-003


## Related backlog item

FEAT-003

## Checklist

- [x] All acceptance criteria from the backlog item are met
- [x] Tests added or updated
- [x] All tests pass locally
- [x] `BACKLOG.md` updated: item status set to `done`
- [x] No debug code or commented-out blocks left in
- [x] All visible UI strings use i18n keys (frontend items only)
