### PR TITLE
chore(testing): relocate MockAlphabet to test/utils per docs/tests/cipher.md

### DIFF
--- a/backend/src/cipher/preprocess.spec.ts
+++ b/backend/src/cipher/preprocess.spec.ts
@@ -1,6 +1,6 @@
 import { preprocess } from './preprocess';
 import { VisualAlphabet } from '../shared/types';
-import { MockAlphabet } from '../shared/testing/mock-alphabet';
+import { MockAlphabet } from '../../test/utils/mock-alphabet';
 
 // ---------------------------------------------------------------------------
 // Mock alphabet — Hexahue supported character set, no database required

--- a/backend/src/shared/testing/mock-alphabet.spec.ts
+++ b/backend/src/shared/testing/mock-alphabet.spec.ts
@@ -1,4 +1,4 @@
-import { MockAlphabet } from './mock-alphabet';
+import { MockAlphabet } from '../../../test/utils/mock-alphabet';
 import { UnsupportedCharacterError } from '../../alphabet/errors/unsupported-character.error';
 
 describe('MockAlphabet', () => {

--- a/backend/src/shared/testing/visual-alphabet-contract.spec.ts
+++ b/backend/src/shared/testing/visual-alphabet-contract.spec.ts
@@ -1,4 +1,4 @@
-import { MockAlphabet } from './mock-alphabet';
+import { MockAlphabet } from '../../../test/utils/mock-alphabet';
 
 describe('VisualAlphabet contract (dimension-agnostic, via MockAlphabet)', () => {
   let alphabet: MockAlphabet;

--- a/backend/test/utils/mock-alphabet.ts
+++ b/backend/test/utils/mock-alphabet.ts
@@ -1,5 +1,5 @@
-import { VisualAlphabet, ColorGrid } from '../types';
-import { UnsupportedCharacterError } from '../../alphabet/errors/unsupported-character.error';
+import { VisualAlphabet, ColorGrid } from '../../src/shared/types';
+import { UnsupportedCharacterError } from '../../src/alphabet/errors/unsupported-character.error';
 
 /**
  * Minimal, self-contained VisualAlphabet double for tests.

--- a/backend/tsconfig.build.json
+++ b/backend/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts", "src/shared/testing"]
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
 }


### PR DESCRIPTION
## Summary
- Moves MockAlphabet from backend/src/shared/testing/mock-alphabet.ts to backend/test/utils/mock-alphabet.ts, matching the path docs/tests/cipher.md specifies as canonical for this shared test double (defined by TEST-004).
- Only *.spec.ts files need to live under Jest's rootDir (backend/src) to be discovered as tests; MockAlphabet itself is a plain module imported by spec files, so it can live anywhere reachable by relative import - the original placement under src/shared/testing was an unnecessarily conservative reading of that constraint.
- Updates the 3 import sites: mock-alphabet.spec.ts, visual-alphabet-contract.spec.ts (both stay under src/shared/testing,
since they are spec files), and preprocess.spec.ts.
- Drops the now-unneeded src/shared/testing entry from tsconfig.build.json's exclude list (that directory now only holds
*.spec.ts files, already covered by the existing **/*spec.ts exclude; the new location is covered by the existing top-level "test" exclude).

No behavior change - MockAlphabet's implementation, dimensions (3x2, chars A-F), and all existing tests are untouched.

## Test plan
- [x] Full backend suite: 168/168 passing (13 suites), no regressions
- [x] ESLint clean on all touched files
- [x] `tsc --noEmit -p tsconfig.build.json` confirms mock-alphabet.ts stays out of the production build
- [x] Grepped for any other consumer of the old path - none found
