### PR TITLE
feat(frontend): implement the decode view (FEAT-015)

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -170,7 +170,7 @@ frontend/
 - ✅ Stratégies d'ordre de lecture (4 directions + mode alterné)
 - ✅ Renderers (PNG + SVG)
 - ✅ Endpoints API (encode, decode, key)
-- 🔄 Frontend (vue encodage terminée ; vue décodage, vue clé restantes)
+- 🔄 Frontend (vue encodage, vue décodage terminées ; vue clé restante)
 - 🔄 Tests & couverture (chaque feature livrée embarque déjà sa propre suite unitaire/e2e ; les items de suite de tests dédiée restent ouverts)
 
 ### V2

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ frontend/
 - ✅ Reading order strategies (4 directions + alternate)
 - ✅ Renderers (PNG + SVG)
 - ✅ API endpoints (encode, decode, key)
-- 🔄 Frontend (encode view done; decode view, key view still open)
+- 🔄 Frontend (encode view, decode view done; key view still open)
 - 🔄 Tests & coverage (every shipped feature carries its own unit/e2e suite; dedicated backend/frontend test-suite items still open)
 
 ### V2

--- a/docs/superpowers/plans/2026-08-18-feat-015-decode-view.md
+++ b/docs/superpowers/plans/2026-08-18-feat-015-decode-view.md
@@ -1,0 +1,1031 @@
+# FEAT-015 Decode View Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the frontend's second view (`/decode`): the user uploads a PNG or SVG cryptogram file (click-to-browse or drag-and-drop), enters the HR key and the cryptogram's size, and sees the decoded plaintext message.
+
+**Architecture:** Reuses all of FEAT-014's shared infrastructure unchanged (`vue-router`'s existing `/decode` route, `src/api/client.ts`, the Pinia-store-per-view pattern, `isValidKeyFormat`). Adds one new Pinia store (`useDecodeStore`), a file-upload component (`DecodeUploadArea.vue`, native HTML5 drag-and-drop, no library), a params form (`DecodeParamsForm.vue`), and the routed view (`DecodeView.vue`) - no new shared infrastructure.
+
+**Tech Stack:** Vue 3.5, TypeScript strict, Pinia 3, `vue-i18n` 9, Vitest 3 + `@vue/test-utils` 2.4 + jsdom (all already configured by FEAT-014).
+
+**Spec:** `docs/superpowers/specs/2026-08-18-feat-015-decode-view-design.md`
+
+**Test contract:** `docs/tests/frontend.md` section 3 ("Decode view") and section 4 ("Decode store") - Task 4's integration spec must cover every bullet listed there.
+
+## Global Constraints
+
+- Every user-visible string goes through a `vue-i18n` key in `src/locales/en.json`, under a `decode.*` namespace (`decode.upload.*`, `decode.form.*`, `decode.result.*`) - no hardcoded literal text in any template.
+- No CSS framework. Plain scoped `<style>` blocks, functional and minimal.
+- Test bodies never contain a bare `for`/`while`/`if`. Use `it.each` for parameterized cases.
+- `src/api/client.ts` is the only module allowed to call `fetch` directly. `useDecodeStore` calls `postJson`; its own tests mock `'../api/client'`, not `fetch`.
+- File format is detected by extension (`.png`/`.svg`, case-insensitive), never by MIME type.
+- `size` is a manual `small`/`medium`/`large` selector defaulting to `'medium'` - no auto-detection.
+- Drag-and-drop uses native HTML5 events (`dragover`/`dragleave`/`drop`) - no new dependency.
+- Backend request/response shapes are copied verbatim from `backend/src/api/dto/decode-request.dto.ts` (`cryptogram: string`, `format: 'png'|'svg'`, `key: string`, `size: 'small'|'medium'|'large'`, all required) and `backend/src/api/decode.service.ts`'s `DecodeResult` (`{ message: string }`).
+
+---
+
+### Task 1: Decode Pinia store and shared fixtures
+
+**Files:**
+- Modify: `frontend/src/__fixtures__/frontend.fixtures.ts`
+- Create: `frontend/src/stores/decode.ts`
+- Create: `frontend/src/stores/decode.spec.ts`
+
+**Interfaces:**
+- Consumes: `postJson`/`ApiError` from `src/api/client.ts` (unchanged from FEAT-014 - `postJson<TResponse>(path, body): Promise<TResponse>`, `ApiError` with `message: string`, `code: 'http' | 'network'`, `status?: number`).
+- Produces: `useDecodeStore` Pinia store - state fields `file: File | null`, `keyInput: string`, `size: 'small' | 'medium' | 'large'`, `status: 'idle' | 'loading' | 'success' | 'error'`, `result: string | null`, `errorMessage: string | null`, `errorCode: 'network' | 'unknown' | null`; actions `submit(): Promise<void>` and `reset(): void`. Tasks 2-4 consume this store via `useDecodeStore()`. `MOCK_DECODE_RESPONSE`, `MOCK_PNG_FILE`, `MOCK_SVG_FILE` exported from `src/__fixtures__/frontend.fixtures.ts` (Task 2's and Task 4's tests consume these); `TINY_PNG_BASE64` and `SVG_CRYPTOGRAM_CONTENT` also exported from the same file (this task's own test consumes them, to assert the exact base64/text round-trip without duplicating the literal).
+
+- [ ] **Step 1: Extend the shared fixtures file**
+
+`frontend/src/__fixtures__/frontend.fixtures.ts` currently has a private (non-exported) `const TINY_PNG_BASE64 = '...'` used only by `MOCK_ENCODE_RESPONSE`. Change its declaration from `const TINY_PNG_BASE64 =` to `export const TINY_PNG_BASE64 =` (widen visibility only - the value and every existing use stay exactly as they are).
+
+Then append these new exports at the end of the file:
+
+```typescript
+function base64ToBytes(base64: string): Uint8Array {
+  return Uint8Array.from(atob(base64), (char) => char.charCodeAt(0))
+}
+
+export const MOCK_PNG_FILE = new File([base64ToBytes(TINY_PNG_BASE64)], 'cryptogram.png', {
+  type: 'image/png',
+})
+
+export const SVG_CRYPTOGRAM_CONTENT =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"><rect width="10" height="10" fill="#000"/></svg>'
+
+export const MOCK_SVG_FILE = new File([SVG_CRYPTOGRAM_CONTENT], 'cryptogram.svg', {
+  type: 'image/svg+xml',
+})
+
+export const MOCK_DECODE_RESPONSE = {
+  message: 'HELLO WORLD',
+}
+```
+
+The full file's exports after this step: `TINY_PNG_BASE64`, `MOCK_ENCODE_RESPONSE`, `MOCK_ENCODE_RESPONSE_WITH_WARNINGS`, `MALFORMED_KEY` (all pre-existing, `TINY_PNG_BASE64` newly exported), plus the five new ones above.
+
+- [ ] **Step 2: Write the failing store tests**
+
+Create `frontend/src/stores/decode.spec.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useDecodeStore } from './decode'
+import { ApiError } from '../api/client'
+import {
+  MOCK_DECODE_RESPONSE,
+  MOCK_PNG_FILE,
+  MOCK_SVG_FILE,
+  TINY_PNG_BASE64,
+  SVG_CRYPTOGRAM_CONTENT,
+} from '../__fixtures__/frontend.fixtures'
+
+vi.mock('../api/client', async () => {
+  const actual = await vi.importActual<typeof import('../api/client')>('../api/client')
+  return { ...actual, postJson: vi.fn() }
+})
+
+import { postJson } from '../api/client'
+
+describe('useDecodeStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.mocked(postJson).mockReset()
+  })
+
+  it('initialises with default field values and no result or error', () => {
+    const store = useDecodeStore()
+
+    expect(store.file).toBeNull()
+    expect(store.keyInput).toBe('')
+    expect(store.size).toBe('medium')
+    expect(store.status).toBe('idle')
+    expect(store.result).toBeNull()
+    expect(store.errorMessage).toBeNull()
+    expect(store.errorCode).toBeNull()
+  })
+
+  it('builds the PNG payload with a base64-encoded cryptogram when submitting', async () => {
+    vi.mocked(postJson).mockResolvedValue(MOCK_DECODE_RESPONSE)
+    const store = useDecodeStore()
+    store.file = MOCK_PNG_FILE
+    store.keyInput = 'HR1·a1b2'
+
+    await store.submit()
+
+    expect(postJson).toHaveBeenCalledWith('/decode', {
+      cryptogram: TINY_PNG_BASE64,
+      format: 'png',
+      key: 'HR1·a1b2',
+      size: 'medium',
+    })
+  })
+
+  it('builds the SVG payload with the raw text content when submitting', async () => {
+    vi.mocked(postJson).mockResolvedValue(MOCK_DECODE_RESPONSE)
+    const store = useDecodeStore()
+    store.file = MOCK_SVG_FILE
+    store.keyInput = 'HR1·a1b2'
+
+    await store.submit()
+
+    expect(postJson).toHaveBeenCalledWith('/decode', {
+      cryptogram: SVG_CRYPTOGRAM_CONTENT,
+      format: 'svg',
+      key: 'HR1·a1b2',
+      size: 'medium',
+    })
+  })
+
+  it('sets status to loading while the request is in flight', () => {
+    vi.mocked(postJson).mockReturnValue(new Promise(() => {}))
+    const store = useDecodeStore()
+    store.file = MOCK_PNG_FILE
+    store.keyInput = 'HR1·a1b2'
+
+    void store.submit()
+
+    expect(store.status).toBe('loading')
+  })
+
+  it('stores the result and sets status to success on a successful submit', async () => {
+    vi.mocked(postJson).mockResolvedValue(MOCK_DECODE_RESPONSE)
+    const store = useDecodeStore()
+    store.file = MOCK_PNG_FILE
+    store.keyInput = 'HR1·a1b2'
+
+    await store.submit()
+
+    expect(store.result).toBe(MOCK_DECODE_RESPONSE.message)
+    expect(store.status).toBe('success')
+    expect(store.errorMessage).toBeNull()
+  })
+
+  it('stores the error message and sets status to error on a failed submit', async () => {
+    vi.mocked(postJson).mockRejectedValue(new ApiError('invalid key', 'http', 400))
+    const store = useDecodeStore()
+    store.file = MOCK_PNG_FILE
+    store.keyInput = 'HR1·a1b2'
+
+    await store.submit()
+
+    expect(store.status).toBe('error')
+    expect(store.errorMessage).toBe('invalid key')
+    expect(store.result).toBeNull()
+  })
+
+  it('sets errorCode to network and leaves errorMessage null on a network failure', async () => {
+    vi.mocked(postJson).mockRejectedValue(new ApiError('Network error: unable to reach the server', 'network'))
+    const store = useDecodeStore()
+    store.file = MOCK_PNG_FILE
+    store.keyInput = 'HR1·a1b2'
+
+    await store.submit()
+
+    expect(store.status).toBe('error')
+    expect(store.errorCode).toBe('network')
+    expect(store.errorMessage).toBeNull()
+  })
+
+  it('clears the previous result when a new submit is dispatched', async () => {
+    vi.mocked(postJson).mockResolvedValue(MOCK_DECODE_RESPONSE)
+    const store = useDecodeStore()
+    store.file = MOCK_PNG_FILE
+    store.keyInput = 'HR1·a1b2'
+    await store.submit()
+    expect(store.result).toBe(MOCK_DECODE_RESPONSE.message)
+
+    vi.mocked(postJson).mockReturnValue(new Promise(() => {}))
+    void store.submit()
+
+    expect(store.result).toBeNull()
+  })
+
+  it('restores default state when reset is called', async () => {
+    vi.mocked(postJson).mockResolvedValue(MOCK_DECODE_RESPONSE)
+    const store = useDecodeStore()
+    store.file = MOCK_PNG_FILE
+    store.keyInput = 'HR1·a1b2'
+    await store.submit()
+
+    store.reset()
+
+    expect(store.file).toBeNull()
+    expect(store.keyInput).toBe('')
+    expect(store.status).toBe('idle')
+    expect(store.result).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 3: Run the tests and confirm they fail**
+
+Run: `npm test -- src/stores/decode.spec.ts`
+Expected: FAIL - `./decode` does not exist yet.
+
+- [ ] **Step 4: Implement the store**
+
+Create `frontend/src/stores/decode.ts`:
+
+```typescript
+import { defineStore } from 'pinia'
+import { postJson, ApiError } from '../api/client'
+
+export type DecodeStatus = 'idle' | 'loading' | 'success' | 'error'
+export type CryptogramSize = 'small' | 'medium' | 'large'
+
+interface DecodeState {
+  file: File | null
+  keyInput: string
+  size: CryptogramSize
+  status: DecodeStatus
+  result: string | null
+  errorMessage: string | null
+  errorCode: 'network' | 'unknown' | null
+}
+
+function initialState(): DecodeState {
+  return {
+    file: null,
+    keyInput: '',
+    size: 'medium',
+    status: 'idle',
+    result: null,
+    errorMessage: null,
+    errorCode: null,
+  }
+}
+
+function detectFormat(file: File): 'png' | 'svg' {
+  return /\.svg$/i.test(file.name) ? 'svg' : 'png'
+}
+
+function readFileAsBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => {
+      const dataUrl = reader.result as string
+      resolve(dataUrl.slice(dataUrl.indexOf(',') + 1))
+    }
+    reader.onerror = () => reject(reader.error)
+    reader.readAsDataURL(file)
+  })
+}
+
+function readFileAsText(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(reader.result as string)
+    reader.onerror = () => reject(reader.error)
+    reader.readAsText(file)
+  })
+}
+
+export const useDecodeStore = defineStore('decode', {
+  state: initialState,
+  actions: {
+    async submit(): Promise<void> {
+      const file = this.file
+      if (!file) return
+
+      this.status = 'loading'
+      this.result = null
+      this.errorMessage = null
+      this.errorCode = null
+
+      const format = detectFormat(file)
+      const cryptogram = format === 'png' ? await readFileAsBase64(file) : await readFileAsText(file)
+
+      try {
+        const response = await postJson<{ message: string }>('/decode', {
+          cryptogram,
+          format,
+          key: this.keyInput,
+          size: this.size,
+        })
+        this.result = response.message
+        this.status = 'success'
+      } catch (err) {
+        if (err instanceof ApiError && err.code === 'http') {
+          this.errorMessage = err.message
+        } else if (err instanceof ApiError && err.code === 'network') {
+          this.errorMessage = null
+          this.errorCode = 'network'
+        } else {
+          this.errorMessage = null
+          this.errorCode = 'unknown'
+        }
+        this.status = 'error'
+      }
+    },
+    reset(): void {
+      Object.assign(this, initialState())
+    },
+  },
+})
+```
+
+- [ ] **Step 5: Run the tests and confirm they pass**
+
+Run: `npm test -- src/stores/decode.spec.ts`
+Expected: PASS, all 8 tests green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/__fixtures__/frontend.fixtures.ts frontend/src/stores/decode.ts frontend/src/stores/decode.spec.ts
+git commit -m "feat(frontend): add decode Pinia store and decode-related test fixtures"
+```
+
+---
+
+### Task 2: File upload area (drag-and-drop + click-to-browse)
+
+**Files:**
+- Create: `frontend/src/components/DecodeUploadArea.vue`
+- Create: `frontend/src/components/DecodeUploadArea.spec.ts`
+- Modify: `frontend/src/locales/en.json`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks (a leaf component - only reads the fixtures in its own test).
+- Produces: `DecodeUploadArea.vue`, a `v-model`-compatible component: prop `modelValue: File | null`, event `update:modelValue` with the selected `File`. Task 3's `DecodeParamsForm.vue` consumes this as `<DecodeUploadArea v-model="store.file" />`.
+
+- [ ] **Step 1: Add the component's i18n keys**
+
+Add a `decode` top-level key to `frontend/src/locales/en.json`, as a sibling of the existing `nav`/`encode`/`errors` keys:
+
+```json
+"decode": {
+  "upload": {
+    "browse": "Choose a file",
+    "dropHint": "or drag and drop a PNG or SVG file here",
+    "invalidExtension": "Only .png and .svg files are supported."
+  }
+}
+```
+
+Do not touch `nav`, `encode`, or `errors` - only add this new `decode` key alongside them.
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `frontend/src/components/DecodeUploadArea.spec.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import DecodeUploadArea from './DecodeUploadArea.vue'
+import en from '../locales/en.json'
+import { MOCK_PNG_FILE, MOCK_SVG_FILE } from '../__fixtures__/frontend.fixtures'
+
+const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
+
+function mountArea(modelValue: File | null = null) {
+  return mount(DecodeUploadArea, {
+    props: { modelValue },
+    global: { plugins: [i18n] },
+  })
+}
+
+describe('DecodeUploadArea', () => {
+  it.each([
+    ['PNG', MOCK_PNG_FILE],
+    ['SVG', MOCK_SVG_FILE],
+  ])('emits the selected %s file when chosen via the file input', async (_label, file) => {
+    const wrapper = mountArea()
+    const input = wrapper.find('input[type="file"]')
+    Object.defineProperty(input.element, 'files', { value: [file], writable: false })
+
+    await input.trigger('change')
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([[file]])
+  })
+
+  it('shows an inline error and does not emit for an unsupported extension', async () => {
+    const invalidFile = new File(['not a cryptogram'], 'notes.txt', { type: 'text/plain' })
+    const wrapper = mountArea()
+    const input = wrapper.find('input[type="file"]')
+    Object.defineProperty(input.element, 'files', { value: [invalidFile], writable: false })
+
+    await input.trigger('change')
+
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+    expect(wrapper.find('.decode-upload-area__error').exists()).toBe(true)
+  })
+
+  it('emits the dropped file when a valid file is dropped', async () => {
+    const wrapper = mountArea()
+
+    await wrapper.find('.decode-upload-area').trigger('drop', {
+      dataTransfer: { files: [MOCK_PNG_FILE] },
+    })
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([[MOCK_PNG_FILE]])
+  })
+
+  it('displays the filename once a file is selected', () => {
+    const wrapper = mountArea(MOCK_PNG_FILE)
+    expect(wrapper.text()).toContain(MOCK_PNG_FILE.name)
+  })
+
+  it('does not display a filename when no file is selected', () => {
+    const wrapper = mountArea(null)
+    expect(wrapper.text()).not.toContain(MOCK_PNG_FILE.name)
+  })
+})
+```
+
+- [ ] **Step 3: Run the tests and confirm they fail**
+
+Run: `npm test -- src/components/DecodeUploadArea.spec.ts`
+Expected: FAIL - `DecodeUploadArea.vue` does not exist yet.
+
+- [ ] **Step 4: Implement the component**
+
+Create `frontend/src/components/DecodeUploadArea.vue`:
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const props = defineProps<{
+  modelValue: File | null
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: File]
+}>()
+
+const { t } = useI18n()
+
+const isDragging = ref(false)
+const formatError = ref<string | null>(null)
+const fileInput = ref<HTMLInputElement | null>(null)
+
+function isValidExtension(file: File): boolean {
+  return /\.(png|svg)$/i.test(file.name)
+}
+
+function selectFile(file: File): void {
+  if (!isValidExtension(file)) {
+    formatError.value = t('decode.upload.invalidExtension')
+    return
+  }
+  formatError.value = null
+  emit('update:modelValue', file)
+}
+
+function handleInputChange(event: Event): void {
+  const target = event.target as HTMLInputElement
+  const file = target.files?.[0]
+  if (file) selectFile(file)
+}
+
+function handleDrop(event: DragEvent): void {
+  isDragging.value = false
+  const file = event.dataTransfer?.files?.[0]
+  if (file) selectFile(file)
+}
+
+function handleDragOver(): void {
+  isDragging.value = true
+}
+
+function handleDragLeave(): void {
+  isDragging.value = false
+}
+
+function triggerBrowse(): void {
+  fileInput.value?.click()
+}
+</script>
+
+<template>
+  <div
+    class="decode-upload-area"
+    :class="{ 'decode-upload-area--dragging': isDragging }"
+    @dragover.prevent="handleDragOver"
+    @dragleave.prevent="handleDragLeave"
+    @drop.prevent="handleDrop"
+  >
+    <input
+      ref="fileInput"
+      type="file"
+      accept=".png,.svg"
+      class="decode-upload-area__input"
+      @change="handleInputChange"
+    >
+    <button type="button" @click="triggerBrowse">{{ t('decode.upload.browse') }}</button>
+    <p>{{ t('decode.upload.dropHint') }}</p>
+    <p v-if="modelValue" class="decode-upload-area__filename">{{ modelValue.name }}</p>
+    <p v-if="formatError" class="decode-upload-area__error" role="alert">{{ formatError }}</p>
+  </div>
+</template>
+
+<style scoped>
+.decode-upload-area {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px;
+  border: 2px dashed var(--border);
+  border-radius: 4px;
+}
+
+.decode-upload-area--dragging {
+  border-color: var(--accent);
+}
+
+.decode-upload-area__input {
+  display: none;
+}
+
+.decode-upload-area__error {
+  color: #c0392b;
+}
+</style>
+```
+
+- [ ] **Step 5: Run the tests and confirm they pass**
+
+Run: `npm test -- src/components/DecodeUploadArea.spec.ts`
+Expected: PASS, all 6 test cases green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/DecodeUploadArea.vue frontend/src/components/DecodeUploadArea.spec.ts frontend/src/locales/en.json
+git commit -m "feat(frontend): add file upload area with drag-and-drop for the decode view"
+```
+
+---
+
+### Task 3: Decode parameters form
+
+**Files:**
+- Create: `frontend/src/components/DecodeParamsForm.vue`
+- Modify: `frontend/src/locales/en.json`
+
+**Interfaces:**
+- Consumes: `useDecodeStore` (Task 1), `DecodeUploadArea.vue` (Task 2), `isValidKeyFormat` from `src/utils/key-format.ts` (unchanged from FEAT-014 - `(key: string): boolean`).
+- Produces: `DecodeParamsForm.vue`, a component with no props (reads/writes `useDecodeStore()` directly). Task 4's `DecodeView.vue` renders it as `<DecodeParamsForm />`. No dedicated spec file - its behavior is verified by Task 4's `DecodeView.spec.ts` integration test, same reasoning as FEAT-014's `EncodeParamsForm`.
+
+- [ ] **Step 1: Add the form's i18n keys**
+
+Extend the `decode` key in `frontend/src/locales/en.json` (added in Task 2) to its full shape - add `form` as a sibling of the existing `upload` key:
+
+```json
+"decode": {
+  "upload": {
+    "browse": "Choose a file",
+    "dropHint": "or drag and drop a PNG or SVG file here",
+    "invalidExtension": "Only .png and .svg files are supported."
+  },
+  "form": {
+    "upload": {
+      "label": "Cryptogram file"
+    },
+    "key": {
+      "label": "HexaRot key",
+      "placeholder": "HR1·xxxx",
+      "formatError": "This does not look like a valid HexaRot key."
+    },
+    "size": {
+      "label": "Cryptogram size",
+      "small": "Small",
+      "medium": "Medium",
+      "large": "Large"
+    },
+    "submit": {
+      "label": "Decode",
+      "loading": "Decoding..."
+    }
+  }
+}
+```
+
+(`upload` at the top of `decode` stays as Task 2 added it - only `form` is new here.)
+
+- [ ] **Step 2: Implement the component**
+
+Create `frontend/src/components/DecodeParamsForm.vue`:
+
+```vue
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useDecodeStore } from '../stores/decode'
+import { isValidKeyFormat } from '../utils/key-format'
+import DecodeUploadArea from './DecodeUploadArea.vue'
+
+const store = useDecodeStore()
+const { t } = useI18n()
+
+const keyFormatError = computed(() => {
+  if (store.keyInput.length === 0) return null
+  return isValidKeyFormat(store.keyInput) ? null : t('decode.form.key.formatError')
+})
+
+const canSubmit = computed(() => {
+  if (store.status === 'loading') return false
+  if (store.file === null) return false
+  return store.keyInput.length > 0 && keyFormatError.value === null
+})
+
+function handleSubmit(): void {
+  if (!canSubmit.value) return
+  void store.submit()
+}
+</script>
+
+<template>
+  <form class="decode-params-form" @submit.prevent="handleSubmit">
+    <div class="decode-params-form__field">
+      {{ t('decode.form.upload.label') }}
+      <DecodeUploadArea v-model="store.file" />
+    </div>
+
+    <label class="decode-params-form__field">
+      {{ t('decode.form.key.label') }}
+      <input v-model="store.keyInput" type="text" :placeholder="t('decode.form.key.placeholder')">
+    </label>
+    <p v-if="keyFormatError" class="decode-params-form__error" role="alert">{{ keyFormatError }}</p>
+
+    <label class="decode-params-form__field">
+      {{ t('decode.form.size.label') }}
+      <select v-model="store.size" name="size">
+        <option value="small">{{ t('decode.form.size.small') }}</option>
+        <option value="medium">{{ t('decode.form.size.medium') }}</option>
+        <option value="large">{{ t('decode.form.size.large') }}</option>
+      </select>
+    </label>
+
+    <button type="submit" :disabled="!canSubmit">
+      {{ store.status === 'loading' ? t('decode.form.submit.loading') : t('decode.form.submit.label') }}
+    </button>
+  </form>
+</template>
+
+<style scoped>
+.decode-params-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 480px;
+}
+
+.decode-params-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.decode-params-form__error {
+  color: #c0392b;
+}
+</style>
+```
+
+- [ ] **Step 3: Verify the build is clean**
+
+Run from `frontend/`: `npm run build`
+Expected: exits 0. (No dedicated spec for this task - behavioral verification happens in Task 4.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/DecodeParamsForm.vue frontend/src/locales/en.json
+git commit -m "feat(frontend): add decode parameters form"
+```
+
+---
+
+### Task 4: Decode view assembly, integration tests, and roadmap update
+
+**Files:**
+- Create: `frontend/src/views/DecodeView.vue` (overwrites the 3-line stub)
+- Create: `frontend/src/views/DecodeView.spec.ts`
+- Modify: `frontend/src/locales/en.json`
+- Modify: `README.md`
+- Modify: `README.fr.md`
+
+**Interfaces:**
+- Consumes: `useDecodeStore` (Task 1), `DecodeParamsForm.vue` (Task 3), `MOCK_DECODE_RESPONSE`/`MOCK_PNG_FILE`/`MOCK_SVG_FILE` (Task 1), `postJson`/`ApiError` (mocked in tests, from `src/api/client.ts`).
+- Produces: the routed `/decode` page. Nothing downstream in this plan consumes this task's output - it is the plan's final deliverable.
+
+- [ ] **Step 1: Add the view's remaining i18n keys**
+
+Add `title` and `result` as siblings of `upload`/`form` inside the existing `decode` object in `frontend/src/locales/en.json`:
+
+```json
+"decode": {
+  "title": "Decode a cryptogram",
+  "upload": { ... },
+  "form": { ... },
+  "result": {
+    "label": "Decoded message"
+  }
+}
+```
+
+(Keep the existing `upload` and `form` objects from Tasks 2/3 unchanged - only add `title` and `result` at the same nesting level.)
+
+- [ ] **Step 2: Write the failing integration tests**
+
+Create `frontend/src/views/DecodeView.spec.ts`. This covers every bullet in `docs/tests/frontend.md` section 3 (`DecodeView`) and section 4 (`useDecodeStore`, already covered by Task 1's own store spec but exercised again here end-to-end):
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createI18n } from 'vue-i18n'
+import DecodeView from './DecodeView.vue'
+import en from '../locales/en.json'
+import {
+  MOCK_DECODE_RESPONSE,
+  MOCK_PNG_FILE,
+  MOCK_SVG_FILE,
+  MALFORMED_KEY,
+} from '../__fixtures__/frontend.fixtures'
+import { ApiError } from '../api/client'
+
+vi.mock('../api/client', async () => {
+  const actual = await vi.importActual<typeof import('../api/client')>('../api/client')
+  return { ...actual, postJson: vi.fn() }
+})
+
+import { postJson } from '../api/client'
+
+function mountView() {
+  const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
+  return mount(DecodeView, {
+    global: { plugins: [createPinia(), i18n] },
+  })
+}
+
+async function selectFile(wrapper: ReturnType<typeof mountView>, file: File) {
+  const input = wrapper.find('input[type="file"]')
+  Object.defineProperty(input.element, 'files', { value: [file], writable: false })
+  await input.trigger('change')
+}
+
+describe('DecodeView', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.mocked(postJson).mockReset()
+  })
+
+  describe('initial state', () => {
+    it('renders the file upload area', () => {
+      const wrapper = mountView()
+      expect(wrapper.find('input[type="file"]').exists()).toBe(true)
+    })
+
+    it('renders the HR key input field', () => {
+      const wrapper = mountView()
+      expect(wrapper.find('input[type="text"]').exists()).toBe(true)
+    })
+
+    it('renders the submit button', () => {
+      const wrapper = mountView()
+      expect(wrapper.find('button[type="submit"]').exists()).toBe(true)
+    })
+
+    it('does not display a decoded message on initial render', () => {
+      const wrapper = mountView()
+      expect(wrapper.find('.decode-view__result').exists()).toBe(false)
+    })
+  })
+
+  describe('file upload', () => {
+    it('accepts a PNG file via the file input', async () => {
+      const wrapper = mountView()
+      await selectFile(wrapper, MOCK_PNG_FILE)
+      expect(wrapper.text()).toContain(MOCK_PNG_FILE.name)
+    })
+
+    it('accepts an SVG file via the file input', async () => {
+      const wrapper = mountView()
+      await selectFile(wrapper, MOCK_SVG_FILE)
+      expect(wrapper.text()).toContain(MOCK_SVG_FILE.name)
+    })
+
+    it('rejects files with unsupported extensions and shows an error', async () => {
+      const wrapper = mountView()
+      const invalidFile = new File(['x'], 'notes.txt', { type: 'text/plain' })
+      await selectFile(wrapper, invalidFile)
+      expect(wrapper.find('.decode-upload-area__error').exists()).toBe(true)
+    })
+
+    it('displays the uploaded filename after selection', async () => {
+      const wrapper = mountView()
+      await selectFile(wrapper, MOCK_PNG_FILE)
+      expect(wrapper.text()).toContain('cryptogram.png')
+    })
+
+    it('supports drag-and-drop (dragover and drop events are handled)', async () => {
+      const wrapper = mountView()
+      const dropZone = wrapper.find('.decode-upload-area')
+      await dropZone.trigger('dragover')
+      await dropZone.trigger('drop', { dataTransfer: { files: [MOCK_PNG_FILE] } })
+      expect(wrapper.text()).toContain(MOCK_PNG_FILE.name)
+    })
+  })
+
+  describe('form submission', () => {
+    it('calls the decode API with the file content and key when submitted', async () => {
+      vi.mocked(postJson).mockResolvedValue(MOCK_DECODE_RESPONSE)
+      const wrapper = mountView()
+      await selectFile(wrapper, MOCK_PNG_FILE)
+      await wrapper.find('input[type="text"]').setValue('HR1·a1b2')
+
+      await wrapper.find('form').trigger('submit')
+      await flushPromises()
+
+      expect(postJson).toHaveBeenCalledWith(
+        '/decode',
+        expect.objectContaining({ format: 'png', key: 'HR1·a1b2', size: 'medium' }),
+      )
+    })
+
+    it('shows a loading indicator while the API call is in progress', async () => {
+      vi.mocked(postJson).mockReturnValue(new Promise(() => {}))
+      const wrapper = mountView()
+      await selectFile(wrapper, MOCK_PNG_FILE)
+      await wrapper.find('input[type="text"]').setValue('HR1·a1b2')
+
+      await wrapper.find('form').trigger('submit')
+      await flushPromises()
+
+      expect(wrapper.find('button[type="submit"]').text()).toBe('Decoding...')
+    })
+  })
+
+  describe('successful response', () => {
+    it('displays the decoded message after a successful decode response', async () => {
+      vi.mocked(postJson).mockResolvedValue(MOCK_DECODE_RESPONSE)
+      const wrapper = mountView()
+      await selectFile(wrapper, MOCK_PNG_FILE)
+      await wrapper.find('input[type="text"]').setValue('HR1·a1b2')
+
+      await wrapper.find('form').trigger('submit')
+      await flushPromises()
+
+      expect(wrapper.find('.decode-view__result').text()).toContain(MOCK_DECODE_RESPONSE.message)
+    })
+  })
+
+  describe('error handling', () => {
+    it('displays an error when the key format is invalid (client-side, before the API call)', async () => {
+      const wrapper = mountView()
+      await selectFile(wrapper, MOCK_PNG_FILE)
+      await wrapper.find('input[type="text"]').setValue(MALFORMED_KEY)
+
+      expect(wrapper.find('.decode-params-form__error').exists()).toBe(true)
+      expect(wrapper.find('button[type="submit"]').attributes('disabled')).toBeDefined()
+      expect(postJson).not.toHaveBeenCalled()
+    })
+
+    it('displays an error when the API call fails', async () => {
+      vi.mocked(postJson).mockRejectedValue(new ApiError('invalid key', 'http', 400))
+      const wrapper = mountView()
+      await selectFile(wrapper, MOCK_PNG_FILE)
+      await wrapper.find('input[type="text"]').setValue('HR1·a1b2')
+
+      await wrapper.find('form').trigger('submit')
+      await flushPromises()
+
+      expect(wrapper.text()).toContain('invalid key')
+    })
+
+    it('does not display a decoded message after an API error', async () => {
+      vi.mocked(postJson).mockRejectedValue(new ApiError('invalid key', 'http', 400))
+      const wrapper = mountView()
+      await selectFile(wrapper, MOCK_PNG_FILE)
+      await wrapper.find('input[type="text"]').setValue('HR1·a1b2')
+
+      await wrapper.find('form').trigger('submit')
+      await flushPromises()
+
+      expect(wrapper.find('.decode-view__result').exists()).toBe(false)
+    })
+  })
+
+  describe('i18n', () => {
+    it('renders no raw string literals - the submit button text comes from the locale file', () => {
+      const wrapper = mountView()
+      expect(wrapper.find('button[type="submit"]').text()).toBe(en.decode.form.submit.label)
+    })
+  })
+})
+```
+
+- [ ] **Step 3: Run the tests and confirm they fail**
+
+Run: `npm test -- src/views/DecodeView.spec.ts`
+Expected: FAIL - `DecodeView.vue` is still the 3-line stub (`<div>DecodeView</div>`), none of the selectors exist.
+
+- [ ] **Step 4: Implement the view**
+
+Replace the full contents of `frontend/src/views/DecodeView.vue`:
+
+```vue
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import { useDecodeStore } from '../stores/decode'
+import DecodeParamsForm from '../components/DecodeParamsForm.vue'
+
+const store = useDecodeStore()
+const { t } = useI18n()
+</script>
+
+<template>
+  <div class="decode-view">
+    <h1>{{ t('decode.title') }}</h1>
+    <DecodeParamsForm />
+    <p v-if="store.status === 'error'" class="decode-view__error" role="alert">
+      {{ store.errorMessage ?? t(`errors.${store.errorCode}`) }}
+    </p>
+    <p v-if="store.status === 'success' && store.result" class="decode-view__result">
+      <strong>{{ t('decode.result.label') }}:</strong> {{ store.result }}
+    </p>
+  </div>
+</template>
+
+<style scoped>
+.decode-view {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.decode-view__error {
+  color: #c0392b;
+}
+</style>
+```
+
+- [ ] **Step 5: Run the tests and confirm they pass**
+
+Run: `npm test -- src/views/DecodeView.spec.ts`
+Expected: PASS, all tests green.
+
+Then run the full frontend suite: `npm test`
+Expected: PASS - every spec file from Tasks 1-4 green together with FEAT-014's existing suite (no cross-test pollution from shared mocks/fixtures).
+
+- [ ] **Step 6: Update the README roadmap**
+
+In `README.md`, replace the line:
+
+```markdown
+- 🔄 Frontend (encode view done; decode view, key view still open)
+```
+
+with:
+
+```markdown
+- 🔄 Frontend (encode view, decode view done; key view still open)
+```
+
+In `README.fr.md`, replace the line:
+
+```markdown
+- 🔄 Frontend (vue encodage terminée ; vue décodage, vue clé restantes)
+```
+
+with:
+
+```markdown
+- 🔄 Frontend (vue encodage, vue décodage terminées ; vue clé restante)
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/views/DecodeView.vue frontend/src/views/DecodeView.spec.ts frontend/src/locales/en.json README.md README.fr.md
+git commit -m "feat(frontend): assemble the decode view and wire it into the router"
+```
+
+- [ ] **Step 8: Real functional check (not just the automated suite)**
+
+Per the project's standing rule that every feature producing a user-facing result gets a real, manual check in addition to its automated tests:
+
+1. Start the backend for real against a real database (a throwaway Postgres container, `prisma migrate deploy`, `prisma db seed`, then boot the backend - reuse the exact setup from FEAT-014's own verification).
+2. Start the frontend for real. Per FEAT-014's final review finding, prefer `docker-compose up` over a bare `npm run dev` if practical, since that is the project's documented deployment path and the one that actually exercises the Vite dev-proxy → backend-container route end to end.
+3. First, encode a real message via the `/encode` view (already shipped) to get a real PNG (or SVG) cryptogram, its key, and note the `size` used.
+4. Navigate to `/decode`. Upload the PNG (or SVG) via click-to-browse, enter the key from step 3, select the matching `size`, and submit. Confirm the real decoded message matches the original.
+5. Try dropping a file via drag-and-drop instead of click-to-browse, and confirm it works identically.
+6. Try an intentionally wrong key or wrong `size` and confirm a real error renders.
+7. Stop the frontend/backend/database when done, and clean up any container-written root-owned files per `project-docker-functional-test-root-files` if you ran Prisma commands inside a container.
+
+This step has no code artifact - it is a verification gate before considering FEAT-015 done, not a task with a commit.
+
+---
+
+## Post-plan notes (not tasks — for the controller running this plan)
+
+- The approved spec (`docs/superpowers/specs/2026-08-18-feat-015-decode-view-design.md`) currently sits as an untracked file in the main checkout. Per the established pattern (FEAT-012, FEAT-014), copy it into the FEAT-015 worktree and commit it there as the worktree's first commit, before dispatching Task 1 - then delete the stray copy from the main checkout. Fold this plan file into that same first commit.
+- `KeyView.vue` is untouched by this plan beyond nothing - it isn't referenced at all here. FEAT-016 is its own scope.

--- a/docs/superpowers/specs/2026-08-18-feat-015-decode-view-design.md
+++ b/docs/superpowers/specs/2026-08-18-feat-015-decode-view-design.md
@@ -1,0 +1,158 @@
+# FEAT-015 Decode View Design Spec
+
+**Status:** Approved by the user (2026-08-18), ready for writing-plans.
+
+**Backlog item:** FEAT-015, `status: ready`, `depends-on: FEAT-012` (done), `domain: frontend`, `complexity: M`.
+
+## Context
+
+FEAT-015 is the second frontend feature. Unlike FEAT-014 (which had to stand up
+routing, the HTTP client, and the Pinia-store-per-view pattern from a blank
+scaffold), this feature reuses all of that shared infrastructure as-is:
+`vue-router` already routes `/decode` to `DecodeView.vue` (currently a 3-line
+stub), `src/api/client.ts`'s `postJson`/`getJson`/`ApiError` need no changes,
+and `useDecodeStore` follows the exact shape established by `useEncodeStore`.
+`isValidKeyFormat` (`src/utils/key-format.ts`, built during FEAT-014) is reused
+verbatim for this view's own client-side key check.
+
+The backend endpoint this view consumes is complete: `POST /api/decode`
+(FEAT-012). Its request DTO (`backend/src/api/dto/decode-request.dto.ts`)
+requires all four fields - `cryptogram` (string), `format` (`'png'|'svg'`),
+`key` (string), `size` (`'small'|'medium'|'large'`) - and its service
+(`backend/src/api/decode.service.ts`) decodes `cryptogram` as
+`Buffer.from(dto.cryptogram, 'base64')` when `format === 'png'`, or as a raw
+SVG string when `format === 'svg'`. The response is `{ message: string }`.
+
+The user uploads a cryptogram file (PNG or SVG, via click-to-browse or
+drag-and-drop) and enters the HR key that was used to encode it, plus the
+`size` it was rendered at (required - `size` determines `casePixels` on the
+backend, and a mismatch fails with a dimensions error). The view displays the
+decoded plaintext.
+
+## Decision 1: `size` is a manual selector, not auto-detected
+
+`size` must exactly match the value used at encode time, or the backend
+rejects the request with a dimensions-mismatch error. **Decided:** a manual
+`small`/`medium`/`large` selector defaulting to `medium`, mirroring the
+encode view's own `size` field - the user adjusts it if decoding fails. An
+auto-detection approach (trying all three sizes until one parses) was
+considered and rejected: it adds real complexity (multiple sequential API
+calls, more store state to track which attempt is "current") for UX benefit
+that's marginal given there are only three values and a clear error message
+tells the user what went wrong.
+
+## Decision 2: native drag-and-drop, no library
+
+Unlike FEAT-014's rotation-sequence picker (where `vuedraggable` was worth
+its dependency cost for real reordering logic and touch support), a file
+drop zone is a much shallower interaction: a `dragover`/`drop` event pair
+toggling a visual state and reading `event.dataTransfer.files`. Native HTML5
+drag-and-drop handles this fully; no dependency earns its cost here.
+
+## Decision 3: file format detected by extension, not MIME type
+
+Matches the test contract's own wording ("rejects files with unsupported
+extensions and shows an error"). The uploaded `File`'s `.name` is checked
+against `.png`/`.svg` (case-insensitive) on selection, before any read or
+API call.
+
+## Architecture
+
+- `frontend/src/stores/decode.ts` (`useDecodeStore`): state `file: File | null`
+  (format is never stored separately - it's derived from `file.name`'s
+  extension where needed, avoiding two fields that could drift out of sync),
+  `keyInput: string`, `size: 'small' | 'medium' | 'large'` (default
+  `'medium'`), `status: 'idle' | 'loading' | 'success' | 'error'`,
+  `result: string | null`, `errorMessage: string | null`,
+  `errorCode: 'network' | 'unknown' | null` (mirrors `useEncodeStore`'s
+  post-FEAT-014-review error shape exactly). Actions:
+  - `submit()`: derives `format` from `file.name`'s extension (`.png` ->
+    `'png'`, `.svg` -> `'svg'`), reads `file` via `FileReader`
+    (`readAsDataURL` for PNG, stripping the `data:image/png;base64,` prefix
+    to get the raw base64 payload the backend expects; `readAsText` for SVG,
+    used as-is), builds `{ cryptogram, format, key: keyInput, size }`, calls
+    `postJson<{ message: string }>('/decode', payload)`, and follows the same
+    status/result/errorMessage/errorCode transitions as `useEncodeStore.submit()`.
+  - `reset()`: same `Object.assign(this, initialState())` pattern.
+- `frontend/src/components/DecodeUploadArea.vue`: a `v-model`-compatible
+  component bound directly to `store.file` from the parent
+  (`<DecodeUploadArea v-model="store.file" />`, same direct-binding pattern
+  FEAT-014 used for `<RotationSequencePicker v-model="store.rotationSequence" />`
+  - no separate store action needed, since the component only ever emits an
+    already-valid `File`). Renders a hidden
+  `<input type="file" accept=".png,.svg">` triggered by a visible "browse"
+  button, plus a drop zone (`@dragover.prevent`, `@dragleave`, `@drop.prevent`)
+  toggling an `isDragging` class for visual feedback. On a valid selection
+  (click or drop), emits the `File` (`update:modelValue`) and displays its
+  `.name`. On an invalid extension, shows an inline error and does not emit
+  (previous valid file, if any, stays selected).
+- `frontend/src/components/DecodeParamsForm.vue`: renders `DecodeUploadArea`,
+  the key input (with the same client-side `isValidKeyFormat` check pattern
+  as `EncodeParamsForm`'s key mode), the `size` selector, and the submit
+  button (disabled while loading, or while no file is selected, or while the
+  key is empty/invalid).
+- `frontend/src/views/DecodeView.vue`: renders `DecodeParamsForm`, the error
+  message (`v-if="store.status === 'error'"`, same `errorMessage ?? t(...)`
+  resolution as `EncodeView`), and the decoded message
+  (`v-if="store.status === 'success'"`) directly inline - no separate result
+  component, since there is only one string to display (no previews,
+  downloads, or warnings to render).
+
+## Error handling
+
+- **Client-side file extension check**: on selection (click or drop), before
+  any read or network call - inline error in `DecodeUploadArea`.
+- **Client-side key format check**: same `isValidKeyFormat` reuse as
+  `EncodeParamsForm`'s key mode, checked before submit.
+- **Backend errors and network failures**: normalized through `ApiError`
+  (`code: 'http' | 'network'`) exactly as `useEncodeStore` does post-FEAT-014-
+  review - HTTP-coded errors keep the backend's own message verbatim,
+  network/unknown errors resolve through `errors.network`/`errors.unknown`
+  i18n keys.
+- **Loading state**: submit button disabled and a loading indicator shown
+  while `status === 'loading'`.
+
+## Testing strategy
+
+- `frontend/src/components/DecodeUploadArea.spec.ts`: file selection via the
+  hidden input's `change` event, `dragover`/`drop` event handling, extension
+  rejection (using the shared `MOCK_PNG_FILE`/`MOCK_SVG_FILE` fixtures plus a
+  new invalid-extension `File`), filename display after a valid selection.
+- `frontend/src/stores/decode.spec.ts`: mirrors `encode.spec.ts` - payload
+  construction differs correctly by format (base64-stripped for PNG, raw text
+  for SVG), status/result/errorCode transitions through success and failure,
+  `reset()` restores defaults. `api/client.ts` is mocked (`postJson`), same
+  pattern as `encode.spec.ts`.
+- `frontend/src/views/DecodeView.spec.ts`: integration test covering
+  `docs/tests/frontend.md` section 3 (`DecodeView`) and section 4 (`useDecodeStore`)
+  in full - mounted with a real Pinia store and a mocked `api/client.ts`,
+  mirroring `EncodeView.spec.ts`'s established pattern (including the lesson
+  from FEAT-014's final review: tests must prove controls are actually bound,
+  not just rendered with their default values).
+- Fixtures added to the existing shared `src/__fixtures__/frontend.fixtures.ts`
+  (already holding the encode-related ones): `MOCK_DECODE_RESPONSE`,
+  `MOCK_PNG_FILE`, `MOCK_SVG_FILE` - the three decode-related fixtures named
+  in `docs/tests/frontend.md`'s Fixtures section.
+- No dedicated `DecodeParamsForm.spec.ts` (same reasoning as
+  `EncodeParamsForm`): its wiring is verified through `DecodeView.spec.ts`.
+- House rule carried over: no bare `for`/`while`/`if` in test bodies, use
+  `it.each` for parameterized cases (e.g. the PNG vs. SVG payload-shape test).
+
+## i18n
+
+Every user-visible string (upload area labels/errors, key/size field labels,
+submit button, decoded-message label, error messages) routes through a
+`vue-i18n` key under a `decode.*` namespace in `src/locales/en.json`
+(`decode.upload.*`, `decode.form.*`, `decode.result.*`), mirroring the
+`encode.*` structure from FEAT-014.
+
+## Explicitly out of scope for this feature
+
+- File size limits on upload - not required by the backlog's acceptance
+  criteria; can be added later if real-world file sizes prove it necessary.
+- Any visual preview of the uploaded file before submission - only the
+  filename is required to be shown (per the test contract).
+- Visual design/styling polish - REFACTOR-001, same carve-out as FEAT-014.
+- French interface - FEAT-020, same carve-out as FEAT-014.
+- Any change to `EncodeView.vue`/`KeyView.vue` beyond none - this feature
+  touches neither.

--- a/frontend/src/__fixtures__/frontend.fixtures.ts
+++ b/frontend/src/__fixtures__/frontend.fixtures.ts
@@ -3,7 +3,7 @@ import type { EncodeResult } from '../stores/encode'
 // A minimal valid 1x1 transparent PNG, base64-encoded — realistic enough to
 // exercise data-URL rendering and blob-download code paths without needing
 // a real render.
-const TINY_PNG_BASE64 =
+export const TINY_PNG_BASE64 =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII='
 
 export const MOCK_ENCODE_RESPONSE: EncodeResult = {
@@ -21,3 +21,22 @@ export const MOCK_ENCODE_RESPONSE_WITH_WARNINGS: EncodeResult = {
 }
 
 export const MALFORMED_KEY = 'not-a-valid-key'
+
+function base64ToBytes(base64: string): Uint8Array<ArrayBuffer> {
+  return Uint8Array.from(atob(base64), (char) => char.charCodeAt(0)) as Uint8Array<ArrayBuffer>
+}
+
+export const MOCK_PNG_FILE = new File([base64ToBytes(TINY_PNG_BASE64)], 'cryptogram.png', {
+  type: 'image/png',
+})
+
+export const SVG_CRYPTOGRAM_CONTENT =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"><rect width="10" height="10" fill="#000"/></svg>'
+
+export const MOCK_SVG_FILE = new File([SVG_CRYPTOGRAM_CONTENT], 'cryptogram.svg', {
+  type: 'image/svg+xml',
+})
+
+export const MOCK_DECODE_RESPONSE = {
+  message: 'HELLO WORLD',
+}

--- a/frontend/src/components/DecodeParamsForm.vue
+++ b/frontend/src/components/DecodeParamsForm.vue
@@ -1,0 +1,92 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useDecodeStore } from '../stores/decode'
+import { isValidKeyFormat } from '../utils/key-format'
+import DecodeUploadArea from './DecodeUploadArea.vue'
+
+const store = useDecodeStore()
+const { t } = useI18n()
+
+const keyFormatError = computed(() => {
+  if (store.keyInput.length === 0) return null
+  return isValidKeyFormat(store.keyInput) ? null : t('decode.form.key.formatError')
+})
+
+const canSubmit = computed(() => {
+  if (store.status === 'loading') return false
+  if (store.file === null) return false
+  return store.keyInput.length > 0 && keyFormatError.value === null
+})
+
+function handleSubmit(): void {
+  if (!canSubmit.value) return
+  void store.submit()
+}
+</script>
+
+<template>
+  <form
+    class="decode-params-form"
+    @submit.prevent="handleSubmit"
+  >
+    <div class="decode-params-form__field">
+      {{ t('decode.form.upload.label') }}
+      <DecodeUploadArea v-model="store.file" />
+    </div>
+
+    <label class="decode-params-form__field">
+      {{ t('decode.form.key.label') }}
+      <input
+        v-model="store.keyInput"
+        type="text"
+        :placeholder="t('decode.form.key.placeholder')"
+      >
+    </label>
+    <p
+      v-if="keyFormatError"
+      class="decode-params-form__error"
+      role="alert"
+    >
+      {{ keyFormatError }}
+    </p>
+
+    <label class="decode-params-form__field">
+      {{ t('decode.form.size.label') }}
+      <select
+        v-model="store.size"
+        name="size"
+      >
+        <option value="small">{{ t('decode.form.size.small') }}</option>
+        <option value="medium">{{ t('decode.form.size.medium') }}</option>
+        <option value="large">{{ t('decode.form.size.large') }}</option>
+      </select>
+    </label>
+
+    <button
+      type="submit"
+      :disabled="!canSubmit"
+    >
+      {{ store.status === 'loading' ? t('decode.form.submit.loading') : t('decode.form.submit.label') }}
+    </button>
+  </form>
+</template>
+
+<style scoped>
+.decode-params-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 480px;
+}
+
+.decode-params-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.decode-params-form__error {
+  color: #c0392b;
+}
+</style>

--- a/frontend/src/components/DecodeParamsForm.vue
+++ b/frontend/src/components/DecodeParamsForm.vue
@@ -62,6 +62,9 @@ function handleSubmit(): void {
         <option value="large">{{ t('decode.form.size.large') }}</option>
       </select>
     </label>
+    <p class="decode-params-form__hint">
+      {{ t('decode.form.size.hint') }}
+    </p>
 
     <button
       type="submit"
@@ -88,5 +91,11 @@ function handleSubmit(): void {
 
 .decode-params-form__error {
   color: #c0392b;
+}
+
+.decode-params-form__hint {
+  font-size: 0.85em;
+  color: var(--text);
+  margin: 0;
 }
 </style>

--- a/frontend/src/components/DecodeUploadArea.spec.ts
+++ b/frontend/src/components/DecodeUploadArea.spec.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import DecodeUploadArea from './DecodeUploadArea.vue'
+import en from '../locales/en.json'
+import { MOCK_PNG_FILE, MOCK_SVG_FILE } from '../__fixtures__/frontend.fixtures'
+
+const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
+
+function mountArea(modelValue: File | null = null) {
+  return mount(DecodeUploadArea, {
+    props: { modelValue },
+    global: { plugins: [i18n] },
+  })
+}
+
+describe('DecodeUploadArea', () => {
+  it.each([
+    ['PNG', MOCK_PNG_FILE],
+    ['SVG', MOCK_SVG_FILE],
+  ])('emits the selected %s file when chosen via the file input', async (_label, file) => {
+    const wrapper = mountArea()
+    const input = wrapper.find('input[type="file"]')
+    Object.defineProperty(input.element, 'files', { value: [file], writable: false })
+
+    await input.trigger('change')
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([[file]])
+  })
+
+  it('shows an inline error and does not emit for an unsupported extension', async () => {
+    const invalidFile = new File(['not a cryptogram'], 'notes.txt', { type: 'text/plain' })
+    const wrapper = mountArea()
+    const input = wrapper.find('input[type="file"]')
+    Object.defineProperty(input.element, 'files', { value: [invalidFile], writable: false })
+
+    await input.trigger('change')
+
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+    expect(wrapper.find('.decode-upload-area__error').exists()).toBe(true)
+  })
+
+  it('emits the dropped file when a valid file is dropped', async () => {
+    const wrapper = mountArea()
+
+    await wrapper.find('.decode-upload-area').trigger('drop', {
+      dataTransfer: { files: [MOCK_PNG_FILE] },
+    })
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([[MOCK_PNG_FILE]])
+  })
+
+  it('displays the filename once a file is selected', () => {
+    const wrapper = mountArea(MOCK_PNG_FILE)
+    expect(wrapper.text()).toContain(MOCK_PNG_FILE.name)
+  })
+
+  it('does not display a filename when no file is selected', () => {
+    const wrapper = mountArea(null)
+    expect(wrapper.text()).not.toContain(MOCK_PNG_FILE.name)
+  })
+})

--- a/frontend/src/components/DecodeUploadArea.vue
+++ b/frontend/src/components/DecodeUploadArea.vue
@@ -1,0 +1,116 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+defineProps<{
+  modelValue: File | null
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: File]
+}>()
+
+const { t } = useI18n()
+
+const isDragging = ref(false)
+const formatError = ref<string | null>(null)
+const fileInput = ref<HTMLInputElement | null>(null)
+
+function isValidExtension(file: File): boolean {
+  return /\.(png|svg)$/i.test(file.name)
+}
+
+function selectFile(file: File): void {
+  if (!isValidExtension(file)) {
+    formatError.value = t('decode.upload.invalidExtension')
+    return
+  }
+  formatError.value = null
+  emit('update:modelValue', file)
+}
+
+function handleInputChange(event: Event): void {
+  const target = event.target as HTMLInputElement
+  const file = target.files?.[0]
+  if (file) selectFile(file)
+}
+
+function handleDrop(event: DragEvent): void {
+  isDragging.value = false
+  const file = event.dataTransfer?.files?.[0]
+  if (file) selectFile(file)
+}
+
+function handleDragOver(): void {
+  isDragging.value = true
+}
+
+function handleDragLeave(): void {
+  isDragging.value = false
+}
+
+function triggerBrowse(): void {
+  fileInput.value?.click()
+}
+</script>
+
+<template>
+  <div
+    class="decode-upload-area"
+    :class="{ 'decode-upload-area--dragging': isDragging }"
+    @dragover.prevent="handleDragOver"
+    @dragleave.prevent="handleDragLeave"
+    @drop.prevent="handleDrop"
+  >
+    <input
+      ref="fileInput"
+      type="file"
+      accept=".png,.svg"
+      class="decode-upload-area__input"
+      @change="handleInputChange"
+    >
+    <button
+      type="button"
+      @click="triggerBrowse"
+    >
+      {{ t('decode.upload.browse') }}
+    </button>
+    <p>{{ t('decode.upload.dropHint') }}</p>
+    <p
+      v-if="modelValue"
+      class="decode-upload-area__filename"
+    >
+      {{ modelValue.name }}
+    </p>
+    <p
+      v-if="formatError"
+      class="decode-upload-area__error"
+      role="alert"
+    >
+      {{ formatError }}
+    </p>
+  </div>
+</template>
+
+<style scoped>
+.decode-upload-area {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px;
+  border: 2px dashed var(--border);
+  border-radius: 4px;
+}
+
+.decode-upload-area--dragging {
+  border-color: var(--accent);
+}
+
+.decode-upload-area__input {
+  display: none;
+}
+
+.decode-upload-area__error {
+  color: #c0392b;
+}
+</style>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -81,7 +81,8 @@
         "label": "Cryptogram size",
         "small": "Small",
         "medium": "Medium",
-        "large": "Large"
+        "large": "Large",
+        "hint": "Must match the size used when the cryptogram was encoded."
       },
       "submit": {
         "label": "Decode",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -61,6 +61,13 @@
       "copyError": "Copy failed"
     }
   },
+  "decode": {
+    "upload": {
+      "browse": "Choose a file",
+      "dropHint": "or drag and drop a PNG or SVG file here",
+      "invalidExtension": "Only .png and .svg files are supported."
+    }
+  },
   "errors": {
     "network": "Network error: unable to reach the server",
     "unknown": "Something went wrong. Please try again."

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -66,6 +66,26 @@
       "browse": "Choose a file",
       "dropHint": "or drag and drop a PNG or SVG file here",
       "invalidExtension": "Only .png and .svg files are supported."
+    },
+    "form": {
+      "upload": {
+        "label": "Cryptogram file"
+      },
+      "key": {
+        "label": "HexaRot key",
+        "placeholder": "HR1·xxxx",
+        "formatError": "This does not look like a valid HexaRot key."
+      },
+      "size": {
+        "label": "Cryptogram size",
+        "small": "Small",
+        "medium": "Medium",
+        "large": "Large"
+      },
+      "submit": {
+        "label": "Decode",
+        "loading": "Decoding..."
+      }
     }
   },
   "errors": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -62,6 +62,7 @@
     }
   },
   "decode": {
+    "title": "Decode a cryptogram",
     "upload": {
       "browse": "Choose a file",
       "dropHint": "or drag and drop a PNG or SVG file here",
@@ -86,6 +87,9 @@
         "label": "Decode",
         "loading": "Decoding..."
       }
+    },
+    "result": {
+      "label": "Decoded message"
     }
   },
   "errors": {

--- a/frontend/src/stores/decode.spec.ts
+++ b/frontend/src/stores/decode.spec.ts
@@ -131,6 +131,36 @@ describe('useDecodeStore', () => {
     expect(store.result).toBeNull()
   })
 
+  it('sets errorCode to unknown and status to error when the file cannot be read', async () => {
+    const store = useDecodeStore()
+    store.file = MOCK_PNG_FILE
+    store.keyInput = 'HR1·a1b2'
+
+    const OriginalFileReader = globalThis.FileReader
+    class FailingFileReader {
+      onload: (() => void) | null = null
+      onerror: ((event: unknown) => void) | null = null
+      error = new Error('read failed')
+      readAsDataURL(): void {
+        queueMicrotask(() => this.onerror?.(new Event('error')))
+      }
+      readAsText(): void {
+        queueMicrotask(() => this.onerror?.(new Event('error')))
+      }
+    }
+    // @ts-expect-error -- intentionally stubbing the global for this one test
+    globalThis.FileReader = FailingFileReader
+
+    try {
+      await store.submit()
+    } finally {
+      globalThis.FileReader = OriginalFileReader
+    }
+
+    expect(store.status).toBe('error')
+    expect(store.errorCode).toBe('unknown')
+  })
+
   it('restores default state when reset is called', async () => {
     vi.mocked(postJson).mockResolvedValue(MOCK_DECODE_RESPONSE)
     const store = useDecodeStore()

--- a/frontend/src/stores/decode.spec.ts
+++ b/frontend/src/stores/decode.spec.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useDecodeStore } from './decode'
+import { ApiError } from '../api/client'
+import {
+  MOCK_DECODE_RESPONSE,
+  MOCK_PNG_FILE,
+  MOCK_SVG_FILE,
+  TINY_PNG_BASE64,
+  SVG_CRYPTOGRAM_CONTENT,
+} from '../__fixtures__/frontend.fixtures'
+
+vi.mock('../api/client', async () => {
+  const actual = await vi.importActual<typeof import('../api/client')>('../api/client')
+  return { ...actual, postJson: vi.fn() }
+})
+
+import { postJson } from '../api/client'
+
+describe('useDecodeStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.mocked(postJson).mockReset()
+  })
+
+  it('initialises with default field values and no result or error', () => {
+    const store = useDecodeStore()
+
+    expect(store.file).toBeNull()
+    expect(store.keyInput).toBe('')
+    expect(store.size).toBe('medium')
+    expect(store.status).toBe('idle')
+    expect(store.result).toBeNull()
+    expect(store.errorMessage).toBeNull()
+    expect(store.errorCode).toBeNull()
+  })
+
+  it('builds the PNG payload with a base64-encoded cryptogram when submitting', async () => {
+    vi.mocked(postJson).mockResolvedValue(MOCK_DECODE_RESPONSE)
+    const store = useDecodeStore()
+    store.file = MOCK_PNG_FILE
+    store.keyInput = 'HR1·a1b2'
+
+    await store.submit()
+
+    expect(postJson).toHaveBeenCalledWith('/decode', {
+      cryptogram: TINY_PNG_BASE64,
+      format: 'png',
+      key: 'HR1·a1b2',
+      size: 'medium',
+    })
+  })
+
+  it('builds the SVG payload with the raw text content when submitting', async () => {
+    vi.mocked(postJson).mockResolvedValue(MOCK_DECODE_RESPONSE)
+    const store = useDecodeStore()
+    store.file = MOCK_SVG_FILE
+    store.keyInput = 'HR1·a1b2'
+
+    await store.submit()
+
+    expect(postJson).toHaveBeenCalledWith('/decode', {
+      cryptogram: SVG_CRYPTOGRAM_CONTENT,
+      format: 'svg',
+      key: 'HR1·a1b2',
+      size: 'medium',
+    })
+  })
+
+  it('sets status to loading while the request is in flight', () => {
+    vi.mocked(postJson).mockReturnValue(new Promise(() => {}))
+    const store = useDecodeStore()
+    store.file = MOCK_PNG_FILE
+    store.keyInput = 'HR1·a1b2'
+
+    void store.submit()
+
+    expect(store.status).toBe('loading')
+  })
+
+  it('stores the result and sets status to success on a successful submit', async () => {
+    vi.mocked(postJson).mockResolvedValue(MOCK_DECODE_RESPONSE)
+    const store = useDecodeStore()
+    store.file = MOCK_PNG_FILE
+    store.keyInput = 'HR1·a1b2'
+
+    await store.submit()
+
+    expect(store.result).toBe(MOCK_DECODE_RESPONSE.message)
+    expect(store.status).toBe('success')
+    expect(store.errorMessage).toBeNull()
+  })
+
+  it('stores the error message and sets status to error on a failed submit', async () => {
+    vi.mocked(postJson).mockRejectedValue(new ApiError('invalid key', 'http', 400))
+    const store = useDecodeStore()
+    store.file = MOCK_PNG_FILE
+    store.keyInput = 'HR1·a1b2'
+
+    await store.submit()
+
+    expect(store.status).toBe('error')
+    expect(store.errorMessage).toBe('invalid key')
+    expect(store.result).toBeNull()
+  })
+
+  it('sets errorCode to network and leaves errorMessage null on a network failure', async () => {
+    vi.mocked(postJson).mockRejectedValue(new ApiError('Network error: unable to reach the server', 'network'))
+    const store = useDecodeStore()
+    store.file = MOCK_PNG_FILE
+    store.keyInput = 'HR1·a1b2'
+
+    await store.submit()
+
+    expect(store.status).toBe('error')
+    expect(store.errorCode).toBe('network')
+    expect(store.errorMessage).toBeNull()
+  })
+
+  it('clears the previous result when a new submit is dispatched', async () => {
+    vi.mocked(postJson).mockResolvedValue(MOCK_DECODE_RESPONSE)
+    const store = useDecodeStore()
+    store.file = MOCK_PNG_FILE
+    store.keyInput = 'HR1·a1b2'
+    await store.submit()
+    expect(store.result).toBe(MOCK_DECODE_RESPONSE.message)
+
+    vi.mocked(postJson).mockReturnValue(new Promise(() => {}))
+    void store.submit()
+
+    expect(store.result).toBeNull()
+  })
+
+  it('restores default state when reset is called', async () => {
+    vi.mocked(postJson).mockResolvedValue(MOCK_DECODE_RESPONSE)
+    const store = useDecodeStore()
+    store.file = MOCK_PNG_FILE
+    store.keyInput = 'HR1·a1b2'
+    await store.submit()
+
+    store.reset()
+
+    expect(store.file).toBeNull()
+    expect(store.keyInput).toBe('')
+    expect(store.status).toBe('idle')
+    expect(store.result).toBeNull()
+  })
+})

--- a/frontend/src/stores/decode.ts
+++ b/frontend/src/stores/decode.ts
@@ -1,0 +1,95 @@
+import { defineStore } from 'pinia'
+import { postJson, ApiError } from '../api/client'
+
+export type DecodeStatus = 'idle' | 'loading' | 'success' | 'error'
+export type CryptogramSize = 'small' | 'medium' | 'large'
+
+interface DecodeState {
+  file: File | null
+  keyInput: string
+  size: CryptogramSize
+  status: DecodeStatus
+  result: string | null
+  errorMessage: string | null
+  errorCode: 'network' | 'unknown' | null
+}
+
+function initialState(): DecodeState {
+  return {
+    file: null,
+    keyInput: '',
+    size: 'medium',
+    status: 'idle',
+    result: null,
+    errorMessage: null,
+    errorCode: null,
+  }
+}
+
+function detectFormat(file: File): 'png' | 'svg' {
+  return /\.svg$/i.test(file.name) ? 'svg' : 'png'
+}
+
+function readFileAsBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => {
+      const dataUrl = reader.result as string
+      resolve(dataUrl.slice(dataUrl.indexOf(',') + 1))
+    }
+    reader.onerror = () => reject(reader.error)
+    reader.readAsDataURL(file)
+  })
+}
+
+function readFileAsText(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(reader.result as string)
+    reader.onerror = () => reject(reader.error)
+    reader.readAsText(file)
+  })
+}
+
+export const useDecodeStore = defineStore('decode', {
+  state: initialState,
+  actions: {
+    async submit(): Promise<void> {
+      const file = this.file
+      if (!file) return
+
+      this.status = 'loading'
+      this.result = null
+      this.errorMessage = null
+      this.errorCode = null
+
+      const format = detectFormat(file)
+      const cryptogram = format === 'png' ? await readFileAsBase64(file) : await readFileAsText(file)
+
+      try {
+        const response = await postJson<{ message: string }>('/decode', {
+          cryptogram,
+          format,
+          key: this.keyInput,
+          size: this.size,
+        })
+        this.result = response.message
+        this.status = 'success'
+      } catch (err) {
+        if (err instanceof ApiError && err.code === 'http') {
+          this.errorMessage = err.message
+        } else if (err instanceof ApiError && err.code === 'network') {
+          this.errorMessage = null
+          this.errorCode = 'network'
+        } else {
+          this.errorMessage = null
+          this.errorCode = 'unknown'
+        }
+        this.status = 'error'
+      }
+    },
+    reset(): void {
+      Object.assign(this, initialState())
+    },
+  },
+})

--- a/frontend/src/stores/decode.ts
+++ b/frontend/src/stores/decode.ts
@@ -63,10 +63,10 @@ export const useDecodeStore = defineStore('decode', {
       this.errorMessage = null
       this.errorCode = null
 
-      const format = detectFormat(file)
-      const cryptogram = format === 'png' ? await readFileAsBase64(file) : await readFileAsText(file)
-
       try {
+        const format = detectFormat(file)
+        const cryptogram = format === 'png' ? await readFileAsBase64(file) : await readFileAsText(file)
+
         const response = await postJson<{ message: string }>('/decode', {
           cryptogram,
           format,

--- a/frontend/src/views/DecodeView.spec.ts
+++ b/frontend/src/views/DecodeView.spec.ts
@@ -3,6 +3,7 @@ import { mount, flushPromises } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { createI18n } from 'vue-i18n'
 import DecodeView from './DecodeView.vue'
+import { useDecodeStore } from '../stores/decode'
 import en from '../locales/en.json'
 import {
   MOCK_DECODE_RESPONSE,
@@ -183,6 +184,26 @@ describe('DecodeView', () => {
       await vi.waitFor(() => expect(wrapper.text()).toContain('invalid key'))
 
       expect(wrapper.find('.decode-view__result').exists()).toBe(false)
+    })
+  })
+
+  describe('unmount', () => {
+    it('resets the store when the view unmounts', async () => {
+      vi.mocked(postJson).mockResolvedValue(MOCK_DECODE_RESPONSE)
+      const wrapper = mountView()
+      await selectFile(wrapper, MOCK_PNG_FILE)
+      await wrapper.find('input[type="text"]').setValue('HR1·a1b2')
+
+      await wrapper.find('form').trigger('submit')
+      await vi.waitFor(() => expect(wrapper.find('.decode-view__result').exists()).toBe(true))
+
+      const store = useDecodeStore()
+      expect(store.result).toBe(MOCK_DECODE_RESPONSE.message)
+
+      wrapper.unmount()
+
+      expect(store.result).toBeNull()
+      expect(store.status).toBe('idle')
     })
   })
 

--- a/frontend/src/views/DecodeView.spec.ts
+++ b/frontend/src/views/DecodeView.spec.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createI18n } from 'vue-i18n'
+import DecodeView from './DecodeView.vue'
+import en from '../locales/en.json'
+import {
+  MOCK_DECODE_RESPONSE,
+  MOCK_PNG_FILE,
+  MOCK_SVG_FILE,
+  MALFORMED_KEY,
+} from '../__fixtures__/frontend.fixtures'
+import { ApiError } from '../api/client'
+
+vi.mock('../api/client', async () => {
+  const actual = await vi.importActual<typeof import('../api/client')>('../api/client')
+  return { ...actual, postJson: vi.fn() }
+})
+
+import { postJson } from '../api/client'
+
+function mountView() {
+  const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
+  return mount(DecodeView, {
+    global: { plugins: [createPinia(), i18n] },
+  })
+}
+
+async function selectFile(wrapper: ReturnType<typeof mountView>, file: File) {
+  const input = wrapper.find('input[type="file"]')
+  Object.defineProperty(input.element, 'files', { value: [file], writable: false })
+  await input.trigger('change')
+}
+
+describe('DecodeView', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.mocked(postJson).mockReset()
+  })
+
+  describe('initial state', () => {
+    it('renders the file upload area', () => {
+      const wrapper = mountView()
+      expect(wrapper.find('input[type="file"]').exists()).toBe(true)
+    })
+
+    it('renders the HR key input field', () => {
+      const wrapper = mountView()
+      expect(wrapper.find('input[type="text"]').exists()).toBe(true)
+    })
+
+    it('renders the submit button', () => {
+      const wrapper = mountView()
+      expect(wrapper.find('button[type="submit"]').exists()).toBe(true)
+    })
+
+    it('does not display a decoded message on initial render', () => {
+      const wrapper = mountView()
+      expect(wrapper.find('.decode-view__result').exists()).toBe(false)
+    })
+  })
+
+  describe('file upload', () => {
+    it('accepts a PNG file via the file input', async () => {
+      const wrapper = mountView()
+      await selectFile(wrapper, MOCK_PNG_FILE)
+      expect(wrapper.text()).toContain(MOCK_PNG_FILE.name)
+    })
+
+    it('accepts an SVG file via the file input', async () => {
+      const wrapper = mountView()
+      await selectFile(wrapper, MOCK_SVG_FILE)
+      expect(wrapper.text()).toContain(MOCK_SVG_FILE.name)
+    })
+
+    it('rejects files with unsupported extensions and shows an error', async () => {
+      const wrapper = mountView()
+      const invalidFile = new File(['x'], 'notes.txt', { type: 'text/plain' })
+      await selectFile(wrapper, invalidFile)
+      expect(wrapper.find('.decode-upload-area__error').exists()).toBe(true)
+    })
+
+    it('displays the uploaded filename after selection', async () => {
+      const wrapper = mountView()
+      await selectFile(wrapper, MOCK_PNG_FILE)
+      expect(wrapper.text()).toContain('cryptogram.png')
+    })
+
+    it('supports drag-and-drop (dragover and drop events are handled)', async () => {
+      const wrapper = mountView()
+      const dropZone = wrapper.find('.decode-upload-area')
+      await dropZone.trigger('dragover')
+      await dropZone.trigger('drop', { dataTransfer: { files: [MOCK_PNG_FILE] } })
+      expect(wrapper.text()).toContain(MOCK_PNG_FILE.name)
+    })
+  })
+
+  describe('form submission', () => {
+    it('calls the decode API with the file content and key when submitted', async () => {
+      vi.mocked(postJson).mockResolvedValue(MOCK_DECODE_RESPONSE)
+      const wrapper = mountView()
+      await selectFile(wrapper, MOCK_PNG_FILE)
+      await wrapper.find('input[type="text"]').setValue('HR1·a1b2')
+
+      await wrapper.find('form').trigger('submit')
+
+      // FileReader resolves via a browser task, not a microtask, so a single
+      // flushPromises() tick is not guaranteed to be enough - poll instead.
+      await vi.waitFor(() =>
+        expect(postJson).toHaveBeenCalledWith(
+          '/decode',
+          expect.objectContaining({ format: 'png', key: 'HR1·a1b2', size: 'medium' }),
+        ),
+      )
+    })
+
+    it('shows a loading indicator while the API call is in progress', async () => {
+      vi.mocked(postJson).mockReturnValue(new Promise(() => {}))
+      const wrapper = mountView()
+      await selectFile(wrapper, MOCK_PNG_FILE)
+      await wrapper.find('input[type="text"]').setValue('HR1·a1b2')
+
+      await wrapper.find('form').trigger('submit')
+      await flushPromises()
+
+      expect(wrapper.find('button[type="submit"]').text()).toBe('Decoding...')
+    })
+  })
+
+  describe('successful response', () => {
+    it('displays the decoded message after a successful decode response', async () => {
+      vi.mocked(postJson).mockResolvedValue(MOCK_DECODE_RESPONSE)
+      const wrapper = mountView()
+      await selectFile(wrapper, MOCK_PNG_FILE)
+      await wrapper.find('input[type="text"]').setValue('HR1·a1b2')
+
+      await wrapper.find('form').trigger('submit')
+
+      // FileReader resolves via a browser task, not a microtask, so a single
+      // flushPromises() tick is not guaranteed to be enough - poll instead.
+      await vi.waitFor(() => expect(wrapper.find('.decode-view__result').exists()).toBe(true))
+      await flushPromises()
+
+      expect(wrapper.find('.decode-view__result').text()).toContain(MOCK_DECODE_RESPONSE.message)
+    })
+  })
+
+  describe('error handling', () => {
+    it('displays an error when the key format is invalid (client-side, before the API call)', async () => {
+      const wrapper = mountView()
+      await selectFile(wrapper, MOCK_PNG_FILE)
+      await wrapper.find('input[type="text"]').setValue(MALFORMED_KEY)
+
+      expect(wrapper.find('.decode-params-form__error').exists()).toBe(true)
+      expect(wrapper.find('button[type="submit"]').attributes('disabled')).toBeDefined()
+      expect(postJson).not.toHaveBeenCalled()
+    })
+
+    it('displays an error when the API call fails', async () => {
+      vi.mocked(postJson).mockRejectedValue(new ApiError('invalid key', 'http', 400))
+      const wrapper = mountView()
+      await selectFile(wrapper, MOCK_PNG_FILE)
+      await wrapper.find('input[type="text"]').setValue('HR1·a1b2')
+
+      await wrapper.find('form').trigger('submit')
+
+      // FileReader resolves via a browser task, not a microtask, so a single
+      // flushPromises() tick is not guaranteed to be enough - poll instead.
+      await vi.waitFor(() => expect(wrapper.text()).toContain('invalid key'))
+    })
+
+    it('does not display a decoded message after an API error', async () => {
+      vi.mocked(postJson).mockRejectedValue(new ApiError('invalid key', 'http', 400))
+      const wrapper = mountView()
+      await selectFile(wrapper, MOCK_PNG_FILE)
+      await wrapper.find('input[type="text"]').setValue('HR1·a1b2')
+
+      await wrapper.find('form').trigger('submit')
+
+      // FileReader resolves via a browser task, not a microtask, so a single
+      // flushPromises() tick is not guaranteed to be enough - poll until the
+      // error has actually surfaced before asserting the result is absent.
+      await vi.waitFor(() => expect(wrapper.text()).toContain('invalid key'))
+
+      expect(wrapper.find('.decode-view__result').exists()).toBe(false)
+    })
+  })
+
+  describe('i18n', () => {
+    it('renders no raw string literals - the submit button text comes from the locale file', () => {
+      const wrapper = mountView()
+      expect(wrapper.find('button[type="submit"]').text()).toBe(en.decode.form.submit.label)
+    })
+  })
+})

--- a/frontend/src/views/DecodeView.vue
+++ b/frontend/src/views/DecodeView.vue
@@ -1,3 +1,40 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import { useDecodeStore } from '../stores/decode'
+import DecodeParamsForm from '../components/DecodeParamsForm.vue'
+
+const store = useDecodeStore()
+const { t } = useI18n()
+</script>
+
 <template>
-  <div>DecodeView</div>
+  <div class="decode-view">
+    <h1>{{ t('decode.title') }}</h1>
+    <DecodeParamsForm />
+    <p
+      v-if="store.status === 'error'"
+      class="decode-view__error"
+      role="alert"
+    >
+      {{ store.errorMessage ?? t(`errors.${store.errorCode}`) }}
+    </p>
+    <p
+      v-if="store.status === 'success' && store.result"
+      class="decode-view__result"
+    >
+      <strong>{{ t('decode.result.label') }}:</strong> {{ store.result }}
+    </p>
+  </div>
 </template>
+
+<style scoped>
+.decode-view {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.decode-view__error {
+  color: #c0392b;
+}
+</style>

--- a/frontend/src/views/DecodeView.vue
+++ b/frontend/src/views/DecodeView.vue
@@ -1,10 +1,15 @@
 <script setup lang="ts">
+import { onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useDecodeStore } from '../stores/decode'
 import DecodeParamsForm from '../components/DecodeParamsForm.vue'
 
 const store = useDecodeStore()
 const { t } = useI18n()
+
+onUnmounted(() => {
+  store.reset()
+})
 </script>
 
 <template>
@@ -21,6 +26,7 @@ const { t } = useI18n()
     <p
       v-if="store.status === 'success' && store.result"
       class="decode-view__result"
+      aria-live="polite"
     >
       <strong>{{ t('decode.result.label') }}:</strong> {{ store.result }}
     </p>


### PR DESCRIPTION
## Description
Implements FEAT-015: HexaRot's second frontend feature, the decode view (/decode). The user uploads a cryptogram file (PNG or SVG, click-to-browse or native HTML5 drag-and-drop), enters the HR key and the cryptogram's size, and sees the decoded plaintext.

Reuses all of FEAT-014's shared infrastructure unchanged (vue-router, src/api/client.ts, the Pinia-store-per-view pattern, isValidKeyFormat) - no new dependencies, no new shared infra.

Executed via subagent-driven-development from docs/superpowers/plans/2026-08-18-feat-015-decode-view.md (spec: docs/superpowers/specs/2026-08-18-feat-015-decode-view-design.md).

## What's included

- useDecodeStore (Pinia): file/key/size state, request lifecycle, submit/reset, same ApiError.code/errorCode shape as useEncodeStore
- DecodeUploadArea: click-to-browse + native drag-and-drop, extension-based format validation (.png/.svg)
- DecodeParamsForm, DecodeView (assembly)
- 24 new frontend tests (92 total), full docs/tests/frontend.md sections 3-4 coverage
- README roadmap updated (both languages)

## Bugs found and fixed during review

- A real bug: a FileReader failure (e.g. file removed between selection and submit) left the view stuck on "Decoding..." forever with no error and no recovery - the file read happened outside the try block. Fixed and covered by a new test.
- Added a hint under the size selector ("must match the size used when (FEAT-012's png-parser: a too-small size silently produces garbage output instead of an error, structurally undetectable by pixel sampling).
- Cleared stale decoded results on navigating away (store.reset() on unmount), added aria-live to the result for screen readers.
- Three smaller plan-authoring bugs caught during task review (a TS 5.9 typed-array/BlobPart type mismatch, an unused-variable lint error, a flushPromises() timing issue in a FileReader-dependent test) - all disclosed, verified, and fixed with no production-behavior impact.

## Known follow-up needed (not fixed here, out of scope for this branch)

**Backend request body size limit.** SVG cryptograms for messages above roughly 230-250 characters exceed Express's default 100kb body limit in backend/src/main.ts, causing an opaque failure on decode. This is a pre-existing backend capacity limit, not introduced by this branch (the already-shipped encode view can already produce SVGs that hit it) - flagging it here since decode is what makes the failure reachable end-to-end. Should become its own backend fix/backlog item (raise the body limit, e.g. app.use(json({ limit: '5mb' }))).

## Manual verification

Ran the full stack via docker-compose up against a real seeded database: encoded a real message to get a real PNG, decoded it back via click-to-browse and got the exact original message back; encoded a second message to SVG, decoded it back via real drag-and-drop; tried a wrong key and confirmed the real backend error message renders. All three round-tripped correctly.

## Test plan

- [x] npm run build (vue-tsc + vite build) - clean
- [x] npm test - 92/92 passing
- [x] npm run lint - clean
- [x] Manual verification via docker-compose up against a real backend/DB (PNG click-to-browse, SVG drag-and-drop, wrong-key error - see above)
