### PR TITLE
fix(prisma): force CommonJS output for the generated Prisma client

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,6 +1,7 @@
 generator client {
-  provider = "prisma-client"
-  output   = "../generated/prisma"
+  provider     = "prisma-client"
+  output       = "../generated/prisma"
+  moduleFormat = "cjs"
 }
 
 datasource db {


### PR DESCRIPTION
The `prisma-client` generator emits `import.meta.url` by default, which TypeScript compiles to CommonJS output since backend/package.json has no "type": "module". The mixed exports.foo= / import.meta.url file cannot be resolved by Node's module loader, crashing every real boot (`nest start`, `nest start --watch`, built dist/src/main.js) with `ReferenceError: exports is not defined` at dist/generated/prisma/client.js:38.

Invisible to the test suite because every spec/e2e file mocks PrismaService.
Fix: add `moduleFormat = "cjs"` to the generator client block in backend/prisma/schema.prisma, forcing require()-based output.

Verified reproducible identically on Node 22.23.0 and Node 23.1.0 (ruling out a Node-version cause), and verified fixed on both after the change.

Modified files:
- backend/prisma/schema.prisma — added moduleFormat = "cjs" to the generator client block
