### PR TITLE
feat(renderer): implement PngRenderer with Sharp

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -583,7 +583,7 @@ implement `encodeHeader` and `decodeHeader` functions.
 - **type:** feat
 - **id:** FEAT-009
 - **milestone:** v1
-- **status:** ready
+- **status:** done
 - **priority:** critical
 - **domain:** renderer
 - **complexity:** M

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -588,7 +588,7 @@ implement `encodeHeader` and `decodeHeader` functions.
 - **domain:** renderer
 - **complexity:** M
 - **parent:** ~
-- **depends-on:** FEAT-007, FEAT-008
+- **depends-on:** FEAT-007
 - **learning:** [Sharp library API, pixel buffer construction, image dimensions and DPI, colour space handling in Sharp]
 - **labels:** [feat, domain:renderer, priority:critical, milestone:v1]
 
@@ -603,14 +603,15 @@ Case sizes in pixels (to be confirmed, suggested values):
 - medium: 16px per case
 - large: 32px per case
 
-The header row is rendered above the grid. The Hexahue standard colour palette is used.
+The Hexahue standard colour palette is used. No metadata header is rendered - the
+encoded grid is the pre-processed message plus random padding only (see
+docs/tests/renderer.md, "Design note: no visual header row").
 
 #### Acceptance criteria
 
 - Output is a valid PNG binary buffer
 - All three case sizes produce images with correct pixel dimensions
 - Colours match the Hexahue standard palette values exactly
-- Header row is visible and correctly positioned above the grid
 - Renderer implements the `Renderer` interface
 - Integration test: encode a known short message, render to PNG, verify output
   dimensions match expected values
@@ -627,7 +628,7 @@ The header row is rendered above the grid. The Hexahue standard colour palette i
 - **domain:** renderer
 - **complexity:** M
 - **parent:** ~
-- **depends-on:** FEAT-007, FEAT-008
+- **depends-on:** FEAT-007
 - **learning:** [SVG coordinate system, SVG rect elements, native string-based SVG generation without DOM, SVG viewBox]
 - **labels:** [feat, domain:renderer, priority:critical, milestone:v1]
 
@@ -638,7 +639,9 @@ native SVG string generation (no DOM library). The renderer takes a fully rotate
 grid, a case size option, and outputs an SVG string.
 
 The SVG must be well-formed, self-contained, and renderable in a browser without
-additional assets. Case sizes follow the same pixel values as the PNG renderer.
+additional assets. Case sizes follow the same pixel values as the PNG renderer. No
+metadata header is rendered (see docs/tests/renderer.md, "Design note: no visual
+header row").
 
 #### Acceptance criteria
 
@@ -646,7 +649,6 @@ additional assets. Case sizes follow the same pixel values as the PNG renderer.
 - SVG is self-contained (no external references)
 - All three case sizes produce SVG with correct viewBox dimensions
 - Colours match the Hexahue standard palette values exactly
-- Header row is present and correctly positioned
 - Renderer implements the `Renderer` interface
 - Integration test: encode a known short message, render to SVG, verify viewBox
   dimensions and presence of correct number of `<rect>` elements
@@ -718,8 +720,10 @@ Response:
 #### Description
 
 Implement the `POST /decode` endpoint. The endpoint accepts a cryptogram (PNG or SVG)
-and a key, reads the metadata header to determine message length, applies inverse
-rotations, and returns the decoded plaintext.
+and a key, applies inverse rotations, and returns the decoded plaintext. There is no
+metadata header to determine message length (see docs/tests/renderer.md, "Design
+note: no visual header row") - message-boundary detection (message vs. random
+padding) is an open design question for this item, not yet resolved.
 
 Request body:
 - `cryptogram: string` — base64-encoded PNG or SVG string

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,7 +15,8 @@
         "@prisma/client": "^6.19.2",
         "prisma": "^6.19.2",
         "reflect-metadata": "^0.2.2",
-        "rxjs": "^7.8.1"
+        "rxjs": "^7.8.1",
+        "sharp": "^0.35.3"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
@@ -764,10 +765,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
-      "dev": true,
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1434,6 +1434,506 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@inquirer/ansi": {
@@ -5412,6 +5912,15 @@
       "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
       "license": "MIT"
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -9308,10 +9817,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -9370,6 +9878,55 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.5"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,7 +26,8 @@
     "@prisma/client": "^6.19.2",
     "prisma": "^6.19.2",
     "reflect-metadata": "^0.2.2",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "sharp": "^0.35.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/backend/src/renderer/__fixtures__/renderer.fixtures.ts
+++ b/backend/src/renderer/__fixtures__/renderer.fixtures.ts
@@ -1,0 +1,35 @@
+import { ColorGrid, CaseSize } from '../../shared/types';
+
+/** A hardcoded 4-column x 6-row pre-rotated grid, ready for rendering. */
+export const MOCK_ROTATED_GRID_4x6: ColorGrid = [
+  ['red', 'green', 'blue', 'yellow'],
+  ['cyan', 'purple', 'black', 'white'],
+  ['gray', 'red', 'green', 'blue'],
+  ['yellow', 'cyan', 'purple', 'black'],
+  ['white', 'gray', 'red', 'green'],
+  ['blue', 'yellow', 'cyan', 'purple'],
+];
+
+/** Every Hexahue palette colour mapped to its expected RGB tuple and hex string. */
+export const HEXAHUE_PALETTE_MAP: Record<
+  string,
+  { rgb: [number, number, number]; hex: string }
+> = {
+  purple: { rgb: [255, 0, 255], hex: '#ff00ff' },
+  red: { rgb: [255, 0, 0], hex: '#ff0000' },
+  green: { rgb: [102, 255, 0], hex: '#66ff00' },
+  yellow: { rgb: [255, 255, 0], hex: '#ffff00' },
+  blue: { rgb: [0, 0, 255], hex: '#0000ff' },
+  cyan: { rgb: [0, 255, 255], hex: '#00ffff' },
+  white: { rgb: [255, 255, 255], hex: '#ffffff' },
+  black: { rgb: [0, 0, 0], hex: '#000000' },
+  gray: { rgb: [136, 136, 136], hex: '#888888' },
+};
+
+/** Case-size -> { casePixels } used by tests to compute expected PNG dimensions. */
+export const EXPECTED_PNG_DIMENSIONS: Record<CaseSize, { casePixels: number }> =
+  {
+    small: { casePixels: 8 },
+    medium: { casePixels: 16 },
+    large: { casePixels: 32 },
+  };

--- a/backend/src/renderer/__fixtures__/renderer.fixtures.ts
+++ b/backend/src/renderer/__fixtures__/renderer.fixtures.ts
@@ -1,4 +1,4 @@
-import { ColorGrid, CaseSize } from '../../shared/types';
+import { ColorGrid, CaseSize, VisualAlphabet } from '../../shared/types';
 
 /** A hardcoded 4-column x 6-row pre-rotated grid, ready for rendering. */
 export const MOCK_ROTATED_GRID_4x6: ColorGrid = [
@@ -33,3 +33,36 @@ export const EXPECTED_PNG_DIMENSIONS: Record<CaseSize, { casePixels: number }> =
     medium: { casePixels: 16 },
     large: { casePixels: 32 },
   };
+
+/**
+ * Minimal in-memory VisualAlphabet double with real Hexahue dimensions
+ * (2 wide x 3 tall), supporting 'A' and 'B' - enough to run the full
+ * pipeline end-to-end without a real database, per docs/tests/renderer.md
+ * section 3's explicit allowance for "a complete in-memory fixture".
+ */
+export const MOCK_HEXAHUE_ALPHABET: VisualAlphabet = {
+  symbolWidth: 2,
+  symbolHeight: 3,
+  getBlock(char: string) {
+    const blocks: Record<string, string[][]> = {
+      A: [
+        ['red', 'green'],
+        ['blue', 'yellow'],
+        ['cyan', 'purple'],
+      ],
+      B: [
+        ['green', 'red'],
+        ['yellow', 'blue'],
+        ['purple', 'cyan'],
+      ],
+    };
+    const grid = blocks[char];
+    if (!grid) {
+      throw new Error(`unsupported character: ${char}`);
+    }
+    return grid;
+  },
+  getSupportedChars() {
+    return ['A', 'B'];
+  },
+};

--- a/backend/src/renderer/palette.spec.ts
+++ b/backend/src/renderer/palette.spec.ts
@@ -1,0 +1,42 @@
+import { HEXAHUE_COLOR_HEX, CASE_PIXELS, colorNameToRgb } from './palette';
+
+describe('HEXAHUE_COLOR_HEX', () => {
+  it('maps all 9 Hexahue palette colours to their exact hex value', () => {
+    expect(HEXAHUE_COLOR_HEX).toEqual({
+      purple: '#ff00ff',
+      red: '#ff0000',
+      green: '#66ff00',
+      yellow: '#ffff00',
+      blue: '#0000ff',
+      cyan: '#00ffff',
+      white: '#ffffff',
+      black: '#000000',
+      gray: '#888888',
+    });
+  });
+});
+
+describe('CASE_PIXELS', () => {
+  it('maps each case size to its pixel-per-case value', () => {
+    expect(CASE_PIXELS).toEqual({ small: 8, medium: 16, large: 32 });
+  });
+});
+
+describe('colorNameToRgb', () => {
+  it('resolves each of the 9 palette colours to the correct RGB triple', () => {
+    expect(colorNameToRgb('purple')).toEqual([255, 0, 255]);
+    expect(colorNameToRgb('red')).toEqual([255, 0, 0]);
+    expect(colorNameToRgb('green')).toEqual([102, 255, 0]);
+    expect(colorNameToRgb('yellow')).toEqual([255, 255, 0]);
+    expect(colorNameToRgb('blue')).toEqual([0, 0, 255]);
+    expect(colorNameToRgb('cyan')).toEqual([0, 255, 255]);
+    expect(colorNameToRgb('white')).toEqual([255, 255, 255]);
+    expect(colorNameToRgb('black')).toEqual([0, 0, 0]);
+    expect(colorNameToRgb('gray')).toEqual([136, 136, 136]);
+  });
+
+  it('throws a RangeError for a colour name outside the Hexahue palette', () => {
+    expect(() => colorNameToRgb('magenta')).toThrow(RangeError);
+    expect(() => colorNameToRgb('')).toThrow(RangeError);
+  });
+});

--- a/backend/src/renderer/palette.spec.ts
+++ b/backend/src/renderer/palette.spec.ts
@@ -39,4 +39,9 @@ describe('colorNameToRgb', () => {
     expect(() => colorNameToRgb('magenta')).toThrow(RangeError);
     expect(() => colorNameToRgb('')).toThrow(RangeError);
   });
+
+  it('throws a RangeError for colour names that match Object.prototype members', () => {
+    expect(() => colorNameToRgb('constructor')).toThrow(RangeError);
+    expect(() => colorNameToRgb('toString')).toThrow(RangeError);
+  });
 });

--- a/backend/src/renderer/palette.ts
+++ b/backend/src/renderer/palette.ts
@@ -1,0 +1,44 @@
+import { CaseSize } from '../shared/types';
+
+/**
+ * Hexahue standard palette: colour name (as stored in ColorGrid cells) to
+ * hex RGB string. V1 renders only this fixed palette (see CONTEXT.md,
+ * "Colour Palette" - alternate themes are out of scope).
+ */
+export const HEXAHUE_COLOR_HEX: Readonly<Record<string, string>> = {
+  purple: '#ff00ff',
+  red: '#ff0000',
+  green: '#66ff00',
+  yellow: '#ffff00',
+  blue: '#0000ff',
+  cyan: '#00ffff',
+  white: '#ffffff',
+  black: '#000000',
+  gray: '#888888',
+};
+
+/** Pixel size (width and height) of a single colour case, per case-size option. */
+export const CASE_PIXELS: Readonly<Record<CaseSize, number>> = {
+  small: 8,
+  medium: 16,
+  large: 32,
+};
+
+/**
+ * Resolves a Hexahue colour name to its RGB triple.
+ *
+ * @throws {RangeError} If the colour name is not part of the Hexahue palette.
+ */
+export function colorNameToRgb(colorName: string): [number, number, number] {
+  const hex = HEXAHUE_COLOR_HEX[colorName];
+  if (!hex) {
+    throw new RangeError(
+      `Unknown colour "${colorName}", expected one of: ${Object.keys(HEXAHUE_COLOR_HEX).join(', ')}`,
+    );
+  }
+  return [
+    parseInt(hex.slice(1, 3), 16),
+    parseInt(hex.slice(3, 5), 16),
+    parseInt(hex.slice(5, 7), 16),
+  ];
+}

--- a/backend/src/renderer/palette.ts
+++ b/backend/src/renderer/palette.ts
@@ -5,24 +5,25 @@ import { CaseSize } from '../shared/types';
  * hex RGB string. V1 renders only this fixed palette (see CONTEXT.md,
  * "Colour Palette" - alternate themes are out of scope).
  */
-export const HEXAHUE_COLOR_HEX: Readonly<Record<string, string>> = {
-  purple: '#ff00ff',
-  red: '#ff0000',
-  green: '#66ff00',
-  yellow: '#ffff00',
-  blue: '#0000ff',
-  cyan: '#00ffff',
-  white: '#ffffff',
-  black: '#000000',
-  gray: '#888888',
-};
+export const HEXAHUE_COLOR_HEX: Readonly<Record<string, string>> =
+  Object.freeze({
+    purple: '#ff00ff',
+    red: '#ff0000',
+    green: '#66ff00',
+    yellow: '#ffff00',
+    blue: '#0000ff',
+    cyan: '#00ffff',
+    white: '#ffffff',
+    black: '#000000',
+    gray: '#888888',
+  });
 
 /** Pixel size (width and height) of a single colour case, per case-size option. */
-export const CASE_PIXELS: Readonly<Record<CaseSize, number>> = {
+export const CASE_PIXELS: Readonly<Record<CaseSize, number>> = Object.freeze({
   small: 8,
   medium: 16,
   large: 32,
-};
+});
 
 /**
  * Resolves a Hexahue colour name to its RGB triple.

--- a/backend/src/renderer/palette.ts
+++ b/backend/src/renderer/palette.ts
@@ -30,12 +30,12 @@ export const CASE_PIXELS: Readonly<Record<CaseSize, number>> = {
  * @throws {RangeError} If the colour name is not part of the Hexahue palette.
  */
 export function colorNameToRgb(colorName: string): [number, number, number] {
-  const hex = HEXAHUE_COLOR_HEX[colorName];
-  if (!hex) {
+  if (!Object.prototype.hasOwnProperty.call(HEXAHUE_COLOR_HEX, colorName)) {
     throw new RangeError(
       `Unknown colour "${colorName}", expected one of: ${Object.keys(HEXAHUE_COLOR_HEX).join(', ')}`,
     );
   }
+  const hex = HEXAHUE_COLOR_HEX[colorName];
   return [
     parseInt(hex.slice(1, 3), 16),
     parseInt(hex.slice(3, 5), 16),

--- a/backend/src/renderer/png-renderer.integration.spec.ts
+++ b/backend/src/renderer/png-renderer.integration.spec.ts
@@ -1,0 +1,61 @@
+import sharp from 'sharp';
+import { preprocess } from '../cipher/preprocess';
+import { buildGrid } from '../cipher/build-grid';
+import { RotationEngine } from '../rotation/rotation-engine';
+import { ReadingOrderRegistry } from '../reading-order/reading-order.registry';
+import { PngRenderer } from './png-renderer';
+import {
+  MOCK_HEXAHUE_ALPHABET,
+  EXPECTED_PNG_DIMENSIONS,
+} from './__fixtures__/renderer.fixtures';
+
+/**
+ * Runs the full encoding pipeline (preprocess -> buildGrid -> rotate ->
+ * render) for a known short message, as required by
+ * docs/tests/renderer.md section 3.
+ *
+ * T=5, LR-TB, sequence [0,90,180,270] (index sequence [0,1,2,3] - see this
+ * plan's Global Constraints for why), CW, size medium. No header anywhere
+ * in this pipeline - see this plan's "Design decision" note.
+ */
+async function encodeAndRender(): Promise<Buffer> {
+  const alphabet = MOCK_HEXAHUE_ALPHABET;
+  const pivotBlockSize = 5;
+
+  const { text } = preprocess('AB', alphabet);
+  const bodyGrid = buildGrid(text, alphabet, pivotBlockSize);
+
+  const rotationEngine = new RotationEngine(new ReadingOrderRegistry());
+  const rotatedGrid = rotationEngine.encode(
+    bodyGrid,
+    pivotBlockSize,
+    [0, 1, 2, 3],
+    'cw',
+    'LR-TB',
+  );
+
+  const renderer = new PngRenderer();
+  return renderer.render(rotatedGrid, 'medium');
+}
+
+describe('PngRenderer - integration', () => {
+  it('encodes the message AB with T=5, LR-TB, sequence [0,90,180,270], CW, size medium and produces a PNG whose width equals the expected pixel value', async () => {
+    const buffer = await encodeAndRender();
+    const meta = await sharp(buffer).metadata();
+
+    const expectedGridWidthInCases = 10; // lcm(pivotBlockSize=5, symbolWidth=2)
+    expect(meta.width).toBe(
+      expectedGridWidthInCases * EXPECTED_PNG_DIMENSIONS.medium.casePixels,
+    );
+  });
+
+  it('encodes the message AB with the same params and produces a PNG whose height equals the expected pixel value', async () => {
+    const buffer = await encodeAndRender();
+    const meta = await sharp(buffer).metadata();
+
+    const expectedGridHeightInCases = 5; // ceil(symbolHeight=3 / pivotBlockSize=5) * 5
+    expect(meta.height).toBe(
+      expectedGridHeightInCases * EXPECTED_PNG_DIMENSIONS.medium.casePixels,
+    );
+  });
+});

--- a/backend/src/renderer/png-renderer.integration.spec.ts
+++ b/backend/src/renderer/png-renderer.integration.spec.ts
@@ -14,9 +14,10 @@ import {
  * render) for a known short message, as required by
  * docs/tests/renderer.md section 3.
  *
- * T=5, LR-TB, sequence [0,90,180,270] (index sequence [0,1,2,3] - see this
- * plan's Global Constraints for why), CW, size medium. No header anywhere
- * in this pipeline - see this plan's "Design decision" note.
+ * T=5, LR-TB, sequence [0,90,180,270] (index sequence [0,1,2,3] - see
+ * docs/tests/renderer.md, "Design note: no visual header row", for why),
+ * CW, size medium. No header anywhere in this pipeline - see
+ * docs/tests/renderer.md, "Design note: no visual header row".
  */
 async function encodeAndRender(): Promise<Buffer> {
   const alphabet = MOCK_HEXAHUE_ALPHABET;
@@ -43,7 +44,7 @@ describe('PngRenderer - integration', () => {
     const buffer = await encodeAndRender();
     const meta = await sharp(buffer).metadata();
 
-    const expectedGridWidthInCases = 10; // lcm(pivotBlockSize=5, symbolWidth=2)
+    const expectedGridWidthInCases = 10; // widthMultiplier(1) * lcm(pivotBlockSize=5, symbolWidth=2)
     expect(meta.width).toBe(
       expectedGridWidthInCases * EXPECTED_PNG_DIMENSIONS.medium.casePixels,
     );

--- a/backend/src/renderer/png-renderer.spec.ts
+++ b/backend/src/renderer/png-renderer.spec.ts
@@ -1,5 +1,5 @@
 import sharp from 'sharp';
-import { ColorGrid } from '../shared/types';
+import { CaseSize, ColorGrid } from '../shared/types';
 import { PngRenderer } from './png-renderer';
 import {
   MOCK_ROTATED_GRID_4x6,
@@ -134,6 +134,12 @@ describe('PngRenderer', () => {
       await expect(renderer.render(raggedGrid, 'small')).rejects.toThrow(
         RangeError,
       );
+    });
+
+    it('throws a RangeError for an invalid size value', async () => {
+      await expect(
+        renderer.render(MOCK_ROTATED_GRID_4x6, 'huge' as CaseSize),
+      ).rejects.toThrow(RangeError);
     });
   });
 });

--- a/backend/src/renderer/png-renderer.spec.ts
+++ b/backend/src/renderer/png-renderer.spec.ts
@@ -1,0 +1,139 @@
+import sharp from 'sharp';
+import { ColorGrid } from '../shared/types';
+import { PngRenderer } from './png-renderer';
+import {
+  MOCK_ROTATED_GRID_4x6,
+  HEXAHUE_PALETTE_MAP,
+  EXPECTED_PNG_DIMENSIONS,
+} from './__fixtures__/renderer.fixtures';
+
+describe('PngRenderer', () => {
+  const renderer = new PngRenderer();
+
+  describe('interface compliance', () => {
+    it('exposes a render(grid, size) method returning a Promise<Buffer>', () => {
+      const result = renderer.render(MOCK_ROTATED_GRID_4x6, 'small');
+      expect(result).toBeInstanceOf(Promise);
+      return result.then((buffer) => {
+        expect(Buffer.isBuffer(buffer)).toBe(true);
+      });
+    });
+  });
+
+  describe('output validity', () => {
+    it('returns a Buffer (not null, not undefined)', async () => {
+      const buffer = await renderer.render(MOCK_ROTATED_GRID_4x6, 'small');
+      expect(buffer).not.toBeNull();
+      expect(buffer).not.toBeUndefined();
+      expect(Buffer.isBuffer(buffer)).toBe(true);
+    });
+
+    it('returns a buffer whose first bytes match the PNG magic number', async () => {
+      const buffer = await renderer.render(MOCK_ROTATED_GRID_4x6, 'small');
+      expect(buffer.subarray(0, 4)).toEqual(
+        Buffer.from([0x89, 0x50, 0x4e, 0x47]),
+      );
+    });
+  });
+
+  describe('dimensions - case size: small (8px per case)', () => {
+    it('produces an image of width = gridWidthInCases x 8', async () => {
+      const buffer = await renderer.render(MOCK_ROTATED_GRID_4x6, 'small');
+      const meta = await sharp(buffer).metadata();
+      expect(meta.width).toBe(4 * EXPECTED_PNG_DIMENSIONS.small.casePixels);
+    });
+
+    it('produces an image of height = gridHeightInCases x 8', async () => {
+      const buffer = await renderer.render(MOCK_ROTATED_GRID_4x6, 'small');
+      const meta = await sharp(buffer).metadata();
+      expect(meta.height).toBe(6 * EXPECTED_PNG_DIMENSIONS.small.casePixels);
+    });
+  });
+
+  describe('dimensions - case size: medium (16px per case)', () => {
+    it('produces an image of width = gridWidthInCases x 16', async () => {
+      const buffer = await renderer.render(MOCK_ROTATED_GRID_4x6, 'medium');
+      const meta = await sharp(buffer).metadata();
+      expect(meta.width).toBe(4 * EXPECTED_PNG_DIMENSIONS.medium.casePixels);
+    });
+
+    it('produces an image of height = gridHeightInCases x 16', async () => {
+      const buffer = await renderer.render(MOCK_ROTATED_GRID_4x6, 'medium');
+      const meta = await sharp(buffer).metadata();
+      expect(meta.height).toBe(6 * EXPECTED_PNG_DIMENSIONS.medium.casePixels);
+    });
+  });
+
+  describe('dimensions - case size: large (32px per case)', () => {
+    it('produces an image of width = gridWidthInCases x 32', async () => {
+      const buffer = await renderer.render(MOCK_ROTATED_GRID_4x6, 'large');
+      const meta = await sharp(buffer).metadata();
+      expect(meta.width).toBe(4 * EXPECTED_PNG_DIMENSIONS.large.casePixels);
+    });
+
+    it('produces an image of height = gridHeightInCases x 32', async () => {
+      const buffer = await renderer.render(MOCK_ROTATED_GRID_4x6, 'large');
+      const meta = await sharp(buffer).metadata();
+      expect(meta.height).toBe(6 * EXPECTED_PNG_DIMENSIONS.large.casePixels);
+    });
+  });
+
+  describe('colour accuracy', () => {
+    it('maps each Hexahue palette colour to the correct RGB value', async () => {
+      const casePixels = EXPECTED_PNG_DIMENSIONS.small.casePixels;
+      const buffer = await renderer.render(MOCK_ROTATED_GRID_4x6, 'small');
+      const { data, info } = await sharp(buffer)
+        .raw()
+        .toBuffer({ resolveWithObject: true });
+
+      for (let caseY = 0; caseY < MOCK_ROTATED_GRID_4x6.length; caseY++) {
+        for (
+          let caseX = 0;
+          caseX < MOCK_ROTATED_GRID_4x6[caseY].length;
+          caseX++
+        ) {
+          const colorName = MOCK_ROTATED_GRID_4x6[caseY][caseX];
+          const expectedRgb = HEXAHUE_PALETTE_MAP[colorName].rgb;
+          const px = caseX * casePixels;
+          const py = caseY * casePixels;
+          const offset = (py * info.width + px) * info.channels;
+          expect([data[offset], data[offset + 1], data[offset + 2]]).toEqual(
+            expectedRgb,
+          );
+        }
+      }
+    });
+
+    it('does not introduce colours outside the Hexahue palette for non-padding cells', async () => {
+      const buffer = await renderer.render(MOCK_ROTATED_GRID_4x6, 'small');
+      const { data, info } = await sharp(buffer)
+        .raw()
+        .toBuffer({ resolveWithObject: true });
+      const knownRgbs = new Set(
+        Object.values(HEXAHUE_PALETTE_MAP).map(({ rgb }) => rgb.join(',')),
+      );
+
+      for (let i = 0; i < data.length; i += info.channels) {
+        const pixel = [data[i], data[i + 1], data[i + 2]].join(',');
+        expect(knownRgbs.has(pixel)).toBe(true);
+      }
+    });
+  });
+
+  describe('input validation', () => {
+    it('throws a RangeError for an empty grid (zero rows)', async () => {
+      await expect(renderer.render([], 'small')).rejects.toThrow(RangeError);
+    });
+
+    it('throws a RangeError for a grid with a zero-length row', async () => {
+      await expect(renderer.render([[]], 'small')).rejects.toThrow(RangeError);
+    });
+
+    it('throws a RangeError for a grid with inconsistent row lengths', async () => {
+      const raggedGrid: ColorGrid = [['red', 'green'], ['blue']];
+      await expect(renderer.render(raggedGrid, 'small')).rejects.toThrow(
+        RangeError,
+      );
+    });
+  });
+});

--- a/backend/src/renderer/png-renderer.ts
+++ b/backend/src/renderer/png-renderer.ts
@@ -30,6 +30,11 @@ export class PngRenderer implements Renderer<Buffer> {
     }
 
     const casePixels = CASE_PIXELS[size];
+    if (casePixels === undefined) {
+      throw new RangeError(
+        `size must be one of: ${Object.keys(CASE_PIXELS).join(', ')}, got "${size}"`,
+      );
+    }
     const widthPx = gridWidthInCases * casePixels;
     const heightPx = gridHeightInCases * casePixels;
 

--- a/backend/src/renderer/png-renderer.ts
+++ b/backend/src/renderer/png-renderer.ts
@@ -1,0 +1,62 @@
+import { Injectable } from '@nestjs/common';
+import sharp from 'sharp';
+import { ColorGrid, CaseSize, Renderer } from '../shared/types';
+import { CASE_PIXELS, colorNameToRgb } from './palette';
+
+const CHANNELS = 3; // RGB, no alpha
+
+/**
+ * Renders a ColorGrid (message symbols plus random padding, already
+ * rotated - no header of any kind) to a PNG buffer using Sharp. Each
+ * colour case is painted as a solid casePixels x casePixels square via
+ * direct raw-buffer writes - no interpolation, so only exact Hexahue
+ * palette colours ever appear in the output.
+ */
+@Injectable()
+export class PngRenderer implements Renderer<Buffer> {
+  async render(grid: ColorGrid, size: CaseSize): Promise<Buffer> {
+    const gridHeightInCases = grid.length;
+    if (gridHeightInCases === 0) {
+      throw new RangeError('grid must have at least one row');
+    }
+    const gridWidthInCases = grid[0].length;
+    if (gridWidthInCases === 0) {
+      throw new RangeError('grid rows must have at least one case');
+    }
+    for (const row of grid) {
+      if (row.length !== gridWidthInCases) {
+        throw new RangeError('grid rows must all have the same length');
+      }
+    }
+
+    const casePixels = CASE_PIXELS[size];
+    const widthPx = gridWidthInCases * casePixels;
+    const heightPx = gridHeightInCases * casePixels;
+
+    const pixels = Buffer.alloc(widthPx * heightPx * CHANNELS);
+
+    for (let caseY = 0; caseY < gridHeightInCases; caseY++) {
+      for (let caseX = 0; caseX < gridWidthInCases; caseX++) {
+        const [r, g, b] = colorNameToRgb(grid[caseY][caseX]);
+        const baseX = caseX * casePixels;
+        const baseY = caseY * casePixels;
+
+        for (let dy = 0; dy < casePixels; dy++) {
+          const rowOffset = (baseY + dy) * widthPx * CHANNELS;
+          for (let dx = 0; dx < casePixels; dx++) {
+            const pixelOffset = rowOffset + (baseX + dx) * CHANNELS;
+            pixels[pixelOffset] = r;
+            pixels[pixelOffset + 1] = g;
+            pixels[pixelOffset + 2] = b;
+          }
+        }
+      }
+    }
+
+    return sharp(pixels, {
+      raw: { width: widthPx, height: heightPx, channels: CHANNELS },
+    })
+      .png()
+      .toBuffer();
+  }
+}

--- a/backend/src/renderer/renderer.module.ts
+++ b/backend/src/renderer/renderer.module.ts
@@ -1,4 +1,8 @@
 import { Module } from '@nestjs/common';
+import { PngRenderer } from './png-renderer';
 
-@Module({})
+@Module({
+  providers: [PngRenderer],
+  exports: [PngRenderer],
+})
 export class RendererModule {}

--- a/backend/src/shared/types/case-size.type.ts
+++ b/backend/src/shared/types/case-size.type.ts
@@ -1,0 +1,5 @@
+/**
+ * Rendered case size. Maps to a fixed pixel-per-case value - see
+ * `CASE_PIXELS` in `renderer/palette.ts`.
+ */
+export type CaseSize = 'small' | 'medium' | 'large';

--- a/backend/src/shared/types/index.ts
+++ b/backend/src/shared/types/index.ts
@@ -1,2 +1,4 @@
 export type { ColorGrid } from './color-grid.type';
 export type { VisualAlphabet } from './visual-alphabet.interface';
+export type { CaseSize } from './case-size.type';
+export type { Renderer } from './renderer.interface';

--- a/backend/src/shared/types/renderer.interface.ts
+++ b/backend/src/shared/types/renderer.interface.ts
@@ -6,7 +6,8 @@ import { CaseSize } from './case-size.type';
  *
  * `grid` is exactly the ColorGrid produced by the cipher/rotation pipeline
  * (message symbols plus random padding, already rotated) - there is no
- * metadata header of any kind (see this plan's "Design decision" note).
+ * metadata header of any kind (see docs/tests/renderer.md, "Design note:
+ * no visual header row", for why).
  */
 export interface Renderer<T> {
   render(grid: ColorGrid, size: CaseSize): T | Promise<T>;

--- a/backend/src/shared/types/renderer.interface.ts
+++ b/backend/src/shared/types/renderer.interface.ts
@@ -1,0 +1,13 @@
+import { ColorGrid } from './color-grid.type';
+import { CaseSize } from './case-size.type';
+
+/**
+ * Contract for a concrete image renderer.
+ *
+ * `grid` is exactly the ColorGrid produced by the cipher/rotation pipeline
+ * (message symbols plus random padding, already rotated) - there is no
+ * metadata header of any kind (see this plan's "Design decision" note).
+ */
+export interface Renderer<T> {
+  render(grid: ColorGrid, size: CaseSize): T | Promise<T>;
+}

--- a/docs/superpowers/plans/2026-08-14-feat-009-png-renderer.md
+++ b/docs/superpowers/plans/2026-08-14-feat-009-png-renderer.md
@@ -1,0 +1,748 @@
+# FEAT-009 PNG Renderer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement `PngRenderer`, a Sharp-based concrete implementation of a new `Renderer<T>` interface, that paints a `ColorGrid` (message symbols plus random padding, already rotated - the output of `buildGrid` + `RotationEngine`, nothing else) into a PNG buffer at one of three fixed case sizes, using the exact Hexahue standard palette.
+
+**Architecture:** `PngRenderer.render(grid, size)` is a pure, alphabet-agnostic pixel painter: it paints exactly the rectangular `ColorGrid` it receives, one solid `casePixels x casePixels` square per case, using a fixed Hexahue colour-name-to-hex lookup table. There is no metadata header of any kind - see the "Design decision" note below for why an earlier header design (both a separate unrotated header row, and a header prefixed into the rotated message stream) was rejected and removed from this plan.
+
+**Tech Stack:** NestJS 11, TypeScript strict, Jest, Sharp (new dependency, raw pixel buffer construction - no SVG/DOM compositing).
+
+**Spec:** `docs/tests/renderer.md` section 1 (PngRenderer unit tests) and section 3 (integration tests) is the binding test contract. `BACKLOG.md` FEAT-009 is the acceptance-criteria source. `CONTEXT.md` section "Colour Palette" confirms V1 renders only the fixed Hexahue standard palette (no theming).
+
+## Design decision: no metadata header (2026-08-14)
+
+Two header designs were considered and rejected during planning, both for security reasons - discussed and decided with the user before this plan was written:
+
+1. **A separate header row, rendered above the grid, not subject to rotation.** Rejected: the Hexahue alphabet is public, so anyone viewing the image - with or without the key - could read the header's digit symbols directly and recover the exact message length. This also partially defeats the purpose of random padding, since the message/padding boundary becomes directly computable from the leaked length.
+2. **Header digits prefixed into the message text, subject to the same rotation as the body** (so it is not readable without the key). Rejected: even though the *content* is protected, the *fact* that "the first N decoded symbols are always digits" is public knowledge about how the tool works, independent of any specific key. This is a known-plaintext-at-fixed-position weakness: for any candidate set of decode parameters, checking "do the first N decoded symbols look like digits" is a cheap, key-independent validity oracle that measurably narrows a brute-force search - a real weakness even though no information leaks without attempting a decode.
+
+The encoded grid is therefore the pre-processed message plus random padding only, exactly as `buildGrid` (FEAT-006) and `RotationEngine` (FEAT-007) already produce it, unchanged. `FEAT-008`'s `encodeHeader`/`decodeHeader` (byte-level `Buffer` functions) remain in the codebase, tested, but are not called by this plan or wired into any pipeline - they are effectively unused pending a future, more carefully designed evolution (properly key-dependent encoding, or decode-time message-boundary detection via symbol validity against the alphabet). Do not resurrect either rejected design without discussing the security implications again first.
+
+## Global Constraints
+
+- TypeScript strict mode, no implicit any.
+- English code, comments, commit messages. No em dash, en dash, or curly quotes anywhere - plain ASCII punctuation only (hard house rule).
+- Conventional Commits with a mandatory "Modified files:" list on every commit.
+- **Hexahue palette (fixed, confirmed by the user - do not substitute or derive alternate values):**
+  | Colour name (as stored in `ColorGrid` cells) | Hex |
+  |---|---|
+  | `purple` | `#ff00ff` |
+  | `red` | `#ff0000` |
+  | `green` | `#66ff00` |
+  | `yellow` | `#ffff00` |
+  | `blue` | `#0000ff` (the user called this "dark blue") |
+  | `cyan` | `#00ffff` (the user called this "light blue") |
+  | `white` | `#ffffff` |
+  | `black` | `#000000` |
+  | `gray` | `#888888` |
+
+  `blue`/`cyan` are the exact string literals already used throughout the codebase (`backend/prisma/seed.ts`, `backend/test/utils/mock-alphabet.ts`) for what the user described verbally as "dark blue"/"light blue" - use those literals, not "dark blue"/"light blue", as the `ColorGrid` cell values and map keys.
+- **Case sizes (pixels per case), from `BACKLOG.md` FEAT-009's suggested values, also used directly in `docs/tests/renderer.md`'s dimension bullets:** `small: 8`, `medium: 16`, `large: 32`.
+- **`Renderer<T>.render(grid, size)` receives the grid exactly as `buildGrid` + `RotationEngine` produce it.** No header concept anywhere: width = `grid[0].length * casePixels`, height = `grid.length * casePixels`. Do not add a `messageLength` or `alphabet` parameter to `render()` - the doc's own interface-compliance bullet ("it exposes a `render(grid, size)` method") is exactly two parameters.
+- **No antialiasing/interpolation:** every case is painted as one solid `casePixels x casePixels` block of an exact palette RGB triple, so no colour outside the fixed 9-entry palette can ever appear in rendered output pixels.
+- `PngRenderer` throws `RangeError` for a malformed input grid: zero rows, a zero-length row, or rows of inconsistent length (not rectangular) - mirrors the project's established guard-clause convention (`build-grid.ts`, `header.ts`, `rotation-engine.ts`).
+- The integration test (`docs/tests/renderer.md` section 3) explicitly allows "a complete in-memory fixture" instead of the real seeded database - use an in-memory `VisualAlphabet` fixture (this plan adds `MOCK_HEXAHUE_ALPHABET`), not a real `HexahueAlphabet`/Prisma/database dependency, to keep the test self-contained and fast like the rest of the suite (242 tests currently run with no DB).
+- `docs/tests/renderer.md`'s integration test bullet says `sequence [0,90,180,270]`: this is the doc's angle-value shorthand, not the literal `RotationSequence` parameter. `RotationSequence` (`backend/src/key/key-codec.ts`) is a 4-element array of **indices** into `ROTATION_ANGLES = [0, 90, 180, 270]` (`backend/src/rotation/rotation-engine.ts`). Passing the literal values `[0, 90, 180, 270]` as indices would throw (out of bounds past index 3). The index sequence that produces the angle sequence 0deg, 90deg, 180deg, 270deg in order is `[0, 1, 2, 3]` - use that.
+
+---
+
+### Task 1: `Renderer<T>` interface and `CaseSize` type
+
+**Files:**
+- Create: `backend/src/shared/types/case-size.type.ts`
+- Create: `backend/src/shared/types/renderer.interface.ts`
+- Modify: `backend/src/shared/types/index.ts`
+- Modify: `BACKLOG.md` (already edited in the main checkout before this worktree existed - see Step 6)
+- Modify: `docs/tests/renderer.md` (already edited in the main checkout before this worktree existed - see Step 6)
+
+**Interfaces:**
+- Produces: `CaseSize` (`'small' | 'medium' | 'large'`) and `Renderer<T>` (`render(grid: ColorGrid, size: CaseSize): T | Promise<T>`), both exported from `../shared/types` for Task 2 and Task 3 to import.
+
+- [ ] **Step 1: Create the `CaseSize` type**
+
+`backend/src/shared/types/case-size.type.ts`:
+
+```typescript
+/**
+ * Rendered case size. Maps to a fixed pixel-per-case value - see
+ * `CASE_PIXELS` in `renderer/palette.ts`.
+ */
+export type CaseSize = 'small' | 'medium' | 'large';
+```
+
+- [ ] **Step 2: Create the `Renderer<T>` interface**
+
+`backend/src/shared/types/renderer.interface.ts`:
+
+```typescript
+import { ColorGrid } from './color-grid.type';
+import { CaseSize } from './case-size.type';
+
+/**
+ * Contract for a concrete image renderer.
+ *
+ * `grid` is exactly the ColorGrid produced by the cipher/rotation pipeline
+ * (message symbols plus random padding, already rotated) - there is no
+ * metadata header of any kind (see this plan's "Design decision" note).
+ */
+export interface Renderer<T> {
+  render(grid: ColorGrid, size: CaseSize): T | Promise<T>;
+}
+```
+
+- [ ] **Step 3: Export both from the shared types barrel**
+
+Modify `backend/src/shared/types/index.ts` to:
+
+```typescript
+export type { ColorGrid } from './color-grid.type';
+export type { VisualAlphabet } from './visual-alphabet.interface';
+export type { CaseSize } from './case-size.type';
+export type { Renderer } from './renderer.interface';
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run: `cd backend && npx tsc --noEmit`
+Expected: no new errors introduced by these two files (pre-existing unrelated errors in other files, if any, are not this task's concern).
+
+- [ ] **Step 5: Bring in the pre-existing BACKLOG.md and docs/tests/renderer.md corrections**
+
+Before this plan was written, `BACKLOG.md` (FEAT-009 and FEAT-010 descriptions/acceptance criteria, `depends-on` lists, and the FEAT-012 description) and `docs/tests/renderer.md` (removing the "Header row" test bullets, the `headerRows` dimension term, and adding a "Design note: no visual header row" section) were corrected in the main checkout to reflect the no-header decision above, but never committed. Copy the current versions of both files from the main repository checkout into this worktree, overwriting the worktree's copies (which still reflect the old, header-based design):
+
+```bash
+cp /home/mlr/projets/HexaRot/BACKLOG.md BACKLOG.md
+cp /home/mlr/projets/HexaRot/docs/tests/renderer.md docs/tests/renderer.md
+```
+
+Verify: `git diff BACKLOG.md docs/tests/renderer.md` should show no mention of "header row" or "headerRows" remaining anywhere in either file's renderer-related sections.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/shared/types/case-size.type.ts backend/src/shared/types/renderer.interface.ts backend/src/shared/types/index.ts BACKLOG.md docs/tests/renderer.md
+git commit -m "$(cat <<'EOF'
+feat(shared): add Renderer<T> interface and CaseSize type
+
+Modified files:
+- backend/src/shared/types/case-size.type.ts - new CaseSize type (small/medium/large)
+- backend/src/shared/types/renderer.interface.ts - new generic Renderer<T> contract, no header parameter
+- backend/src/shared/types/index.ts - export both from the shared types barrel
+- BACKLOG.md - remove header-row mentions from FEAT-009/FEAT-010, drop FEAT-008 from their depends-on, correct FEAT-012's description
+- docs/tests/renderer.md - remove Header row test bullets and headerRows dimension term, add design-decision note
+EOF
+)"
+```
+
+---
+
+### Task 2: Hexahue palette constants
+
+**Files:**
+- Create: `backend/src/renderer/palette.ts`
+- Test: `backend/src/renderer/palette.spec.ts`
+
+**Interfaces:**
+- Consumes: `CaseSize` from Task 1.
+- Produces: `HEXAHUE_COLOR_HEX` (`Readonly<Record<string, string>>`), `CASE_PIXELS` (`Readonly<Record<CaseSize, number>>`), `colorNameToRgb(colorName: string): [number, number, number]` - all consumed by Task 3's `PngRenderer`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`backend/src/renderer/palette.spec.ts`:
+
+```typescript
+import { HEXAHUE_COLOR_HEX, CASE_PIXELS, colorNameToRgb } from './palette';
+
+describe('HEXAHUE_COLOR_HEX', () => {
+  it('maps all 9 Hexahue palette colours to their exact hex value', () => {
+    expect(HEXAHUE_COLOR_HEX).toEqual({
+      purple: '#ff00ff',
+      red: '#ff0000',
+      green: '#66ff00',
+      yellow: '#ffff00',
+      blue: '#0000ff',
+      cyan: '#00ffff',
+      white: '#ffffff',
+      black: '#000000',
+      gray: '#888888',
+    });
+  });
+});
+
+describe('CASE_PIXELS', () => {
+  it('maps each case size to its pixel-per-case value', () => {
+    expect(CASE_PIXELS).toEqual({ small: 8, medium: 16, large: 32 });
+  });
+});
+
+describe('colorNameToRgb', () => {
+  it('resolves each of the 9 palette colours to the correct RGB triple', () => {
+    expect(colorNameToRgb('purple')).toEqual([255, 0, 255]);
+    expect(colorNameToRgb('red')).toEqual([255, 0, 0]);
+    expect(colorNameToRgb('green')).toEqual([102, 255, 0]);
+    expect(colorNameToRgb('yellow')).toEqual([255, 255, 0]);
+    expect(colorNameToRgb('blue')).toEqual([0, 0, 255]);
+    expect(colorNameToRgb('cyan')).toEqual([0, 255, 255]);
+    expect(colorNameToRgb('white')).toEqual([255, 255, 255]);
+    expect(colorNameToRgb('black')).toEqual([0, 0, 0]);
+    expect(colorNameToRgb('gray')).toEqual([136, 136, 136]);
+  });
+
+  it('throws a RangeError for a colour name outside the Hexahue palette', () => {
+    expect(() => colorNameToRgb('magenta')).toThrow(RangeError);
+    expect(() => colorNameToRgb('')).toThrow(RangeError);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && npx jest palette.spec.ts`
+Expected: FAIL with "Cannot find module './palette'"
+
+- [ ] **Step 3: Implement**
+
+`backend/src/renderer/palette.ts`:
+
+```typescript
+import { CaseSize } from '../shared/types';
+
+/**
+ * Hexahue standard palette: colour name (as stored in ColorGrid cells) to
+ * hex RGB string. V1 renders only this fixed palette (see CONTEXT.md,
+ * "Colour Palette" - alternate themes are out of scope).
+ */
+export const HEXAHUE_COLOR_HEX: Readonly<Record<string, string>> = {
+  purple: '#ff00ff',
+  red: '#ff0000',
+  green: '#66ff00',
+  yellow: '#ffff00',
+  blue: '#0000ff',
+  cyan: '#00ffff',
+  white: '#ffffff',
+  black: '#000000',
+  gray: '#888888',
+};
+
+/** Pixel size (width and height) of a single colour case, per case-size option. */
+export const CASE_PIXELS: Readonly<Record<CaseSize, number>> = {
+  small: 8,
+  medium: 16,
+  large: 32,
+};
+
+/**
+ * Resolves a Hexahue colour name to its RGB triple.
+ *
+ * @throws {RangeError} If the colour name is not part of the Hexahue palette.
+ */
+export function colorNameToRgb(colorName: string): [number, number, number] {
+  const hex = HEXAHUE_COLOR_HEX[colorName];
+  if (!hex) {
+    throw new RangeError(
+      `Unknown colour "${colorName}", expected one of: ${Object.keys(HEXAHUE_COLOR_HEX).join(', ')}`,
+    );
+  }
+  return [
+    parseInt(hex.slice(1, 3), 16),
+    parseInt(hex.slice(3, 5), 16),
+    parseInt(hex.slice(5, 7), 16),
+  ];
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && npx jest palette.spec.ts`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/renderer/palette.ts backend/src/renderer/palette.spec.ts
+git commit -m "$(cat <<'EOF'
+feat(renderer): add Hexahue palette constants and colour-to-RGB lookup
+
+Modified files:
+- backend/src/renderer/palette.ts - HEXAHUE_COLOR_HEX, CASE_PIXELS, colorNameToRgb with RangeError guard
+- backend/src/renderer/palette.spec.ts - palette mapping and unknown-colour error tests
+EOF
+)"
+```
+
+---
+
+### Task 3: `PngRenderer` (Sharp) and its unit tests
+
+**Files:**
+- Create: `backend/src/renderer/png-renderer.ts`
+- Modify: `backend/src/renderer/renderer.module.ts`
+- Create: `backend/src/renderer/__fixtures__/renderer.fixtures.ts`
+- Test: `backend/src/renderer/png-renderer.spec.ts`
+- Modify: `backend/package.json` (adds `sharp` dependency via `npm install`)
+
+**Interfaces:**
+- Consumes: `Renderer<T>`, `CaseSize`, `ColorGrid` from Task 1; `CASE_PIXELS`, `colorNameToRgb` from Task 2.
+- Produces: `PngRenderer` (implements `Renderer<Buffer>`), registered as a provider in `RendererModule`. `MOCK_ROTATED_GRID_4x6`, `HEXAHUE_PALETTE_MAP`, `EXPECTED_PNG_DIMENSIONS` fixtures, consumed by this task's own tests and by Task 4's integration test.
+
+- [ ] **Step 1: Install Sharp**
+
+Run: `cd backend && npm install sharp`
+Expected: `sharp` added to `dependencies` in `backend/package.json` and `backend/package-lock.json` updated. Sharp ships its own TypeScript types; no separate `@types/sharp` package needed.
+
+- [ ] **Step 2: Create the fixtures file**
+
+`backend/src/renderer/__fixtures__/renderer.fixtures.ts`:
+
+```typescript
+import { ColorGrid, CaseSize } from '../../shared/types';
+
+/** A hardcoded 4-column x 6-row pre-rotated grid, ready for rendering. */
+export const MOCK_ROTATED_GRID_4x6: ColorGrid = [
+  ['red', 'green', 'blue', 'yellow'],
+  ['cyan', 'purple', 'black', 'white'],
+  ['gray', 'red', 'green', 'blue'],
+  ['yellow', 'cyan', 'purple', 'black'],
+  ['white', 'gray', 'red', 'green'],
+  ['blue', 'yellow', 'cyan', 'purple'],
+];
+
+/** Every Hexahue palette colour mapped to its expected RGB tuple and hex string. */
+export const HEXAHUE_PALETTE_MAP: Record<
+  string,
+  { rgb: [number, number, number]; hex: string }
+> = {
+  purple: { rgb: [255, 0, 255], hex: '#ff00ff' },
+  red: { rgb: [255, 0, 0], hex: '#ff0000' },
+  green: { rgb: [102, 255, 0], hex: '#66ff00' },
+  yellow: { rgb: [255, 255, 0], hex: '#ffff00' },
+  blue: { rgb: [0, 0, 255], hex: '#0000ff' },
+  cyan: { rgb: [0, 255, 255], hex: '#00ffff' },
+  white: { rgb: [255, 255, 255], hex: '#ffffff' },
+  black: { rgb: [0, 0, 0], hex: '#000000' },
+  gray: { rgb: [136, 136, 136], hex: '#888888' },
+};
+
+/** Case-size -> { casePixels } used by tests to compute expected PNG dimensions. */
+export const EXPECTED_PNG_DIMENSIONS: Record<CaseSize, { casePixels: number }> = {
+  small: { casePixels: 8 },
+  medium: { casePixels: 16 },
+  large: { casePixels: 32 },
+};
+```
+
+- [ ] **Step 3: Write the failing tests**
+
+`backend/src/renderer/png-renderer.spec.ts`:
+
+```typescript
+import sharp from 'sharp';
+import { ColorGrid } from '../shared/types';
+import { PngRenderer } from './png-renderer';
+import {
+  MOCK_ROTATED_GRID_4x6,
+  HEXAHUE_PALETTE_MAP,
+  EXPECTED_PNG_DIMENSIONS,
+} from './__fixtures__/renderer.fixtures';
+
+describe('PngRenderer', () => {
+  const renderer = new PngRenderer();
+
+  describe('interface compliance', () => {
+    it('exposes a render(grid, size) method returning a Promise<Buffer>', () => {
+      const result = renderer.render(MOCK_ROTATED_GRID_4x6, 'small');
+      expect(result).toBeInstanceOf(Promise);
+      return result.then((buffer) => {
+        expect(Buffer.isBuffer(buffer)).toBe(true);
+      });
+    });
+  });
+
+  describe('output validity', () => {
+    it('returns a Buffer (not null, not undefined)', async () => {
+      const buffer = await renderer.render(MOCK_ROTATED_GRID_4x6, 'small');
+      expect(buffer).not.toBeNull();
+      expect(buffer).not.toBeUndefined();
+      expect(Buffer.isBuffer(buffer)).toBe(true);
+    });
+
+    it('returns a buffer whose first bytes match the PNG magic number', async () => {
+      const buffer = await renderer.render(MOCK_ROTATED_GRID_4x6, 'small');
+      expect(buffer.subarray(0, 4)).toEqual(
+        Buffer.from([0x89, 0x50, 0x4e, 0x47]),
+      );
+    });
+  });
+
+  describe('dimensions - case size: small (8px per case)', () => {
+    it('produces an image of width = gridWidthInCases x 8', async () => {
+      const buffer = await renderer.render(MOCK_ROTATED_GRID_4x6, 'small');
+      const meta = await sharp(buffer).metadata();
+      expect(meta.width).toBe(4 * EXPECTED_PNG_DIMENSIONS.small.casePixels);
+    });
+
+    it('produces an image of height = gridHeightInCases x 8', async () => {
+      const buffer = await renderer.render(MOCK_ROTATED_GRID_4x6, 'small');
+      const meta = await sharp(buffer).metadata();
+      expect(meta.height).toBe(6 * EXPECTED_PNG_DIMENSIONS.small.casePixels);
+    });
+  });
+
+  describe('dimensions - case size: medium (16px per case)', () => {
+    it('produces an image of width = gridWidthInCases x 16', async () => {
+      const buffer = await renderer.render(MOCK_ROTATED_GRID_4x6, 'medium');
+      const meta = await sharp(buffer).metadata();
+      expect(meta.width).toBe(4 * EXPECTED_PNG_DIMENSIONS.medium.casePixels);
+    });
+
+    it('produces an image of height = gridHeightInCases x 16', async () => {
+      const buffer = await renderer.render(MOCK_ROTATED_GRID_4x6, 'medium');
+      const meta = await sharp(buffer).metadata();
+      expect(meta.height).toBe(6 * EXPECTED_PNG_DIMENSIONS.medium.casePixels);
+    });
+  });
+
+  describe('dimensions - case size: large (32px per case)', () => {
+    it('produces an image of width = gridWidthInCases x 32', async () => {
+      const buffer = await renderer.render(MOCK_ROTATED_GRID_4x6, 'large');
+      const meta = await sharp(buffer).metadata();
+      expect(meta.width).toBe(4 * EXPECTED_PNG_DIMENSIONS.large.casePixels);
+    });
+
+    it('produces an image of height = gridHeightInCases x 32', async () => {
+      const buffer = await renderer.render(MOCK_ROTATED_GRID_4x6, 'large');
+      const meta = await sharp(buffer).metadata();
+      expect(meta.height).toBe(6 * EXPECTED_PNG_DIMENSIONS.large.casePixels);
+    });
+  });
+
+  describe('colour accuracy', () => {
+    it('maps each Hexahue palette colour to the correct RGB value', async () => {
+      const casePixels = EXPECTED_PNG_DIMENSIONS.small.casePixels;
+      const buffer = await renderer.render(MOCK_ROTATED_GRID_4x6, 'small');
+      const { data, info } = await sharp(buffer)
+        .raw()
+        .toBuffer({ resolveWithObject: true });
+
+      for (let caseY = 0; caseY < MOCK_ROTATED_GRID_4x6.length; caseY++) {
+        for (let caseX = 0; caseX < MOCK_ROTATED_GRID_4x6[caseY].length; caseX++) {
+          const colorName = MOCK_ROTATED_GRID_4x6[caseY][caseX];
+          const expectedRgb = HEXAHUE_PALETTE_MAP[colorName].rgb;
+          const px = caseX * casePixels;
+          const py = caseY * casePixels;
+          const offset = (py * info.width + px) * info.channels;
+          expect([data[offset], data[offset + 1], data[offset + 2]]).toEqual(
+            expectedRgb,
+          );
+        }
+      }
+    });
+
+    it('does not introduce colours outside the Hexahue palette for non-padding cells', async () => {
+      const buffer = await renderer.render(MOCK_ROTATED_GRID_4x6, 'small');
+      const { data, info } = await sharp(buffer)
+        .raw()
+        .toBuffer({ resolveWithObject: true });
+      const knownRgbs = new Set(
+        Object.values(HEXAHUE_PALETTE_MAP).map(({ rgb }) => rgb.join(',')),
+      );
+
+      for (let i = 0; i < data.length; i += info.channels) {
+        const pixel = [data[i], data[i + 1], data[i + 2]].join(',');
+        expect(knownRgbs.has(pixel)).toBe(true);
+      }
+    });
+  });
+
+  describe('input validation', () => {
+    it('throws a RangeError for an empty grid (zero rows)', async () => {
+      await expect(renderer.render([], 'small')).rejects.toThrow(RangeError);
+    });
+
+    it('throws a RangeError for a grid with a zero-length row', async () => {
+      await expect(renderer.render([[]], 'small')).rejects.toThrow(
+        RangeError,
+      );
+    });
+
+    it('throws a RangeError for a grid with inconsistent row lengths', async () => {
+      const raggedGrid: ColorGrid = [
+        ['red', 'green'],
+        ['blue'],
+      ];
+      await expect(renderer.render(raggedGrid, 'small')).rejects.toThrow(
+        RangeError,
+      );
+    });
+  });
+});
+```
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+Run: `cd backend && npx jest png-renderer.spec.ts`
+Expected: FAIL with "Cannot find module './png-renderer'"
+
+- [ ] **Step 5: Implement `PngRenderer`**
+
+`backend/src/renderer/png-renderer.ts`:
+
+```typescript
+import { Injectable } from '@nestjs/common';
+import sharp from 'sharp';
+import { ColorGrid, CaseSize, Renderer } from '../shared/types';
+import { CASE_PIXELS, colorNameToRgb } from './palette';
+
+const CHANNELS = 3; // RGB, no alpha
+
+/**
+ * Renders a ColorGrid (message symbols plus random padding, already
+ * rotated - no header of any kind) to a PNG buffer using Sharp. Each
+ * colour case is painted as a solid casePixels x casePixels square via
+ * direct raw-buffer writes - no interpolation, so only exact Hexahue
+ * palette colours ever appear in the output.
+ */
+@Injectable()
+export class PngRenderer implements Renderer<Buffer> {
+  async render(grid: ColorGrid, size: CaseSize): Promise<Buffer> {
+    const gridHeightInCases = grid.length;
+    if (gridHeightInCases === 0) {
+      throw new RangeError('grid must have at least one row');
+    }
+    const gridWidthInCases = grid[0].length;
+    if (gridWidthInCases === 0) {
+      throw new RangeError('grid rows must have at least one case');
+    }
+    for (const row of grid) {
+      if (row.length !== gridWidthInCases) {
+        throw new RangeError('grid rows must all have the same length');
+      }
+    }
+
+    const casePixels = CASE_PIXELS[size];
+    const widthPx = gridWidthInCases * casePixels;
+    const heightPx = gridHeightInCases * casePixels;
+
+    const pixels = Buffer.alloc(widthPx * heightPx * CHANNELS);
+
+    for (let caseY = 0; caseY < gridHeightInCases; caseY++) {
+      for (let caseX = 0; caseX < gridWidthInCases; caseX++) {
+        const [r, g, b] = colorNameToRgb(grid[caseY][caseX]);
+        const baseX = caseX * casePixels;
+        const baseY = caseY * casePixels;
+
+        for (let dy = 0; dy < casePixels; dy++) {
+          const rowOffset = (baseY + dy) * widthPx * CHANNELS;
+          for (let dx = 0; dx < casePixels; dx++) {
+            const pixelOffset = rowOffset + (baseX + dx) * CHANNELS;
+            pixels[pixelOffset] = r;
+            pixels[pixelOffset + 1] = g;
+            pixels[pixelOffset + 2] = b;
+          }
+        }
+      }
+    }
+
+    return sharp(pixels, {
+      raw: { width: widthPx, height: heightPx, channels: CHANNELS },
+    })
+      .png()
+      .toBuffer();
+  }
+}
+```
+
+- [ ] **Step 6: Register `PngRenderer` in `RendererModule`**
+
+Modify `backend/src/renderer/renderer.module.ts` to:
+
+```typescript
+import { Module } from '@nestjs/common';
+import { PngRenderer } from './png-renderer';
+
+@Module({
+  providers: [PngRenderer],
+  exports: [PngRenderer],
+})
+export class RendererModule {}
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `cd backend && npx jest png-renderer.spec.ts palette.spec.ts`
+Expected: PASS (18 tests: 4 from palette.spec.ts, 14 from png-renderer.spec.ts - 1 interface compliance + 2 output validity + 6 dimensions (3 sizes x 2) + 2 colour accuracy + 3 input validation). This task's test file has no "header row" describe block - that concept was removed along with the header design.
+
+- [ ] **Step 8: Run the full backend suite and lint**
+
+Run: `cd backend && npm run test && npx eslint src/renderer`
+Expected: all tests pass (242 + 18 new = 260), eslint clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add backend/src/renderer/png-renderer.ts backend/src/renderer/renderer.module.ts backend/src/renderer/__fixtures__/renderer.fixtures.ts backend/src/renderer/png-renderer.spec.ts backend/package.json backend/package-lock.json
+git commit -m "$(cat <<'EOF'
+feat(renderer): implement PngRenderer with Sharp raw pixel painting
+
+Modified files:
+- backend/src/renderer/png-renderer.ts - PngRenderer implements Renderer<Buffer>, solid-block Sharp raw buffer painting, no header logic
+- backend/src/renderer/renderer.module.ts - register PngRenderer as a provider
+- backend/src/renderer/__fixtures__/renderer.fixtures.ts - MOCK_ROTATED_GRID_4x6, HEXAHUE_PALETTE_MAP, EXPECTED_PNG_DIMENSIONS
+- backend/src/renderer/png-renderer.spec.ts - unit tests: interface compliance, output validity, dimensions (3 sizes), colour accuracy, input validation
+- backend/package.json, backend/package-lock.json - add sharp dependency
+EOF
+)"
+```
+
+---
+
+### Task 4: Integration tests (full pipeline)
+
+**Files:**
+- Create: `backend/src/renderer/png-renderer.integration.spec.ts`
+- Modify: `backend/src/renderer/__fixtures__/renderer.fixtures.ts` (add `MOCK_HEXAHUE_ALPHABET`)
+
+**Interfaces:**
+- Consumes: `preprocess` (`backend/src/cipher/preprocess.ts`), `buildGrid` (`backend/src/cipher/build-grid.ts`), `RotationEngine` (`backend/src/rotation/rotation-engine.ts`), `ReadingOrderRegistry` (`backend/src/reading-order/reading-order.registry.ts`), `PngRenderer` (Task 3).
+
+- [ ] **Step 1: Add the in-memory alphabet fixture**
+
+Append to `backend/src/renderer/__fixtures__/renderer.fixtures.ts`:
+
+```typescript
+import { VisualAlphabet } from '../../shared/types';
+
+/**
+ * Minimal in-memory VisualAlphabet double with real Hexahue dimensions
+ * (2 wide x 3 tall), supporting 'A' and 'B' - enough to run the full
+ * pipeline end-to-end without a real database, per docs/tests/renderer.md
+ * section 3's explicit allowance for "a complete in-memory fixture".
+ */
+export const MOCK_HEXAHUE_ALPHABET: VisualAlphabet = {
+  symbolWidth: 2,
+  symbolHeight: 3,
+  getBlock(char: string) {
+    const blocks: Record<string, string[][]> = {
+      A: [
+        ['red', 'green'],
+        ['blue', 'yellow'],
+        ['cyan', 'purple'],
+      ],
+      B: [
+        ['green', 'red'],
+        ['yellow', 'blue'],
+        ['purple', 'cyan'],
+      ],
+    };
+    const grid = blocks[char];
+    if (!grid) {
+      throw new Error(`unsupported character: ${char}`);
+    }
+    return grid;
+  },
+  getSupportedChars() {
+    return ['A', 'B'];
+  },
+};
+```
+
+- [ ] **Step 2: Write the integration tests**
+
+`backend/src/renderer/png-renderer.integration.spec.ts`:
+
+```typescript
+import sharp from 'sharp';
+import { preprocess } from '../cipher/preprocess';
+import { buildGrid } from '../cipher/build-grid';
+import { RotationEngine } from '../rotation/rotation-engine';
+import { ReadingOrderRegistry } from '../reading-order/reading-order.registry';
+import { PngRenderer } from './png-renderer';
+import {
+  MOCK_HEXAHUE_ALPHABET,
+  EXPECTED_PNG_DIMENSIONS,
+} from './__fixtures__/renderer.fixtures';
+
+/**
+ * Runs the full encoding pipeline (preprocess -> buildGrid -> rotate ->
+ * render) for a known short message, as required by
+ * docs/tests/renderer.md section 3.
+ *
+ * T=5, LR-TB, sequence [0,90,180,270] (index sequence [0,1,2,3] - see this
+ * plan's Global Constraints for why), CW, size medium. No header anywhere
+ * in this pipeline - see this plan's "Design decision" note.
+ */
+async function encodeAndRender(): Promise<Buffer> {
+  const alphabet = MOCK_HEXAHUE_ALPHABET;
+  const pivotBlockSize = 5;
+
+  const { text } = preprocess('AB', alphabet);
+  const bodyGrid = buildGrid(text, alphabet, pivotBlockSize);
+
+  const rotationEngine = new RotationEngine(new ReadingOrderRegistry());
+  const rotatedGrid = rotationEngine.encode(
+    bodyGrid,
+    pivotBlockSize,
+    [0, 1, 2, 3],
+    'cw',
+    'LR-TB',
+  );
+
+  const renderer = new PngRenderer();
+  return renderer.render(rotatedGrid, 'medium');
+}
+
+describe('PngRenderer - integration', () => {
+  it('encodes the message AB with T=5, LR-TB, sequence [0,90,180,270], CW, size medium and produces a PNG whose width equals the expected pixel value', async () => {
+    const buffer = await encodeAndRender();
+    const meta = await sharp(buffer).metadata();
+
+    const expectedGridWidthInCases = 10; // lcm(pivotBlockSize=5, symbolWidth=2)
+    expect(meta.width).toBe(
+      expectedGridWidthInCases * EXPECTED_PNG_DIMENSIONS.medium.casePixels,
+    );
+  });
+
+  it('encodes the message AB with the same params and produces a PNG whose height equals the expected pixel value', async () => {
+    const buffer = await encodeAndRender();
+    const meta = await sharp(buffer).metadata();
+
+    const expectedGridHeightInCases = 5; // ceil(symbolHeight=3 / pivotBlockSize=5) * 5
+    expect(meta.height).toBe(
+      expectedGridHeightInCases * EXPECTED_PNG_DIMENSIONS.medium.casePixels,
+    );
+  });
+});
+```
+
+- [ ] **Step 3: Run tests to verify they pass**
+
+Run: `cd backend && npx jest png-renderer.integration.spec.ts`
+Expected: PASS (2 tests). If the width/height assertions fail, recompute `expectedGridWidthInCases`/`expectedGridHeightInCases` by hand from `buildGrid`'s adaptive-width formula (`docs/tests/cipher.md` section 4) using `pivotBlockSize=5`, `symbolWidth=2`, `symbolHeight=3`, `messageLength=2` - do not adjust `PngRenderer` to make the numbers match; the arithmetic in this plan was verified by hand when this plan was written.
+
+- [ ] **Step 4: Run the full backend suite**
+
+Run: `cd backend && npm run test`
+Expected: all tests pass (242 base + 18 from Task 2/3 + 2 integration = 262 total; no pre-existing test should regress).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/renderer/png-renderer.integration.spec.ts backend/src/renderer/__fixtures__/renderer.fixtures.ts
+git commit -m "$(cat <<'EOF'
+test(renderer): add PngRenderer integration tests for the full pipeline
+
+Modified files:
+- backend/src/renderer/png-renderer.integration.spec.ts - preprocess to buildGrid to rotate to render, dimension assertions
+- backend/src/renderer/__fixtures__/renderer.fixtures.ts - add MOCK_HEXAHUE_ALPHABET in-memory fixture (2x3 dims, A/B)
+EOF
+)"
+```
+
+---
+
+## After this plan
+
+FEAT-010 (SvgRenderer) implements the same `Renderer<T>` interface (`Renderer<string>`, synchronous) using the same `HEXAHUE_COLOR_HEX`/`CASE_PIXELS` constants from `renderer/palette.ts` - no new design decisions needed there, and no header logic either.
+
+FEAT-011 (API `/encode` endpoint) and FEAT-012 (API `/decode` endpoint) are unaffected in structure by this plan's header decision, except that FEAT-012's decode side has an **open design question**: without a header, how does decode determine where the real message ends and random padding begins? The candidate approach discussed during this plan's design (not built here, out of scope for encoding): decode symbol-by-symbol in the same order `buildGrid` used, stopping at the first block that does not match any character in the alphabet - accepting a small probability that a random padding block coincidentally matches a real symbol. The exact collision rate needs proper analysis at FEAT-012 design time: padding is drawn only from alphabet-present colours via `getPalette()` (`backend/src/cipher/build-grid.ts`), not uniformly from the full 9-colour palette, and real Hexahue symbol blocks are structured rather than arbitrary, so a naive combinatorial estimate over all possible 2x3 colour combinations is likely optimistic. This is an open quantitative question deferred to FEAT-012's own design work.

--- a/docs/tests/renderer.md
+++ b/docs/tests/renderer.md
@@ -25,23 +25,24 @@ describe('PngRenderer')
 
 **Dimensions — case size: small (8px per case)**
 - it produces an image of width = gridWidthInCases × 8 for a known grid
-- it produces an image of height = (gridHeightInCases + headerRows) × 8 for a known grid
+- it produces an image of height = gridHeightInCases × 8 for a known grid
 
 **Dimensions — case size: medium (16px per case)**
 - it produces an image of width = gridWidthInCases × 16
-- it produces an image of height = (gridHeightInCases + headerRows) × 16
+- it produces an image of height = gridHeightInCases × 16
 
 **Dimensions — case size: large (32px per case)**
 - it produces an image of width = gridWidthInCases × 32
-- it produces an image of height = (gridHeightInCases + headerRows) × 32
+- it produces an image of height = gridHeightInCases × 32
 
 **Colour accuracy**
 - it maps each Hexahue palette colour to the correct RGB value
 - it does not introduce colours outside the Hexahue palette for non-padding cells
 
-**Header row**
-- it renders the header above the grid (not below, not overlapping)
-- it renders the header at the correct pixel height
+**Input validation**
+- it throws for an empty grid (zero rows)
+- it throws for a grid with a zero-length row
+- it throws for a grid with inconsistent row lengths (not rectangular)
 
 ---
 
@@ -62,13 +63,12 @@ describe('SvgRenderer')
 
 **viewBox**
 - it sets viewBox width = gridWidthInCases × caseSize for size: small
-- it sets viewBox height = (gridHeightInCases + headerRows) × caseSize for size: small
+- it sets viewBox height = gridHeightInCases × caseSize for size: small
 - it sets correct viewBox for size: medium
 - it sets correct viewBox for size: large
 
 **rect elements**
-- it produces exactly gridWidthInCases × gridHeightInCases `<rect>` elements for the grid
-- it produces the correct number of additional `<rect>` elements for the header
+- it produces exactly gridWidthInCases × gridHeightInCases `<rect>` elements
 - it sets the `fill` attribute of each `<rect>` to the correct Hexahue hex colour value
 - it sets `x`, `y`, `width`, `height` attributes on every `<rect>`
 
@@ -99,7 +99,7 @@ describe('SvgRenderer — integration')
 - it encodes the message 'AB' with T=5, LR-TB, sequence [0,90,180,270], CW, size medium
   and produces an SVG with the correct viewBox
 - it encodes the message 'AB' with the same params and produces an SVG with the
-  correct total number of `<rect>` elements (grid cells + header cells)
+  correct total number of `<rect>` elements (grid cells)
 
 ---
 
@@ -111,5 +111,24 @@ The following shared fixtures must be defined in `__fixtures__/renderer.fixtures
   known palette colours), representing a pre-rotated grid ready for rendering.
 - `HEXAHUE_PALETTE_MAP` — map of colour name → expected RGB tuple and hex string,
   covering all colours in the Hexahue palette.
-- `EXPECTED_PNG_DIMENSIONS` — map of size option → `{ casePixels, headerRows }` for
-  computing expected output dimensions.
+- `EXPECTED_PNG_DIMENSIONS` — map of size option → `{ casePixels }` for computing
+  expected output dimensions.
+
+---
+
+## Design note: no visual header row (2026-08-14)
+
+The encoded grid is composed of the pre-processed message plus random padding only
+— no metadata header is rendered anywhere in the image, and none is planned as part
+of V1. Earlier designs considered a visual header row for the message length
+(FEAT-008's byte-level `encodeHeader`/`decodeHeader`, then a digit-prefix variant),
+but both were rejected: a header row sitting outside the rotation step leaks the
+message length in the clear (the Hexahue alphabet is public, so anyone can read an
+unrotated header without the key); a header prefixed into the rotated message
+stream still leaks a known-plaintext-at-fixed-position weakness (anyone familiar
+with the tool's format knows the first N decoded symbols are always digits,
+regardless of the specific key), giving a cheap parameter-guessing oracle either
+way. `FEAT-008`'s `encodeHeader`/`decodeHeader` remain in the codebase, tested but
+currently unused by the real pipeline — a future evolution may revisit
+message-length metadata (e.g. a properly key-dependent encoding, or decode-time
+boundary detection via symbol validity), but that is out of scope for V1.

--- a/docs/tests/renderer.md
+++ b/docs/tests/renderer.md
@@ -118,8 +118,8 @@ The following shared fixtures must be defined in `__fixtures__/renderer.fixtures
 
 ## Design note: no visual header row (2026-08-14)
 
-The encoded grid is composed of the pre-processed message plus random padding only
-— no metadata header is rendered anywhere in the image, and none is planned as part
+The encoded grid is composed of the pre-processed message plus random padding only.
+No metadata header is rendered anywhere in the image, and none is planned as part
 of V1. Earlier designs considered a visual header row for the message length
 (FEAT-008's byte-level `encodeHeader`/`decodeHeader`, then a digit-prefix variant),
 but both were rejected: a header row sitting outside the rotation step leaks the
@@ -129,6 +129,6 @@ stream still leaks a known-plaintext-at-fixed-position weakness (anyone familiar
 with the tool's format knows the first N decoded symbols are always digits,
 regardless of the specific key), giving a cheap parameter-guessing oracle either
 way. `FEAT-008`'s `encodeHeader`/`decodeHeader` remain in the codebase, tested but
-currently unused by the real pipeline — a future evolution may revisit
+currently unused by the real pipeline. A future evolution may revisit
 message-length metadata (e.g. a properly key-dependent encoding, or decode-time
 boundary detection via symbol validity), but that is out of scope for V1.

--- a/docs/tests/renderer.md
+++ b/docs/tests/renderer.md
@@ -111,7 +111,7 @@ The following shared fixtures must be defined in `__fixtures__/renderer.fixtures
   known palette colours), representing a pre-rotated grid ready for rendering.
 - `HEXAHUE_PALETTE_MAP` — map of colour name → expected RGB tuple and hex string,
   covering all colours in the Hexahue palette.
-- `EXPECTED_PNG_DIMENSIONS` — map of size option → `{ casePixels }` for computing
+- `EXPECTED_PNG_DIMENSIONS` - map of size option → `{ casePixels }` for computing
   expected output dimensions.
 
 ---


### PR DESCRIPTION
## Summary
- Implements `PngRenderer`, a Sharp-based renderer painting a `ColorGrid` to a PNG buffer at three fixed case sizes (small=8px, medium=16px, large=32px per case), using the exact Hexahue standard palette (9 colours).
- Adds a generic `Renderer<T>` interface and `CaseSize` type in `shared/types`, shared with the future SVG renderer (FEAT-010).
- Adds `renderer/palette.ts`: `HEXAHUE_COLOR_HEX`, `CASE_PIXELS`, `colorNameToRgb` (frozen at runtime, guards against prototype-pollution lookups).

## Security decision: no metadata header
Two visual "message length" header designs were proposed and rejected during planning:
1. A separate unrotated header row - rejected, leaks the message length in the clear (Hexahue alphabet is public).
2. Digits prefixed into the rotated message stream - rejected, still gives a key-independent known-plaintext-at-fixed-osition oracle for brute-forcing decode parameters.

Final design: the encoded grid is the pre-processed message plus random padding only, exactly as `buildGrid`/`RotationEngine` already produce it. `FEAT-008`'s `encodeHeader`/`decodeHeader` are not called anywhere in this pipeline (now dead code, kept for a possible future redesign). See `docs/tests/renderer.md`, "Design note: no visual header row" for the full rationale. FEAT-012 (decode) has an explicitly open question in `BACKLOG.md` about message-boundary detection without a header.

## Test plan
- [x] 264/264 backend tests pass (21 suites)
- [x] Full task-level review + one fix round per task (2 real defects caught: em dash in copied docs, and a `colorNameToRgb` prototype-lookup bug where `'constructor'`/`'toString'` bypassed the `RangeError` guard)
- [x] Independent final whole-branch review (opus): confirmed zero header-logic regressions across the whole diff, hand-verified pixel-offset arithmetic and `buildGrid` dimension formulas, decoded a live rendered PNG (0/384 pixel mismatches, crisp block boundaries, no antialiasing)
- [x] One final-review fix wave (BACKLOG.md status, plan committed, runtime `size` guard, frozen palette constants, comment corrections) + scoped re-review, all addressed
- [x] eslint clean on `src/renderer` and `src/shared/types`
