### PR TITLE
docs(readme): update V1 roadmap to reflect completed backend API

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -162,16 +162,16 @@ frontend/
 ### V1
 
 - ✅ Infra (NestJS, Vue.js, Docker Compose, Prisma)
-- 🔄 CI (GitHub Actions — pipeline de tests, synchronisation du backlog)
-- ⬜ Alphabet (interface VisualAlphabet + implémentation Hexahue)
-- ⬜ Cipher (pré-traitement, construction de grille, en-tête de métadonnées)
-- ⬜ Moteur de rotation
-- ⬜ Codec de clé (encodage / décodage / validation base36)
-- ⬜ Stratégies d'ordre de lecture (4 directions + mode alterné)
-- ⬜ Renderers (PNG + SVG)
-- ⬜ Endpoints API (encode, decode, key)
+- ✅ CI (GitHub Actions — pipeline de tests, synchronisation du backlog)
+- ✅ Alphabet (interface VisualAlphabet + implémentation Hexahue)
+- ✅ Cipher (pré-traitement, construction de grille, pas d'en-tête de métadonnées, choix délibéré anti-fuite)
+- ✅ Moteur de rotation
+- ✅ Codec de clé (encodage / décodage / validation base36)
+- ✅ Stratégies d'ordre de lecture (4 directions + mode alterné)
+- ✅ Renderers (PNG + SVG)
+- ✅ Endpoints API (encode, decode, key)
 - ⬜ Frontend (vue encodage, vue décodage, vue clé)
-- ⬜ Tests & couverture
+- 🔄 Tests & couverture (chaque feature livrée embarque déjà sa propre suite unitaire/e2e ; les items de suite de tests dédiée restent ouverts)
 
 ### V2
 

--- a/README.md
+++ b/README.md
@@ -161,16 +161,16 @@ frontend/
 ### V1
 
 - ✅ Infra (NestJS, Vue.js, Docker Compose, Prisma)
-- 🔄 CI (GitHub Actions — tests pipeline, backlog sync)
-- ⬜ Alphabet (VisualAlphabet interface + Hexahue implementation)
-- ⬜ Cipher (pre-processing, grid construction, metadata header)
-- ⬜ Rotation engine
-- ⬜ Key codec (base36 encode / decode / validate)
-- ⬜ Reading order strategies (4 directions + alternate)
-- ⬜ Renderers (PNG + SVG)
-- ⬜ API endpoints (encode, decode, key)
+- ✅ CI (GitHub Actions — tests pipeline, backlog sync)
+- ✅ Alphabet (VisualAlphabet interface + Hexahue implementation)
+- ✅ Cipher (pre-processing, grid construction, no metadata header by design, a deliberate anti-leakage choice)
+- ✅ Rotation engine
+- ✅ Key codec (base36 encode / decode / validate)
+- ✅ Reading order strategies (4 directions + alternate)
+- ✅ Renderers (PNG + SVG)
+- ✅ API endpoints (encode, decode, key)
 - ⬜ Frontend (encode view, decode view, key view)
-- ⬜ Tests & coverage
+- 🔄 Tests & coverage (every shipped feature carries its own unit/e2e suite; dedicated backend/frontend test-suite items still open)
 
 ### V2
 


### PR DESCRIPTION
## Summary
- Marks Infra, CI, Alphabet, Cipher, Rotation, Key codec, Reading order, Renderers, and API endpoints as done in both README.md and README.fr.md
- Notes Tests & coverage as in-progress (every shipped feature ships its own suite; dedicated TEST-001/002/003 items still open)
