### PR TITLE
feat(frontend): add the key view (generate/parse)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -861,7 +861,7 @@ All UI strings are routed through vue-i18n keys.
 - **type:** feat
 - **id:** FEAT-016
 - **milestone:** v1
-- **status:** ready
+- **status:** done
 - **priority:** medium
 - **domain:** frontend
 - **complexity:** S

--- a/README.fr.md
+++ b/README.fr.md
@@ -170,7 +170,7 @@ frontend/
 - ✅ Stratégies d'ordre de lecture (4 directions + mode alterné)
 - ✅ Renderers (PNG + SVG)
 - ✅ Endpoints API (encode, decode, key)
-- 🔄 Frontend (vue encodage, vue décodage terminées ; vue clé restante)
+- ✅ Frontend (vues encodage, décodage, clé toutes terminées)
 - 🔄 Tests & couverture (chaque feature livrée embarque déjà sa propre suite unitaire/e2e ; les items de suite de tests dédiée restent ouverts)
 
 ### V2

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ frontend/
 - ✅ Reading order strategies (4 directions + alternate)
 - ✅ Renderers (PNG + SVG)
 - ✅ API endpoints (encode, decode, key)
-- 🔄 Frontend (encode view, decode view done; key view still open)
+- ✅ Frontend (encode, decode, key views all done)
 - 🔄 Tests & coverage (every shipped feature carries its own unit/e2e suite; dedicated backend/frontend test-suite items still open)
 
 ### V2

--- a/docs/superpowers/plans/2026-08-19-feat-016-key-view.md
+++ b/docs/superpowers/plans/2026-08-19-feat-016-key-view.md
@@ -1,0 +1,1269 @@
+# FEAT-016 Key View Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the key view (`/key`) - a key generator section and a key parser section, each wired to the existing `POST /key/generate` and `GET /key/parse` backend endpoints.
+
+**Architecture:** One Pinia store (`useKeyStore`) with two independent state slices (generate, parse) backing two child components (`KeyGeneratorForm.vue`, `KeyParserForm.vue`) assembled by `KeyView.vue`, replacing its current 3-line stub. Reuses `RotationSequencePicker.vue`, `isValidKeyFormat`, `postJson`/`getJson`/`ApiError`, and the `errors.network`/`errors.unknown` i18n keys as-is - no changes to any existing file's public shape.
+
+**Tech Stack:** Vue 3.5 (`<script setup>`, TypeScript strict), Pinia 3, vue-i18n 9, Vitest 3 + `@vue/test-utils`.
+
+**Spec:** `docs/superpowers/specs/2026-08-19-feat-016-key-view-design.md`
+
+## Global Constraints
+
+- All user-visible strings route through vue-i18n keys under a `key.*` namespace in `frontend/src/locales/en.json` - no hardcoded English strings in templates.
+- `RotationSequencePicker.vue`, `isValidKeyFormat` (`utils/key-format.ts`), `postJson`/`getJson`/`ApiError` (`api/client.ts`), and `READING_ORDERS` (`constants/reading-orders.ts`) are reused as-is - none of these files are modified by this plan.
+- Store error shape mirrors `useEncodeStore`/`useDecodeStore` exactly: `errorMessage: string | null` (keeps the backend's own message for `ApiError.code === 'http'`) plus `errorCode: 'network' | 'unknown' | null` (resolved through `errors.network`/`errors.unknown` i18n keys) - applied independently to each of the store's two slices (`generate*` / `parse*`).
+- `<select>` elements always carry an explicit `name` attribute so tests can target them unambiguously (lesson from FEAT-014's final review, where an ambiguous `'select'` CSS selector silently matched the wrong element).
+- No bare `for`/`while`/`if` loops inside test bodies - use `it.each` for parameterized cases.
+- No new npm dependencies - this feature needs nothing beyond what FEAT-014/015 already installed.
+
+---
+
+### Task 1: `useKeyStore` and shared fixtures
+
+**Files:**
+- Create: `frontend/src/stores/key.ts`
+- Modify: `frontend/src/__fixtures__/frontend.fixtures.ts`
+- Test: `frontend/src/stores/key.spec.ts`
+
+**Interfaces:**
+- Consumes: `postJson`, `getJson`, `ApiError` from `../api/client` (existing, unchanged); `ReadingOrder` type from `../constants/reading-orders` (existing, unchanged).
+- Produces: `useKeyStore` (Pinia store id `'key'`) with state `pivotBlockSize: number`, `rotationSequence: number[]`, `rotationDirection: 'cw' | 'ccw'`, `readingOrder: ReadingOrder`, `generateStatus: 'idle' | 'loading' | 'success' | 'error'`, `generatedKey: string | null`, `generateErrorMessage: string | null`, `generateErrorCode: 'network' | 'unknown' | null`, `keyInput: string`, `parseStatus: 'idle' | 'loading' | 'success' | 'error'`, `parsedParams: KeyParseResult | null`, `parseErrorMessage: string | null`, `parseErrorCode: 'network' | 'unknown' | null`; actions `generate(): Promise<void>`, `parse(): Promise<void>`, `reset(): void`; exported type `KeyParseResult`. Tasks 2-4 import `useKeyStore` and `KeyParseResult` from `../stores/key`.
+
+- [ ] **Step 1: Add the two new fixtures**
+
+Append to `frontend/src/__fixtures__/frontend.fixtures.ts` (after the existing `MOCK_DECODE_RESPONSE` export, end of file):
+
+```typescript
+export const MOCK_KEY_GENERATE_RESPONSE = {
+  key: 'HR1·c3d4',
+}
+
+export const MOCK_KEY_PARSE_RESPONSE = {
+  pivotBlockSize: 5,
+  rotationSequence: [0, 90, 180, 270],
+  rotationDirection: 'cw' as const,
+  readingOrder: 'LR-TB',
+}
+```
+
+(`MALFORMED_KEY` already exists in this file from FEAT-015 - reused as-is, no change needed.)
+
+- [ ] **Step 2: Write the failing store test**
+
+Create `frontend/src/stores/key.spec.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useKeyStore } from './key'
+import { ApiError } from '../api/client'
+import { MOCK_KEY_GENERATE_RESPONSE, MOCK_KEY_PARSE_RESPONSE } from '../__fixtures__/frontend.fixtures'
+
+vi.mock('../api/client', async () => {
+  const actual = await vi.importActual<typeof import('../api/client')>('../api/client')
+  return { ...actual, postJson: vi.fn(), getJson: vi.fn() }
+})
+
+import { postJson, getJson } from '../api/client'
+
+describe('useKeyStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.mocked(postJson).mockReset()
+    vi.mocked(getJson).mockReset()
+  })
+
+  it('initialises with default parameter values and no result or error on either side', () => {
+    const store = useKeyStore()
+
+    expect(store.pivotBlockSize).toBe(5)
+    expect(store.rotationSequence).toEqual([0, 1, 2, 3])
+    expect(store.rotationDirection).toBe('cw')
+    expect(store.readingOrder).toBe('LR-TB')
+    expect(store.generateStatus).toBe('idle')
+    expect(store.generatedKey).toBeNull()
+    expect(store.generateErrorMessage).toBeNull()
+    expect(store.generateErrorCode).toBeNull()
+
+    expect(store.keyInput).toBe('')
+    expect(store.parseStatus).toBe('idle')
+    expect(store.parsedParams).toBeNull()
+    expect(store.parseErrorMessage).toBeNull()
+    expect(store.parseErrorCode).toBeNull()
+  })
+
+  it('calls postJson with the current generator parameters when generate is dispatched', async () => {
+    vi.mocked(postJson).mockResolvedValue(MOCK_KEY_GENERATE_RESPONSE)
+    const store = useKeyStore()
+    store.pivotBlockSize = 7
+    store.rotationDirection = 'ccw'
+    store.readingOrder = 'RL-TB'
+
+    await store.generate()
+
+    expect(postJson).toHaveBeenCalledWith('/key/generate', {
+      pivotBlockSize: 7,
+      rotationSequence: [0, 1, 2, 3],
+      rotationDirection: 'ccw',
+      readingOrder: 'RL-TB',
+    })
+  })
+
+  it('sets generateStatus to loading while the generate request is in flight', () => {
+    vi.mocked(postJson).mockReturnValue(new Promise(() => {}))
+    const store = useKeyStore()
+
+    void store.generate()
+
+    expect(store.generateStatus).toBe('loading')
+  })
+
+  it('stores the generated key and sets generateStatus to success on a successful generate', async () => {
+    vi.mocked(postJson).mockResolvedValue(MOCK_KEY_GENERATE_RESPONSE)
+    const store = useKeyStore()
+
+    await store.generate()
+
+    expect(store.generatedKey).toBe(MOCK_KEY_GENERATE_RESPONSE.key)
+    expect(store.generateStatus).toBe('success')
+    expect(store.generateErrorMessage).toBeNull()
+  })
+
+  it('stores the error message and sets generateStatus to error on a failed generate', async () => {
+    vi.mocked(postJson).mockRejectedValue(new ApiError('invalid parameters', 'http', 400))
+    const store = useKeyStore()
+
+    await store.generate()
+
+    expect(store.generateStatus).toBe('error')
+    expect(store.generateErrorMessage).toBe('invalid parameters')
+    expect(store.generatedKey).toBeNull()
+  })
+
+  it('sets generateErrorCode to network and leaves generateErrorMessage null on a network failure', async () => {
+    vi.mocked(postJson).mockRejectedValue(new ApiError('Network error: unable to reach the server', 'network'))
+    const store = useKeyStore()
+
+    await store.generate()
+
+    expect(store.generateStatus).toBe('error')
+    expect(store.generateErrorCode).toBe('network')
+    expect(store.generateErrorMessage).toBeNull()
+  })
+
+  it('clears the previous generated key when a new generate is dispatched, without touching parse state', async () => {
+    vi.mocked(postJson).mockResolvedValue(MOCK_KEY_GENERATE_RESPONSE)
+    vi.mocked(getJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
+    const store = useKeyStore()
+    await store.generate()
+    store.keyInput = 'HR1·a1b2'
+    await store.parse()
+    expect(store.parsedParams).toEqual(MOCK_KEY_PARSE_RESPONSE)
+
+    vi.mocked(postJson).mockReturnValue(new Promise(() => {}))
+    void store.generate()
+
+    expect(store.generatedKey).toBeNull()
+    expect(store.parsedParams).toEqual(MOCK_KEY_PARSE_RESPONSE)
+  })
+
+  it('calls getJson with the entered key when parse is dispatched', async () => {
+    vi.mocked(getJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
+    const store = useKeyStore()
+    store.keyInput = 'HR1·a1b2'
+
+    await store.parse()
+
+    expect(getJson).toHaveBeenCalledWith('/key/parse', { key: 'HR1·a1b2' })
+  })
+
+  it('sets parseStatus to loading while the parse request is in flight', () => {
+    vi.mocked(getJson).mockReturnValue(new Promise(() => {}))
+    const store = useKeyStore()
+    store.keyInput = 'HR1·a1b2'
+
+    void store.parse()
+
+    expect(store.parseStatus).toBe('loading')
+  })
+
+  it('stores the parsed params and sets parseStatus to success on a successful parse', async () => {
+    vi.mocked(getJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
+    const store = useKeyStore()
+    store.keyInput = 'HR1·a1b2'
+
+    await store.parse()
+
+    expect(store.parsedParams).toEqual(MOCK_KEY_PARSE_RESPONSE)
+    expect(store.parseStatus).toBe('success')
+    expect(store.parseErrorMessage).toBeNull()
+  })
+
+  it('stores the error message and sets parseStatus to error on a failed parse', async () => {
+    vi.mocked(getJson).mockRejectedValue(new ApiError('unsupported key version', 'http', 400))
+    const store = useKeyStore()
+    store.keyInput = 'HR9·zzzz'
+
+    await store.parse()
+
+    expect(store.parseStatus).toBe('error')
+    expect(store.parseErrorMessage).toBe('unsupported key version')
+    expect(store.parsedParams).toBeNull()
+  })
+
+  it('clears the previous parsed params when a new parse is dispatched, without touching generate state', async () => {
+    vi.mocked(getJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
+    vi.mocked(postJson).mockResolvedValue(MOCK_KEY_GENERATE_RESPONSE)
+    const store = useKeyStore()
+    store.keyInput = 'HR1·a1b2'
+    await store.parse()
+    await store.generate()
+    expect(store.generatedKey).toBe(MOCK_KEY_GENERATE_RESPONSE.key)
+
+    vi.mocked(getJson).mockReturnValue(new Promise(() => {}))
+    void store.parse()
+
+    expect(store.parsedParams).toBeNull()
+    expect(store.generatedKey).toBe(MOCK_KEY_GENERATE_RESPONSE.key)
+  })
+
+  it('restores default state when reset is called', async () => {
+    vi.mocked(postJson).mockResolvedValue(MOCK_KEY_GENERATE_RESPONSE)
+    vi.mocked(getJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
+    const store = useKeyStore()
+    await store.generate()
+    store.keyInput = 'HR1·a1b2'
+    await store.parse()
+
+    store.reset()
+
+    expect(store.generatedKey).toBeNull()
+    expect(store.generateStatus).toBe('idle')
+    expect(store.keyInput).toBe('')
+    expect(store.parsedParams).toBeNull()
+    expect(store.parseStatus).toBe('idle')
+  })
+})
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/stores/key.spec.ts`
+Expected: FAIL - `Cannot find module './key'` (the store doesn't exist yet).
+
+- [ ] **Step 4: Implement `useKeyStore`**
+
+Create `frontend/src/stores/key.ts`:
+
+```typescript
+import { defineStore } from 'pinia'
+import { postJson, getJson, ApiError } from '../api/client'
+import type { ReadingOrder } from '../constants/reading-orders'
+
+export type RotationDirection = 'cw' | 'ccw'
+export type KeyStatus = 'idle' | 'loading' | 'success' | 'error'
+
+/** Mirrors backend/src/api/key.service.ts's KeyParseResult. */
+export interface KeyParseResult {
+  pivotBlockSize: number
+  rotationSequence: number[]
+  rotationDirection: RotationDirection
+  readingOrder: string
+}
+
+interface KeyState {
+  pivotBlockSize: number
+  rotationSequence: number[]
+  rotationDirection: RotationDirection
+  readingOrder: ReadingOrder
+  generateStatus: KeyStatus
+  generatedKey: string | null
+  generateErrorMessage: string | null
+  generateErrorCode: 'network' | 'unknown' | null
+
+  keyInput: string
+  parseStatus: KeyStatus
+  parsedParams: KeyParseResult | null
+  parseErrorMessage: string | null
+  parseErrorCode: 'network' | 'unknown' | null
+}
+
+function initialState(): KeyState {
+  return {
+    pivotBlockSize: 5,
+    rotationSequence: [0, 1, 2, 3],
+    rotationDirection: 'cw',
+    readingOrder: 'LR-TB',
+    generateStatus: 'idle',
+    generatedKey: null,
+    generateErrorMessage: null,
+    generateErrorCode: null,
+
+    keyInput: '',
+    parseStatus: 'idle',
+    parsedParams: null,
+    parseErrorMessage: null,
+    parseErrorCode: null,
+  }
+}
+
+export const useKeyStore = defineStore('key', {
+  state: initialState,
+  actions: {
+    async generate(): Promise<void> {
+      this.generateStatus = 'loading'
+      this.generatedKey = null
+      this.generateErrorMessage = null
+      this.generateErrorCode = null
+
+      try {
+        const response = await postJson<{ key: string }>('/key/generate', {
+          pivotBlockSize: this.pivotBlockSize,
+          rotationSequence: this.rotationSequence,
+          rotationDirection: this.rotationDirection,
+          readingOrder: this.readingOrder,
+        })
+        this.generatedKey = response.key
+        this.generateStatus = 'success'
+      } catch (err) {
+        if (err instanceof ApiError && err.code === 'http') {
+          this.generateErrorMessage = err.message
+        } else if (err instanceof ApiError && err.code === 'network') {
+          this.generateErrorMessage = null
+          this.generateErrorCode = 'network'
+        } else {
+          this.generateErrorMessage = null
+          this.generateErrorCode = 'unknown'
+        }
+        this.generateStatus = 'error'
+      }
+    },
+    async parse(): Promise<void> {
+      this.parseStatus = 'loading'
+      this.parsedParams = null
+      this.parseErrorMessage = null
+      this.parseErrorCode = null
+
+      try {
+        this.parsedParams = await getJson<KeyParseResult>('/key/parse', { key: this.keyInput })
+        this.parseStatus = 'success'
+      } catch (err) {
+        if (err instanceof ApiError && err.code === 'http') {
+          this.parseErrorMessage = err.message
+        } else if (err instanceof ApiError && err.code === 'network') {
+          this.parseErrorMessage = null
+          this.parseErrorCode = 'network'
+        } else {
+          this.parseErrorMessage = null
+          this.parseErrorCode = 'unknown'
+        }
+        this.parseStatus = 'error'
+      }
+    },
+    reset(): void {
+      Object.assign(this, initialState())
+    },
+  },
+})
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/stores/key.spec.ts`
+Expected: PASS, all 13 tests green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/stores/key.ts frontend/src/stores/key.spec.ts frontend/src/__fixtures__/frontend.fixtures.ts
+git commit -m "feat(frontend): add the key store for generate and parse actions"
+```
+
+---
+
+### Task 2: `KeyGeneratorForm.vue`
+
+**Files:**
+- Create: `frontend/src/components/KeyGeneratorForm.vue`
+- Test: `frontend/src/components/KeyGeneratorForm.spec.ts`
+- Modify: `frontend/src/locales/en.json`
+
+**Interfaces:**
+- Consumes: `useKeyStore` from `../stores/key` (Task 1); `RotationSequencePicker.vue` from `./RotationSequencePicker.vue` (existing, unchanged - `modelValue: number[]` / `update:modelValue` emit); `READING_ORDERS` from `../constants/reading-orders` (existing, unchanged).
+- Produces: `KeyGeneratorForm.vue`, a self-contained component reading/writing `useKeyStore` directly (no props/emits) - rendered by Task 4's `KeyView.vue`.
+
+- [ ] **Step 1: Add the `key.generator.*` i18n entries**
+
+In `frontend/src/locales/en.json`, add a top-level `"key"` object (insert it after the existing `"decode"` object, before `"errors"`):
+
+```json
+  "key": {
+    "title": "Generate or parse a key",
+    "generator": {
+      "title": "Generate a key",
+      "form": {
+        "pivotBlockSize": {
+          "label": "Pivot block size"
+        },
+        "rotationSequence": {
+          "label": "Rotation sequence"
+        },
+        "rotationDirection": {
+          "label": "Rotation direction",
+          "cw": "Clockwise",
+          "ccw": "Counter-clockwise"
+        },
+        "readingOrder": {
+          "label": "Reading order"
+        },
+        "submit": {
+          "label": "Generate",
+          "loading": "Generating..."
+        }
+      },
+      "result": {
+        "keyLabel": "Key",
+        "copy": "Copy",
+        "copied": "Copied!",
+        "copyError": "Copy failed"
+      }
+    }
+  },
+```
+
+(The `"parser"` sub-object is added by Task 3, and `"key.title"` is used by Task 4 - both land inside this same `"key"` object; this step only adds `"generator"`, so the object is technically incomplete until Task 3 runs. This is fine: Task 2's own test only exercises `key.generator.*` keys.)
+
+- [ ] **Step 2: Write the failing component test**
+
+Create `frontend/src/components/KeyGeneratorForm.spec.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createI18n } from 'vue-i18n'
+import KeyGeneratorForm from './KeyGeneratorForm.vue'
+import en from '../locales/en.json'
+import { MOCK_KEY_GENERATE_RESPONSE } from '../__fixtures__/frontend.fixtures'
+import { ApiError } from '../api/client'
+
+vi.mock('../api/client', async () => {
+  const actual = await vi.importActual<typeof import('../api/client')>('../api/client')
+  return { ...actual, postJson: vi.fn() }
+})
+
+import { postJson } from '../api/client'
+
+function mountForm() {
+  const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
+  return mount(KeyGeneratorForm, {
+    global: { plugins: [createPinia(), i18n] },
+  })
+}
+
+describe('KeyGeneratorForm', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.mocked(postJson).mockReset()
+  })
+
+  it('renders all parameter controls', () => {
+    const wrapper = mountForm()
+    expect(wrapper.find('input[type="number"]').exists()).toBe(true)
+    expect(wrapper.find('.rotation-sequence-picker').exists()).toBe(true)
+    expect(wrapper.find('select[name="rotationDirection"]').exists()).toBe(true)
+    expect(wrapper.find('select[name="readingOrder"]').exists()).toBe(true)
+  })
+
+  it('renders the generate button', () => {
+    const wrapper = mountForm()
+    expect(wrapper.find('button[type="submit"]').exists()).toBe(true)
+  })
+
+  it('calls the key generate API with the current parameters when the generate button is clicked', async () => {
+    vi.mocked(postJson).mockResolvedValue(MOCK_KEY_GENERATE_RESPONSE)
+    const wrapper = mountForm()
+
+    await wrapper.find('input[type="number"]').setValue(7)
+    await wrapper.find('select[name="rotationDirection"]').setValue('ccw')
+    await wrapper.find('select[name="readingOrder"]').setValue('RL-TB')
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(postJson).toHaveBeenCalledWith('/key/generate', {
+      pivotBlockSize: 7,
+      rotationSequence: [0, 1, 2, 3],
+      rotationDirection: 'ccw',
+      readingOrder: 'RL-TB',
+    })
+  })
+
+  it('displays the returned HR key after a successful generate response', async () => {
+    vi.mocked(postJson).mockResolvedValue(MOCK_KEY_GENERATE_RESPONSE)
+    const wrapper = mountForm()
+
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain(MOCK_KEY_GENERATE_RESPONSE.key)
+  })
+
+  it('renders a copy-to-clipboard button next to the key', async () => {
+    vi.mocked(postJson).mockResolvedValue(MOCK_KEY_GENERATE_RESPONSE)
+    const wrapper = mountForm()
+
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(wrapper.find('.key-generator-form__result button').exists()).toBe(true)
+  })
+
+  it('provides visual feedback after a successful clipboard copy', async () => {
+    vi.mocked(postJson).mockResolvedValue(MOCK_KEY_GENERATE_RESPONSE)
+    Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } })
+    const wrapper = mountForm()
+
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+    await wrapper.find('.key-generator-form__result button').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('.key-generator-form__result button').text()).toBe(en.key.generator.result.copied)
+  })
+
+  it('displays an error when the generate API call fails', async () => {
+    vi.mocked(postJson).mockRejectedValue(new ApiError('invalid parameters', 'http', 400))
+    const wrapper = mountForm()
+
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('invalid parameters')
+  })
+})
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/components/KeyGeneratorForm.spec.ts`
+Expected: FAIL - `Failed to resolve import "./KeyGeneratorForm.vue"`.
+
+- [ ] **Step 4: Implement `KeyGeneratorForm.vue`**
+
+Create `frontend/src/components/KeyGeneratorForm.vue`:
+
+```vue
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useKeyStore } from '../stores/key'
+import { READING_ORDERS } from '../constants/reading-orders'
+import RotationSequencePicker from './RotationSequencePicker.vue'
+
+const store = useKeyStore()
+const { t } = useI18n()
+
+const canGenerate = computed(() => {
+  if (store.generateStatus === 'loading') return false
+  return Number.isInteger(store.pivotBlockSize) && store.pivotBlockSize >= 1 && store.pivotBlockSize <= 255
+})
+
+function handleGenerate(): void {
+  if (!canGenerate.value) return
+  void store.generate()
+}
+
+const copyState = ref<'idle' | 'copied' | 'error'>('idle')
+
+async function copyKey(): Promise<void> {
+  if (!store.generatedKey) return
+  try {
+    await navigator.clipboard.writeText(store.generatedKey)
+    copyState.value = 'copied'
+  } catch {
+    copyState.value = 'error'
+  }
+  setTimeout(() => {
+    copyState.value = 'idle'
+  }, 2000)
+}
+</script>
+
+<template>
+  <form
+    class="key-generator-form"
+    @submit.prevent="handleGenerate"
+  >
+    <h2>{{ t('key.generator.title') }}</h2>
+
+    <label class="key-generator-form__field">
+      {{ t('key.generator.form.pivotBlockSize.label') }}
+      <input
+        v-model.number="store.pivotBlockSize"
+        type="number"
+        min="1"
+        max="255"
+      >
+    </label>
+
+    <div class="key-generator-form__field">
+      {{ t('key.generator.form.rotationSequence.label') }}
+      <RotationSequencePicker v-model="store.rotationSequence" />
+    </div>
+
+    <label class="key-generator-form__field">
+      {{ t('key.generator.form.rotationDirection.label') }}
+      <select
+        v-model="store.rotationDirection"
+        name="rotationDirection"
+      >
+        <option value="cw">{{ t('key.generator.form.rotationDirection.cw') }}</option>
+        <option value="ccw">{{ t('key.generator.form.rotationDirection.ccw') }}</option>
+      </select>
+    </label>
+
+    <label class="key-generator-form__field">
+      {{ t('key.generator.form.readingOrder.label') }}
+      <select
+        v-model="store.readingOrder"
+        name="readingOrder"
+      >
+        <option
+          v-for="order in READING_ORDERS"
+          :key="order"
+          :value="order"
+        >{{ order }}</option>
+      </select>
+    </label>
+
+    <button
+      type="submit"
+      :disabled="!canGenerate"
+    >
+      {{ store.generateStatus === 'loading' ? t('key.generator.form.submit.loading') : t('key.generator.form.submit.label') }}
+    </button>
+
+    <p
+      v-if="store.generateStatus === 'error'"
+      class="key-generator-form__error"
+      role="alert"
+    >
+      {{ store.generateErrorMessage ?? t(`errors.${store.generateErrorCode}`) }}
+    </p>
+
+    <div
+      v-if="store.generateStatus === 'success' && store.generatedKey"
+      class="key-generator-form__result"
+    >
+      <span>{{ t('key.generator.result.keyLabel') }}: <code>{{ store.generatedKey }}</code></span>
+      <button
+        type="button"
+        @click="copyKey"
+      >
+        {{ copyState === 'copied' ? t('key.generator.result.copied') : copyState === 'error' ? t('key.generator.result.copyError') : t('key.generator.result.copy') }}
+      </button>
+    </div>
+  </form>
+</template>
+
+<style scoped>
+.key-generator-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 480px;
+}
+
+.key-generator-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.key-generator-form__error {
+  color: #c0392b;
+}
+
+.key-generator-form__result {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+</style>
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/components/KeyGeneratorForm.spec.ts`
+Expected: PASS, all 7 tests green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/KeyGeneratorForm.vue frontend/src/components/KeyGeneratorForm.spec.ts frontend/src/locales/en.json
+git commit -m "feat(frontend): add the key generator form"
+```
+
+---
+
+### Task 3: `KeyParserForm.vue`
+
+**Files:**
+- Create: `frontend/src/components/KeyParserForm.vue`
+- Test: `frontend/src/components/KeyParserForm.spec.ts`
+- Modify: `frontend/src/locales/en.json`
+
+**Interfaces:**
+- Consumes: `useKeyStore` from `../stores/key` (Task 1); `isValidKeyFormat` from `../utils/key-format` (existing, unchanged).
+- Produces: `KeyParserForm.vue`, a self-contained component reading/writing `useKeyStore` directly - rendered by Task 4's `KeyView.vue`.
+
+- [ ] **Step 1: Add the `key.parser.*` i18n entries**
+
+In `frontend/src/locales/en.json`, inside the `"key"` object added by Task 2 (as a sibling of `"generator"`, after its closing brace):
+
+```json
+    "parser": {
+      "title": "Parse a key",
+      "form": {
+        "key": {
+          "label": "HexaRot key",
+          "placeholder": "HR1·xxxx",
+          "formatError": "This does not look like a valid HexaRot key."
+        },
+        "submit": {
+          "label": "Parse",
+          "loading": "Parsing..."
+        }
+      },
+      "result": {
+        "pivotBlockSize": "Pivot block size",
+        "rotationSequence": "Rotation sequence",
+        "rotationDirection": "Rotation direction",
+        "readingOrder": "Reading order"
+      }
+    }
+```
+
+- [ ] **Step 2: Write the failing component test**
+
+Create `frontend/src/components/KeyParserForm.spec.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createI18n } from 'vue-i18n'
+import KeyParserForm from './KeyParserForm.vue'
+import en from '../locales/en.json'
+import { MOCK_KEY_PARSE_RESPONSE, MALFORMED_KEY } from '../__fixtures__/frontend.fixtures'
+import { ApiError } from '../api/client'
+
+vi.mock('../api/client', async () => {
+  const actual = await vi.importActual<typeof import('../api/client')>('../api/client')
+  return { ...actual, getJson: vi.fn() }
+})
+
+import { getJson } from '../api/client'
+
+function mountForm() {
+  const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
+  return mount(KeyParserForm, {
+    global: { plugins: [createPinia(), i18n] },
+  })
+}
+
+describe('KeyParserForm', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.mocked(getJson).mockReset()
+  })
+
+  it('renders the key input field', () => {
+    const wrapper = mountForm()
+    expect(wrapper.find('input[type="text"]').exists()).toBe(true)
+  })
+
+  it('renders the parse button', () => {
+    const wrapper = mountForm()
+    expect(wrapper.find('button[type="submit"]').exists()).toBe(true)
+  })
+
+  it('calls the key parse API with the entered key when the parse button is clicked', async () => {
+    vi.mocked(getJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
+    const wrapper = mountForm()
+
+    await wrapper.find('input[type="text"]').setValue('HR1·a1b2')
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(getJson).toHaveBeenCalledWith('/key/parse', { key: 'HR1·a1b2' })
+  })
+
+  it('displays all decoded parameters after a successful parse response', async () => {
+    vi.mocked(getJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
+    const wrapper = mountForm()
+
+    await wrapper.find('input[type="text"]').setValue('HR1·a1b2')
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain(String(MOCK_KEY_PARSE_RESPONSE.pivotBlockSize))
+    expect(wrapper.text()).toContain('0°, 90°, 180°, 270°')
+    expect(wrapper.text()).toContain(MOCK_KEY_PARSE_RESPONSE.rotationDirection)
+    expect(wrapper.text()).toContain(MOCK_KEY_PARSE_RESPONSE.readingOrder)
+  })
+
+  it('displays a clear error message for a malformed key without calling the API', async () => {
+    const wrapper = mountForm()
+
+    await wrapper.find('input[type="text"]').setValue(MALFORMED_KEY)
+
+    expect(wrapper.find('.key-parser-form__error').exists()).toBe(true)
+    expect(wrapper.find('button[type="submit"]').attributes('disabled')).toBeDefined()
+    expect(getJson).not.toHaveBeenCalled()
+  })
+
+  it('displays a clear error message when the API returns 400', async () => {
+    vi.mocked(getJson).mockRejectedValue(new ApiError('unsupported key version', 'http', 400))
+    const wrapper = mountForm()
+
+    await wrapper.find('input[type="text"]').setValue('HR9·zzzz')
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('unsupported key version')
+  })
+})
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/components/KeyParserForm.spec.ts`
+Expected: FAIL - `Failed to resolve import "./KeyParserForm.vue"`.
+
+- [ ] **Step 4: Implement `KeyParserForm.vue`**
+
+Create `frontend/src/components/KeyParserForm.vue`:
+
+```vue
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useKeyStore } from '../stores/key'
+import { isValidKeyFormat } from '../utils/key-format'
+
+const store = useKeyStore()
+const { t } = useI18n()
+
+const keyFormatError = computed(() => {
+  if (store.keyInput.length === 0) return null
+  return isValidKeyFormat(store.keyInput) ? null : t('key.parser.form.key.formatError')
+})
+
+const canParse = computed(() => {
+  if (store.parseStatus === 'loading') return false
+  return store.keyInput.length > 0 && keyFormatError.value === null
+})
+
+function handleParse(): void {
+  if (!canParse.value) return
+  void store.parse()
+}
+</script>
+
+<template>
+  <form
+    class="key-parser-form"
+    @submit.prevent="handleParse"
+  >
+    <h2>{{ t('key.parser.title') }}</h2>
+
+    <label class="key-parser-form__field">
+      {{ t('key.parser.form.key.label') }}
+      <input
+        v-model="store.keyInput"
+        type="text"
+        :placeholder="t('key.parser.form.key.placeholder')"
+      >
+    </label>
+    <p
+      v-if="keyFormatError"
+      class="key-parser-form__error"
+      role="alert"
+    >
+      {{ keyFormatError }}
+    </p>
+
+    <button
+      type="submit"
+      :disabled="!canParse"
+    >
+      {{ store.parseStatus === 'loading' ? t('key.parser.form.submit.loading') : t('key.parser.form.submit.label') }}
+    </button>
+
+    <p
+      v-if="store.parseStatus === 'error'"
+      class="key-parser-form__error"
+      role="alert"
+    >
+      {{ store.parseErrorMessage ?? t(`errors.${store.parseErrorCode}`) }}
+    </p>
+
+    <dl
+      v-if="store.parseStatus === 'success' && store.parsedParams"
+      class="key-parser-form__result"
+    >
+      <dt>{{ t('key.parser.result.pivotBlockSize') }}</dt>
+      <dd>{{ store.parsedParams.pivotBlockSize }}</dd>
+
+      <dt>{{ t('key.parser.result.rotationSequence') }}</dt>
+      <dd>{{ store.parsedParams.rotationSequence.map((angle) => `${angle}°`).join(', ') }}</dd>
+
+      <dt>{{ t('key.parser.result.rotationDirection') }}</dt>
+      <dd>{{ store.parsedParams.rotationDirection }}</dd>
+
+      <dt>{{ t('key.parser.result.readingOrder') }}</dt>
+      <dd>{{ store.parsedParams.readingOrder }}</dd>
+    </dl>
+  </form>
+</template>
+
+<style scoped>
+.key-parser-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 480px;
+}
+
+.key-parser-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.key-parser-form__error {
+  color: #c0392b;
+}
+
+.key-parser-form__result {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 4px 12px;
+}
+
+.key-parser-form__result dt {
+  font-weight: 600;
+}
+</style>
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/components/KeyParserForm.spec.ts`
+Expected: PASS, all 6 tests green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/KeyParserForm.vue frontend/src/components/KeyParserForm.spec.ts frontend/src/locales/en.json
+git commit -m "feat(frontend): add the key parser form"
+```
+
+---
+
+### Task 4: `KeyView.vue` assembly, integration test, and docs
+
+**Files:**
+- Modify: `frontend/src/views/KeyView.vue`
+- Create: `frontend/src/views/KeyView.spec.ts`
+- Modify: `frontend/src/locales/en.json`
+- Modify: `README.md`
+- Modify: `README.fr.md`
+
+**Interfaces:**
+- Consumes: `useKeyStore` from `../stores/key` (Task 1); `KeyGeneratorForm.vue` (Task 2); `KeyParserForm.vue` (Task 3).
+- Produces: the completed `/key` route content. No later task consumes this one - it is the plan's last task.
+
+- [ ] **Step 1: Add the `key.title` i18n entry**
+
+In `frontend/src/locales/en.json`, inside the `"key"` object (as the first entry, a sibling of `"generator"` and `"parser"`):
+
+```json
+"title": "Generate or parse a key",
+```
+
+(Insert this as the first key inside the `"key"` object, so the full object reads `"key": { "title": "...", "generator": {...}, "parser": {...} }`.)
+
+- [ ] **Step 2: Write the failing integration test**
+
+Create `frontend/src/views/KeyView.spec.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createI18n } from 'vue-i18n'
+import KeyView from './KeyView.vue'
+import { useKeyStore } from '../stores/key'
+import en from '../locales/en.json'
+import { MOCK_KEY_GENERATE_RESPONSE, MOCK_KEY_PARSE_RESPONSE, MALFORMED_KEY } from '../__fixtures__/frontend.fixtures'
+import { ApiError } from '../api/client'
+
+vi.mock('../api/client', async () => {
+  const actual = await vi.importActual<typeof import('../api/client')>('../api/client')
+  return { ...actual, postJson: vi.fn(), getJson: vi.fn() }
+})
+
+import { postJson, getJson } from '../api/client'
+
+function mountView() {
+  const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
+  return mount(KeyView, {
+    global: { plugins: [createPinia(), i18n] },
+  })
+}
+
+describe('KeyView', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.mocked(postJson).mockReset()
+    vi.mocked(getJson).mockReset()
+  })
+
+  describe('key generator section', () => {
+    it('renders all parameter controls', () => {
+      const wrapper = mountView()
+      expect(wrapper.find('input[type="number"]').exists()).toBe(true)
+      expect(wrapper.find('select[name="rotationDirection"]').exists()).toBe(true)
+      expect(wrapper.find('select[name="readingOrder"]').exists()).toBe(true)
+    })
+
+    it('renders the generate button', () => {
+      const wrapper = mountView()
+      expect(wrapper.findAll('button[type="submit"]').length).toBe(2)
+    })
+
+    it('calls the key generate API when the generate button is clicked', async () => {
+      vi.mocked(postJson).mockResolvedValue(MOCK_KEY_GENERATE_RESPONSE)
+      const wrapper = mountView()
+
+      await wrapper.find('.key-generator-form').trigger('submit')
+      await flushPromises()
+
+      expect(postJson).toHaveBeenCalledWith('/key/generate', expect.any(Object))
+    })
+
+    it('displays the returned HR key after a successful generate response', async () => {
+      vi.mocked(postJson).mockResolvedValue(MOCK_KEY_GENERATE_RESPONSE)
+      const wrapper = mountView()
+
+      await wrapper.find('.key-generator-form').trigger('submit')
+      await flushPromises()
+
+      expect(wrapper.text()).toContain(MOCK_KEY_GENERATE_RESPONSE.key)
+    })
+
+    it('renders a copy-to-clipboard button next to the key', async () => {
+      vi.mocked(postJson).mockResolvedValue(MOCK_KEY_GENERATE_RESPONSE)
+      const wrapper = mountView()
+
+      await wrapper.find('.key-generator-form').trigger('submit')
+      await flushPromises()
+
+      expect(wrapper.find('.key-generator-form__result button').exists()).toBe(true)
+    })
+
+    it('provides visual feedback after clipboard copy', async () => {
+      vi.mocked(postJson).mockResolvedValue(MOCK_KEY_GENERATE_RESPONSE)
+      Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } })
+      const wrapper = mountView()
+
+      await wrapper.find('.key-generator-form').trigger('submit')
+      await flushPromises()
+      await wrapper.find('.key-generator-form__result button').trigger('click')
+      await flushPromises()
+
+      expect(wrapper.find('.key-generator-form__result button').text()).toBe(en.key.generator.result.copied)
+    })
+  })
+
+  describe('key parser section', () => {
+    it('renders the key input field', () => {
+      const wrapper = mountView()
+      expect(wrapper.find('.key-parser-form input[type="text"]').exists()).toBe(true)
+    })
+
+    it('renders the parse button', () => {
+      const wrapper = mountView()
+      expect(wrapper.find('.key-parser-form button[type="submit"]').exists()).toBe(true)
+    })
+
+    it('calls the key parse API when the parse button is clicked', async () => {
+      vi.mocked(getJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
+      const wrapper = mountView()
+
+      await wrapper.find('.key-parser-form input[type="text"]').setValue('HR1·a1b2')
+      await wrapper.find('.key-parser-form').trigger('submit')
+      await flushPromises()
+
+      expect(getJson).toHaveBeenCalledWith('/key/parse', { key: 'HR1·a1b2' })
+    })
+
+    it('displays all decoded parameters after a successful parse response', async () => {
+      vi.mocked(getJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
+      const wrapper = mountView()
+
+      await wrapper.find('.key-parser-form input[type="text"]').setValue('HR1·a1b2')
+      await wrapper.find('.key-parser-form').trigger('submit')
+      await flushPromises()
+
+      expect(wrapper.text()).toContain(String(MOCK_KEY_PARSE_RESPONSE.pivotBlockSize))
+    })
+
+    it('displays a clear error message for a malformed key (client-side validation)', async () => {
+      const wrapper = mountView()
+
+      await wrapper.find('.key-parser-form input[type="text"]').setValue(MALFORMED_KEY)
+
+      expect(wrapper.find('.key-parser-form__error').exists()).toBe(true)
+      expect(getJson).not.toHaveBeenCalled()
+    })
+
+    it('displays a clear error message when the API returns 400', async () => {
+      vi.mocked(getJson).mockRejectedValue(new ApiError('unsupported key version', 'http', 400))
+      const wrapper = mountView()
+
+      await wrapper.find('.key-parser-form input[type="text"]').setValue('HR9·zzzz')
+      await wrapper.find('.key-parser-form').trigger('submit')
+      await flushPromises()
+
+      expect(wrapper.text()).toContain('unsupported key version')
+    })
+  })
+
+  describe('unmount', () => {
+    it('resets the store when the view unmounts', async () => {
+      vi.mocked(postJson).mockResolvedValue(MOCK_KEY_GENERATE_RESPONSE)
+      const wrapper = mountView()
+
+      await wrapper.find('.key-generator-form').trigger('submit')
+      await flushPromises()
+
+      const store = useKeyStore()
+      expect(store.generatedKey).toBe(MOCK_KEY_GENERATE_RESPONSE.key)
+
+      wrapper.unmount()
+
+      expect(store.generatedKey).toBeNull()
+      expect(store.generateStatus).toBe('idle')
+    })
+  })
+
+  describe('i18n', () => {
+    it('renders no raw string literals - the generate button text comes from the locale file', () => {
+      const wrapper = mountView()
+      expect(wrapper.find('.key-generator-form button[type="submit"]').text()).toBe(en.key.generator.form.submit.label)
+    })
+  })
+})
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/views/KeyView.spec.ts`
+Expected: FAIL - the stub `KeyView.vue` renders none of the expected controls.
+
+- [ ] **Step 4: Implement `KeyView.vue`**
+
+Replace the full contents of `frontend/src/views/KeyView.vue`:
+
+```vue
+<script setup lang="ts">
+import { onUnmounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useKeyStore } from '../stores/key'
+import KeyGeneratorForm from '../components/KeyGeneratorForm.vue'
+import KeyParserForm from '../components/KeyParserForm.vue'
+
+const store = useKeyStore()
+const { t } = useI18n()
+
+onUnmounted(() => {
+  store.reset()
+})
+</script>
+
+<template>
+  <div class="key-view">
+    <h1>{{ t('key.title') }}</h1>
+    <KeyGeneratorForm />
+    <KeyParserForm />
+  </div>
+</template>
+
+<style scoped>
+.key-view {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+</style>
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/views/KeyView.spec.ts`
+Expected: PASS, all 14 tests green.
+
+- [ ] **Step 6: Run the full frontend suite**
+
+Run: `cd frontend && npm run test -- --run`
+Expected: PASS, all test files green (the pre-existing 92 plus this plan's new ones).
+
+- [ ] **Step 7: Run typecheck, lint, and build**
+
+Run: `cd frontend && npx vue-tsc -b && npm run lint && npm run build`
+Expected: all three succeed with no errors.
+
+- [ ] **Step 8: Update the roadmap in both READMEs**
+
+In `README.md`, replace:
+
+```
+- 🔄 Frontend (encode view, decode view done; key view still open)
+```
+
+with:
+
+```
+- ✅ Frontend (encode, decode, key views all done)
+```
+
+In `README.fr.md`, replace:
+
+```
+- 🔄 Frontend (vue encodage, vue décodage terminées ; vue clé restante)
+```
+
+with:
+
+```
+- ✅ Frontend (vues encodage, décodage, clé toutes terminées)
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add frontend/src/views/KeyView.vue frontend/src/views/KeyView.spec.ts frontend/src/locales/en.json README.md README.fr.md
+git commit -m "feat(frontend): assemble the key view and wire it into the router"
+```
+
+---
+
+## Post-plan: BACKLOG.md status
+
+After all four tasks pass their reviews (handled by the executing skill, not a plan step): flip FEAT-016's `status` in `BACKLOG.md` from `ready` to `done` inside this same branch, per this project's standing rule that backlog status changes land in the feature PR, not via a direct push to main.

--- a/docs/superpowers/specs/2026-08-19-feat-016-key-view-design.md
+++ b/docs/superpowers/specs/2026-08-19-feat-016-key-view-design.md
@@ -1,0 +1,219 @@
+# FEAT-016 Key View Design Spec
+
+**Status:** Approved by the user (2026-08-19), ready for writing-plans.
+
+**Backlog item:** FEAT-016, `status: ready`, `depends-on: FEAT-013` (done), `domain: frontend`, `complexity: S`.
+
+## Context
+
+FEAT-016 is the third and last of the three V1 frontend views. It reuses all
+shared infrastructure built in FEAT-014 and confirmed unchanged by FEAT-015:
+`vue-router` already routes `/key` to `KeyView.vue` (currently a 3-line
+stub), `src/api/client.ts`'s `postJson`/`getJson`/`ApiError` need no changes,
+and `useKeyStore` follows the store-per-view shape established by
+`useEncodeStore`/`useDecodeStore`. `isValidKeyFormat`
+(`src/utils/key-format.ts`) and `RotationSequencePicker.vue` (both built
+during FEAT-014) are reused verbatim.
+
+The backend endpoints this view consumes are complete (FEAT-013):
+
+- `POST /api/key/generate` (`backend/src/api/key.controller.ts`): body is
+  `KeyGenerateRequestDto` - every field independently optional
+  (`pivotBlockSize?: number`, `rotationSequence?: number[]` as **permutation
+  indices 0-3**, `rotationDirection?: 'cw'|'ccw'`, `readingOrder?: string`).
+  Response: `{ key: string }`.
+- `GET /api/key/parse?key=...` (`KeyParseQueryDto`): response is
+  `KeyParseResult` - `{ pivotBlockSize: number, rotationSequence: number[]`
+  (**already converted to degrees**, e.g. `[0, 90, 180, 270]`, unlike the
+  generate endpoint's indices)`, rotationDirection: 'cw'|'ccw', readingOrder:
+  string }`. A malformed or invalid key throws `BadRequestException` (400).
+
+The view has two independent sections: a key generator (parameters in, key
+out) and a key parser (key in, parameters out). Confirmed with the user: each
+section gets its own child component (`KeyGeneratorForm.vue`,
+`KeyParserForm.vue`), matching FEAT-014's form/result split rather than one
+large `KeyView.vue`.
+
+## Architecture
+
+- `frontend/src/stores/key.ts` (`useKeyStore`): two independent state slices
+  in one store, so generating and parsing never interfere with each other's
+  status/result/error - each mirrors `useEncodeStore`'s post-FEAT-014-review
+  error shape exactly (`errorMessage: string | null`,
+  `errorCode: 'network' | 'unknown' | null`).
+
+  ```typescript
+  export type RotationDirection = 'cw' | 'ccw'
+  export type KeyStatus = 'idle' | 'loading' | 'success' | 'error'
+
+  /** Mirrors backend/src/api/key.service.ts's KeyParseResult. */
+  export interface KeyParseResult {
+    pivotBlockSize: number
+    rotationSequence: number[] // degrees, e.g. [0, 90, 180, 270]
+    rotationDirection: RotationDirection
+    readingOrder: string
+  }
+
+  interface KeyState {
+    // Generator
+    pivotBlockSize: number
+    rotationSequence: number[] // permutation indices 0-3, e.g. [0, 1, 2, 3]
+    rotationDirection: RotationDirection
+    readingOrder: ReadingOrder
+    generateStatus: KeyStatus
+    generatedKey: string | null
+    generateErrorMessage: string | null
+    generateErrorCode: 'network' | 'unknown' | null
+
+    // Parser
+    keyInput: string
+    parseStatus: KeyStatus
+    parsedParams: KeyParseResult | null
+    parseErrorMessage: string | null
+    parseErrorCode: 'network' | 'unknown' | null
+  }
+  ```
+
+  Defaults for the generator fields match `useEncodeStore`'s initial state
+  (`pivotBlockSize: 5`, `rotationSequence: [0, 1, 2, 3]`,
+  `rotationDirection: 'cw'`, `readingOrder: 'LR-TB'`) for consistency across
+  views. `keyInput` defaults to `''`.
+
+  Actions:
+  - `generate()`: sets `generateStatus = 'loading'`, `generatedKey = null`,
+    clears prior generate error fields; calls
+    `postJson<{ key: string }>('/key/generate', { pivotBlockSize,
+    rotationSequence, rotationDirection, readingOrder })`; on success sets
+    `generatedKey = response.key`, `generateStatus = 'success'`; on failure
+    follows the same `ApiError.code === 'http' | 'network'` branching as
+    `useEncodeStore.submit()`, `generateStatus = 'error'`.
+  - `parse()`: sets `parseStatus = 'loading'`, `parsedParams = null`, clears
+    prior parse error fields; calls `getJson<KeyParseResult>('/key/parse', {
+    key: keyInput })`; on success sets `parsedParams = response`,
+    `parseStatus = 'success'`; on failure same `ApiError` branching,
+    `parseStatus = 'error'`. Client-side format validation
+    (`isValidKeyFormat`) is not the store's job - the component's
+    `canSubmit`/equivalent computed blocks the call before `parse()` is
+    ever invoked, same separation of concerns as `EncodeParamsForm`'s key
+    mode.
+  - `reset()`: `Object.assign(this, initialState())`, used from
+    `KeyView.vue`'s `onUnmounted` (same pattern as `DecodeView.vue`).
+
+- `frontend/src/components/KeyGeneratorForm.vue`: renders `pivotBlockSize`
+  (number input, min 1 max 255), `RotationSequencePicker` bound to
+  `store.rotationSequence` (same component, same `number[]` index shape -
+  no adaptation needed), `rotationDirection` select, `readingOrder` select
+  (`READING_ORDERS` from `constants/reading-orders.ts`), and a "Generate"
+  button (disabled while `generateStatus === 'loading'` or
+  `pivotBlockSize` is out of `[1, 255]` - mirrors `EncodeParamsForm`'s
+  `canSubmit` bound check). On success, displays `store.generatedKey` in a
+  `<code>` element next to a copy button reusing `EncodeResultPanel.vue`'s
+  `copyKey`/`copyState` (`'idle' | 'copied' | 'error'`) pattern exactly -
+  `navigator.clipboard.writeText`, 2-second auto-reset to `'idle'`. On
+  error, displays `generateErrorMessage ?? t('errors.network'/'errors.unknown')`
+  depending on `generateErrorCode`.
+
+- `frontend/src/components/KeyParserForm.vue`: renders a text input bound to
+  `store.keyInput`, a "Parse" button, and the parsed result once available.
+  Client-side format check via `isValidKeyFormat(store.keyInput)`
+  (identical reuse to `EncodeParamsForm`'s key-mode check) - if it fails,
+  shows an inline `role="alert"` error and the button click does not call
+  `store.parse()`. If the client-side check passes but the backend still
+  rejects the key (400 - e.g. bad checksum, unsupported version),
+  `parseErrorMessage` displays the backend's own message verbatim (same
+  `ApiError.code === 'http'` handling as everywhere else). On success,
+  renders `parsedParams.pivotBlockSize`, each `rotationSequence` entry as
+  `N°` (already in degrees from the backend - no conversion needed, unlike
+  the generator's index-based input), `parsedParams.rotationDirection`, and
+  `parsedParams.readingOrder` as a labeled list.
+
+- `frontend/src/views/KeyView.vue`: renders `KeyGeneratorForm` and
+  `KeyParserForm` with section headings, no logic of its own beyond
+  `onUnmounted(() => store.reset())` (matching `DecodeView.vue`'s
+  established pattern) - replaces the current 3-line stub.
+
+## Error handling
+
+- **Client-side key format check (parser only)**: same `isValidKeyFormat`
+  reuse as `EncodeParamsForm`'s key mode and `DecodeParamsForm`'s key field,
+  checked before `store.parse()` is called - inline error in
+  `KeyParserForm`, i18n key `key.parser.form.key.formatError`.
+- **Client-side range check (generator only)**: `pivotBlockSize` bounds
+  `[1, 255]` disable the Generate button, same pattern as
+  `EncodeParamsForm.canSubmit`. No separate error message needed - the
+  `<input type="number" min="1" max="255">` constraints plus a disabled
+  button are sufficient, matching the existing Encode form's treatment of
+  the same field.
+- **Backend errors and network failures**: normalized through `ApiError`
+  (`code: 'http' | 'network'`) exactly as `useEncodeStore`/`useDecodeStore`
+  do - HTTP-coded errors keep the backend's own message verbatim,
+  network/unknown errors resolve through the existing shared
+  `errors.network`/`errors.unknown` i18n keys (no new keys needed for this
+  case).
+- **Loading state**: each section's own button disabled and a loading label
+  shown while its own `*Status === 'loading'` - the two sections never share
+  a loading state, since they're independent actions.
+
+## Testing strategy
+
+Follows the contract already written in `docs/tests/frontend.md` §5
+(`KeyView`) and §6 (`useKeyStore`) exactly - this section covers the
+mechanics, not a restatement of every assertion:
+
+- `frontend/src/stores/key.spec.ts`: mirrors `encode.spec.ts`/`decode.spec.ts`
+  - `generate()` and `parse()` tested independently (status transitions,
+    stored result, stored error, previous-result clearing on a new
+    dispatch of the *same* action - verifying the *other* section's state
+    is untouched). `postJson`/`getJson` mocked via `vi.mock('../api/client')`.
+- `frontend/src/components/KeyGeneratorForm.spec.ts`: renders all controls
+  with explicit `name="..."` selectors (lesson carried from FEAT-014's
+  final review - ambiguous `'select'` selectors silently matched the wrong
+  element), triggers `store.generate()` on click, displays the returned key
+  and copy button, displays the error state.
+- `frontend/src/components/KeyParserForm.spec.ts`: renders the key input
+  and Parse button, blocks submission and shows the inline error for
+  `MALFORMED_KEY` without calling `store.parse()`, displays all decoded
+  fields on success, displays the API error message on a 400 response.
+- `frontend/src/views/KeyView.spec.ts`: integration test assembling both
+  child components with a real Pinia store and mocked `api/client.ts`,
+  covering `docs/tests/frontend.md` §5-6 in full, plus the i18n check (no
+  raw string literals outside the locale file) and `onUnmounted` calling
+  `store.reset()` (mirrors `DecodeView.spec.ts`'s equivalent test).
+- Fixtures added to the existing shared `src/__fixtures__/frontend.fixtures.ts`:
+  `MOCK_KEY_GENERATE_RESPONSE`, `MOCK_KEY_PARSE_RESPONSE`, `MALFORMED_KEY` -
+  the three named in `docs/tests/frontend.md`'s Fixtures section.
+- House rule carried over: no bare `for`/`while`/`if` in test bodies, use
+  `it.each` for parameterized cases.
+- Real functional test after implementation (per
+  `feedback_functional_test_per_feat.md`): `docker-compose up` against a
+  real backend, generate a key through the UI, then paste that exact key
+  into the parser and verify the round-trip reproduces the same parameters
+  that were submitted to the generator.
+
+## i18n
+
+Every user-visible string routes through a `vue-i18n` key under a `key.*`
+namespace in `src/locales/en.json`, mirroring `encode.*`/`decode.*`'s
+structure: `key.generator.title`, `key.generator.form.*`,
+`key.generator.result.*` (`copy`/`copied`/`copyError`, matching
+`encode.result.copy*` verbatim), `key.parser.title`, `key.parser.form.*`,
+`key.parser.result.*`. The existing `nav.key: "Key"` entry is already in
+place from FEAT-014 and needs no change. Network/unknown error messages
+reuse the existing shared `errors.network`/`errors.unknown` keys - no new
+keys for that case.
+
+## Explicitly out of scope for this feature
+
+- Auto-parsing as the user types in the parser's key field - the test
+  contract specifies a button click triggers the parse call; no debounced
+  live-parse.
+- Any persistence of generated/parsed history (e.g. a list of previously
+  generated keys) - not required by the backlog's acceptance criteria.
+- Visual design/styling polish - REFACTOR-001, same carve-out as
+  FEAT-014/015.
+- French interface - FEAT-020, same carve-out as FEAT-014/015.
+- Any change to `EncodeView.vue`/`DecodeView.vue` beyond none - this
+  feature touches neither.
+- The Express body-size limit bug (`project_backend_body_size_limit.md`) -
+  unrelated to this feature (that bug affects `/decode` payload size, not
+  `/key/generate` or `/key/parse`, both of which have tiny payloads).

--- a/frontend/src/__fixtures__/frontend.fixtures.ts
+++ b/frontend/src/__fixtures__/frontend.fixtures.ts
@@ -9,7 +9,7 @@ export const TINY_PNG_BASE64 =
 export const MOCK_ENCODE_RESPONSE: EncodeResult = {
   png: TINY_PNG_BASE64,
   svg: '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"><rect width="10" height="10" fill="#000"/></svg>',
-  key: 'HR1·a1b2',
+  key: 'HR1·A1B2',
   warnings: [],
   unknownChars: [],
 }
@@ -42,7 +42,7 @@ export const MOCK_DECODE_RESPONSE = {
 }
 
 export const MOCK_KEY_GENERATE_RESPONSE = {
-  key: 'HR1·c3d4',
+  key: 'HR1·035X',
 }
 
 export const MOCK_KEY_PARSE_RESPONSE = {

--- a/frontend/src/__fixtures__/frontend.fixtures.ts
+++ b/frontend/src/__fixtures__/frontend.fixtures.ts
@@ -40,3 +40,14 @@ export const MOCK_SVG_FILE = new File([SVG_CRYPTOGRAM_CONTENT], 'cryptogram.svg'
 export const MOCK_DECODE_RESPONSE = {
   message: 'HELLO WORLD',
 }
+
+export const MOCK_KEY_GENERATE_RESPONSE = {
+  key: 'HR1·c3d4',
+}
+
+export const MOCK_KEY_PARSE_RESPONSE = {
+  pivotBlockSize: 5,
+  rotationSequence: [0, 90, 180, 270],
+  rotationDirection: 'cw' as const,
+  readingOrder: 'LR-TB',
+}

--- a/frontend/src/components/KeyGeneratorForm.spec.ts
+++ b/frontend/src/components/KeyGeneratorForm.spec.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createI18n } from 'vue-i18n'
+import KeyGeneratorForm from './KeyGeneratorForm.vue'
+import en from '../locales/en.json'
+import { MOCK_KEY_GENERATE_RESPONSE } from '../__fixtures__/frontend.fixtures'
+import { ApiError } from '../api/client'
+
+vi.mock('../api/client', async () => {
+  const actual = await vi.importActual<typeof import('../api/client')>('../api/client')
+  return { ...actual, postJson: vi.fn() }
+})
+
+import { postJson } from '../api/client'
+
+function mountForm() {
+  const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
+  return mount(KeyGeneratorForm, {
+    global: { plugins: [createPinia(), i18n] },
+  })
+}
+
+describe('KeyGeneratorForm', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.mocked(postJson).mockReset()
+  })
+
+  it('renders all parameter controls', () => {
+    const wrapper = mountForm()
+    expect(wrapper.find('input[type="number"]').exists()).toBe(true)
+    expect(wrapper.find('.rotation-sequence-picker').exists()).toBe(true)
+    expect(wrapper.find('select[name="rotationDirection"]').exists()).toBe(true)
+    expect(wrapper.find('select[name="readingOrder"]').exists()).toBe(true)
+  })
+
+  it('renders the generate button', () => {
+    const wrapper = mountForm()
+    expect(wrapper.find('button[type="submit"]').exists()).toBe(true)
+  })
+
+  it('calls the key generate API with the current parameters when the generate button is clicked', async () => {
+    vi.mocked(postJson).mockResolvedValue(MOCK_KEY_GENERATE_RESPONSE)
+    const wrapper = mountForm()
+
+    await wrapper.find('input[type="number"]').setValue(7)
+    await wrapper.find('select[name="rotationDirection"]').setValue('ccw')
+    await wrapper.find('select[name="readingOrder"]').setValue('RL-TB')
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(postJson).toHaveBeenCalledWith('/key/generate', {
+      pivotBlockSize: 7,
+      rotationSequence: [0, 1, 2, 3],
+      rotationDirection: 'ccw',
+      readingOrder: 'RL-TB',
+    })
+  })
+
+  it('displays the returned HR key after a successful generate response', async () => {
+    vi.mocked(postJson).mockResolvedValue(MOCK_KEY_GENERATE_RESPONSE)
+    const wrapper = mountForm()
+
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain(MOCK_KEY_GENERATE_RESPONSE.key)
+  })
+
+  it('renders a copy-to-clipboard button next to the key', async () => {
+    vi.mocked(postJson).mockResolvedValue(MOCK_KEY_GENERATE_RESPONSE)
+    const wrapper = mountForm()
+
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(wrapper.find('.key-generator-form__result button').exists()).toBe(true)
+  })
+
+  it('provides visual feedback after a successful clipboard copy', async () => {
+    vi.mocked(postJson).mockResolvedValue(MOCK_KEY_GENERATE_RESPONSE)
+    Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } })
+    const wrapper = mountForm()
+
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+    await wrapper.find('.key-generator-form__result button').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('.key-generator-form__result button').text()).toBe(en.key.generator.result.copied)
+  })
+
+  it('displays an error when the generate API call fails', async () => {
+    vi.mocked(postJson).mockRejectedValue(new ApiError('invalid parameters', 'http', 400))
+    const wrapper = mountForm()
+
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('invalid parameters')
+  })
+})

--- a/frontend/src/components/KeyGeneratorForm.vue
+++ b/frontend/src/components/KeyGeneratorForm.vue
@@ -1,0 +1,137 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useKeyStore } from '../stores/key'
+import { READING_ORDERS } from '../constants/reading-orders'
+import RotationSequencePicker from './RotationSequencePicker.vue'
+
+const store = useKeyStore()
+const { t } = useI18n()
+
+const canGenerate = computed(() => {
+  if (store.generateStatus === 'loading') return false
+  return Number.isInteger(store.pivotBlockSize) && store.pivotBlockSize >= 1 && store.pivotBlockSize <= 255
+})
+
+function handleGenerate(): void {
+  if (!canGenerate.value) return
+  void store.generate()
+}
+
+const copyState = ref<'idle' | 'copied' | 'error'>('idle')
+
+async function copyKey(): Promise<void> {
+  if (!store.generatedKey) return
+  try {
+    await navigator.clipboard.writeText(store.generatedKey)
+    copyState.value = 'copied'
+  } catch {
+    copyState.value = 'error'
+  }
+  setTimeout(() => {
+    copyState.value = 'idle'
+  }, 2000)
+}
+</script>
+
+<template>
+  <form
+    class="key-generator-form"
+    @submit.prevent="handleGenerate"
+  >
+    <h2>{{ t('key.generator.title') }}</h2>
+
+    <label class="key-generator-form__field">
+      {{ t('key.generator.form.pivotBlockSize.label') }}
+      <input
+        v-model.number="store.pivotBlockSize"
+        type="number"
+        min="1"
+        max="255"
+      >
+    </label>
+
+    <div class="key-generator-form__field">
+      {{ t('key.generator.form.rotationSequence.label') }}
+      <RotationSequencePicker v-model="store.rotationSequence" />
+    </div>
+
+    <label class="key-generator-form__field">
+      {{ t('key.generator.form.rotationDirection.label') }}
+      <select
+        v-model="store.rotationDirection"
+        name="rotationDirection"
+      >
+        <option value="cw">{{ t('key.generator.form.rotationDirection.cw') }}</option>
+        <option value="ccw">{{ t('key.generator.form.rotationDirection.ccw') }}</option>
+      </select>
+    </label>
+
+    <label class="key-generator-form__field">
+      {{ t('key.generator.form.readingOrder.label') }}
+      <select
+        v-model="store.readingOrder"
+        name="readingOrder"
+      >
+        <option
+          v-for="order in READING_ORDERS"
+          :key="order"
+          :value="order"
+        >{{ order }}</option>
+      </select>
+    </label>
+
+    <button
+      type="submit"
+      :disabled="!canGenerate"
+    >
+      {{ store.generateStatus === 'loading' ? t('key.generator.form.submit.loading') : t('key.generator.form.submit.label') }}
+    </button>
+
+    <p
+      v-if="store.generateStatus === 'error'"
+      class="key-generator-form__error"
+      role="alert"
+    >
+      {{ store.generateErrorMessage ?? t(`errors.${store.generateErrorCode}`) }}
+    </p>
+
+    <div
+      v-if="store.generateStatus === 'success' && store.generatedKey"
+      class="key-generator-form__result"
+    >
+      <span>{{ t('key.generator.result.keyLabel') }}: <code>{{ store.generatedKey }}</code></span>
+      <button
+        type="button"
+        @click="copyKey"
+      >
+        {{ copyState === 'copied' ? t('key.generator.result.copied') : copyState === 'error' ? t('key.generator.result.copyError') : t('key.generator.result.copy') }}
+      </button>
+    </div>
+  </form>
+</template>
+
+<style scoped>
+.key-generator-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 480px;
+}
+
+.key-generator-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.key-generator-form__error {
+  color: #c0392b;
+}
+
+.key-generator-form__result {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+</style>

--- a/frontend/src/components/KeyParserForm.spec.ts
+++ b/frontend/src/components/KeyParserForm.spec.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createI18n } from 'vue-i18n'
+import KeyParserForm from './KeyParserForm.vue'
+import en from '../locales/en.json'
+import { MOCK_KEY_PARSE_RESPONSE, MALFORMED_KEY } from '../__fixtures__/frontend.fixtures'
+import { ApiError } from '../api/client'
+
+vi.mock('../api/client', async () => {
+  const actual = await vi.importActual<typeof import('../api/client')>('../api/client')
+  return { ...actual, getJson: vi.fn() }
+})
+
+import { getJson } from '../api/client'
+
+function mountForm() {
+  const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
+  return mount(KeyParserForm, {
+    global: { plugins: [createPinia(), i18n] },
+  })
+}
+
+describe('KeyParserForm', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.mocked(getJson).mockReset()
+  })
+
+  it('renders the key input field', () => {
+    const wrapper = mountForm()
+    expect(wrapper.find('input[type="text"]').exists()).toBe(true)
+  })
+
+  it('renders the parse button', () => {
+    const wrapper = mountForm()
+    expect(wrapper.find('button[type="submit"]').exists()).toBe(true)
+  })
+
+  it('calls the key parse API with the entered key when the parse button is clicked', async () => {
+    vi.mocked(getJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
+    const wrapper = mountForm()
+
+    await wrapper.find('input[type="text"]').setValue('HR1·a1b2')
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(getJson).toHaveBeenCalledWith('/key/parse', { key: 'HR1·a1b2' })
+  })
+
+  it('displays all decoded parameters after a successful parse response', async () => {
+    vi.mocked(getJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
+    const wrapper = mountForm()
+
+    await wrapper.find('input[type="text"]').setValue('HR1·a1b2')
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain(String(MOCK_KEY_PARSE_RESPONSE.pivotBlockSize))
+    expect(wrapper.text()).toContain('0°, 90°, 180°, 270°')
+    expect(wrapper.text()).toContain(MOCK_KEY_PARSE_RESPONSE.rotationDirection)
+    expect(wrapper.text()).toContain(MOCK_KEY_PARSE_RESPONSE.readingOrder)
+  })
+
+  it('displays a clear error message for a malformed key without calling the API', async () => {
+    const wrapper = mountForm()
+
+    await wrapper.find('input[type="text"]').setValue(MALFORMED_KEY)
+
+    expect(wrapper.find('.key-parser-form__error').exists()).toBe(true)
+    expect(wrapper.find('button[type="submit"]').attributes('disabled')).toBeDefined()
+    expect(getJson).not.toHaveBeenCalled()
+  })
+
+  it('displays a clear error message when the API returns 400', async () => {
+    vi.mocked(getJson).mockRejectedValue(new ApiError('unsupported key version', 'http', 400))
+    const wrapper = mountForm()
+
+    await wrapper.find('input[type="text"]').setValue('HR9·zzzz')
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('unsupported key version')
+  })
+})

--- a/frontend/src/components/KeyParserForm.vue
+++ b/frontend/src/components/KeyParserForm.vue
@@ -1,0 +1,110 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useKeyStore } from '../stores/key'
+import { isValidKeyFormat } from '../utils/key-format'
+
+const store = useKeyStore()
+const { t } = useI18n()
+
+const keyFormatError = computed(() => {
+  if (store.keyInput.length === 0) return null
+  return isValidKeyFormat(store.keyInput) ? null : t('key.parser.form.key.formatError')
+})
+
+const canParse = computed(() => {
+  if (store.parseStatus === 'loading') return false
+  return store.keyInput.length > 0 && keyFormatError.value === null
+})
+
+function handleParse(): void {
+  if (!canParse.value) return
+  void store.parse()
+}
+</script>
+
+<template>
+  <form
+    class="key-parser-form"
+    @submit.prevent="handleParse"
+  >
+    <h2>{{ t('key.parser.title') }}</h2>
+
+    <label class="key-parser-form__field">
+      {{ t('key.parser.form.key.label') }}
+      <input
+        v-model="store.keyInput"
+        type="text"
+        :placeholder="t('key.parser.form.key.placeholder')"
+      >
+    </label>
+    <p
+      v-if="keyFormatError"
+      class="key-parser-form__error"
+      role="alert"
+    >
+      {{ keyFormatError }}
+    </p>
+
+    <button
+      type="submit"
+      :disabled="!canParse"
+    >
+      {{ store.parseStatus === 'loading' ? t('key.parser.form.submit.loading') : t('key.parser.form.submit.label') }}
+    </button>
+
+    <p
+      v-if="store.parseStatus === 'error'"
+      class="key-parser-form__error"
+      role="alert"
+    >
+      {{ store.parseErrorMessage ?? t(`errors.${store.parseErrorCode}`) }}
+    </p>
+
+    <dl
+      v-if="store.parseStatus === 'success' && store.parsedParams"
+      class="key-parser-form__result"
+    >
+      <dt>{{ t('key.parser.result.pivotBlockSize') }}</dt>
+      <dd>{{ store.parsedParams.pivotBlockSize }}</dd>
+
+      <dt>{{ t('key.parser.result.rotationSequence') }}</dt>
+      <dd>{{ store.parsedParams.rotationSequence.map((angle) => `${angle}°`).join(', ') }}</dd>
+
+      <dt>{{ t('key.parser.result.rotationDirection') }}</dt>
+      <dd>{{ store.parsedParams.rotationDirection }}</dd>
+
+      <dt>{{ t('key.parser.result.readingOrder') }}</dt>
+      <dd>{{ store.parsedParams.readingOrder }}</dd>
+    </dl>
+  </form>
+</template>
+
+<style scoped>
+.key-parser-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 480px;
+}
+
+.key-parser-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.key-parser-form__error {
+  color: #c0392b;
+}
+
+.key-parser-form__result {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 4px 12px;
+}
+
+.key-parser-form__result dt {
+  font-weight: 600;
+}
+</style>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -93,6 +93,38 @@
       "label": "Decoded message"
     }
   },
+  "key": {
+    "title": "Generate or parse a key",
+    "generator": {
+      "title": "Generate a key",
+      "form": {
+        "pivotBlockSize": {
+          "label": "Pivot block size"
+        },
+        "rotationSequence": {
+          "label": "Rotation sequence"
+        },
+        "rotationDirection": {
+          "label": "Rotation direction",
+          "cw": "Clockwise",
+          "ccw": "Counter-clockwise"
+        },
+        "readingOrder": {
+          "label": "Reading order"
+        },
+        "submit": {
+          "label": "Generate",
+          "loading": "Generating..."
+        }
+      },
+      "result": {
+        "keyLabel": "Key",
+        "copy": "Copy",
+        "copied": "Copied!",
+        "copyError": "Copy failed"
+      }
+    }
+  },
   "errors": {
     "network": "Network error: unable to reach the server",
     "unknown": "Something went wrong. Please try again."

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -123,6 +123,26 @@
         "copied": "Copied!",
         "copyError": "Copy failed"
       }
+    },
+    "parser": {
+      "title": "Parse a key",
+      "form": {
+        "key": {
+          "label": "HexaRot key",
+          "placeholder": "HR1·xxxx",
+          "formatError": "This does not look like a valid HexaRot key."
+        },
+        "submit": {
+          "label": "Parse",
+          "loading": "Parsing..."
+        }
+      },
+      "result": {
+        "pivotBlockSize": "Pivot block size",
+        "rotationSequence": "Rotation sequence",
+        "rotationDirection": "Rotation direction",
+        "readingOrder": "Reading order"
+      }
     }
   },
   "errors": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -129,7 +129,7 @@
       "form": {
         "key": {
           "label": "HexaRot key",
-          "placeholder": "HR1·xxxx",
+          "placeholder": "HR1·XXXX",
           "formatError": "This does not look like a valid HexaRot key."
         },
         "submit": {

--- a/frontend/src/stores/key.spec.ts
+++ b/frontend/src/stores/key.spec.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useKeyStore } from './key'
+import { ApiError } from '../api/client'
+import { MOCK_KEY_GENERATE_RESPONSE, MOCK_KEY_PARSE_RESPONSE } from '../__fixtures__/frontend.fixtures'
+
+vi.mock('../api/client', async () => {
+  const actual = await vi.importActual<typeof import('../api/client')>('../api/client')
+  return { ...actual, postJson: vi.fn(), getJson: vi.fn() }
+})
+
+import { postJson, getJson } from '../api/client'
+
+describe('useKeyStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.mocked(postJson).mockReset()
+    vi.mocked(getJson).mockReset()
+  })
+
+  it('initialises with default parameter values and no result or error on either side', () => {
+    const store = useKeyStore()
+
+    expect(store.pivotBlockSize).toBe(5)
+    expect(store.rotationSequence).toEqual([0, 1, 2, 3])
+    expect(store.rotationDirection).toBe('cw')
+    expect(store.readingOrder).toBe('LR-TB')
+    expect(store.generateStatus).toBe('idle')
+    expect(store.generatedKey).toBeNull()
+    expect(store.generateErrorMessage).toBeNull()
+    expect(store.generateErrorCode).toBeNull()
+
+    expect(store.keyInput).toBe('')
+    expect(store.parseStatus).toBe('idle')
+    expect(store.parsedParams).toBeNull()
+    expect(store.parseErrorMessage).toBeNull()
+    expect(store.parseErrorCode).toBeNull()
+  })
+
+  it('calls postJson with the current generator parameters when generate is dispatched', async () => {
+    vi.mocked(postJson).mockResolvedValue(MOCK_KEY_GENERATE_RESPONSE)
+    const store = useKeyStore()
+    store.pivotBlockSize = 7
+    store.rotationDirection = 'ccw'
+    store.readingOrder = 'RL-TB'
+
+    await store.generate()
+
+    expect(postJson).toHaveBeenCalledWith('/key/generate', {
+      pivotBlockSize: 7,
+      rotationSequence: [0, 1, 2, 3],
+      rotationDirection: 'ccw',
+      readingOrder: 'RL-TB',
+    })
+  })
+
+  it('sets generateStatus to loading while the generate request is in flight', () => {
+    vi.mocked(postJson).mockReturnValue(new Promise(() => {}))
+    const store = useKeyStore()
+
+    void store.generate()
+
+    expect(store.generateStatus).toBe('loading')
+  })
+
+  it('stores the generated key and sets generateStatus to success on a successful generate', async () => {
+    vi.mocked(postJson).mockResolvedValue(MOCK_KEY_GENERATE_RESPONSE)
+    const store = useKeyStore()
+
+    await store.generate()
+
+    expect(store.generatedKey).toBe(MOCK_KEY_GENERATE_RESPONSE.key)
+    expect(store.generateStatus).toBe('success')
+    expect(store.generateErrorMessage).toBeNull()
+  })
+
+  it('stores the error message and sets generateStatus to error on a failed generate', async () => {
+    vi.mocked(postJson).mockRejectedValue(new ApiError('invalid parameters', 'http', 400))
+    const store = useKeyStore()
+
+    await store.generate()
+
+    expect(store.generateStatus).toBe('error')
+    expect(store.generateErrorMessage).toBe('invalid parameters')
+    expect(store.generatedKey).toBeNull()
+  })
+
+  it('sets generateErrorCode to network and leaves generateErrorMessage null on a network failure', async () => {
+    vi.mocked(postJson).mockRejectedValue(new ApiError('Network error: unable to reach the server', 'network'))
+    const store = useKeyStore()
+
+    await store.generate()
+
+    expect(store.generateStatus).toBe('error')
+    expect(store.generateErrorCode).toBe('network')
+    expect(store.generateErrorMessage).toBeNull()
+  })
+
+  it('clears the previous generated key when a new generate is dispatched, without touching parse state', async () => {
+    vi.mocked(postJson).mockResolvedValue(MOCK_KEY_GENERATE_RESPONSE)
+    vi.mocked(getJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
+    const store = useKeyStore()
+    await store.generate()
+    store.keyInput = 'HR1·a1b2'
+    await store.parse()
+    expect(store.parsedParams).toEqual(MOCK_KEY_PARSE_RESPONSE)
+
+    vi.mocked(postJson).mockReturnValue(new Promise(() => {}))
+    void store.generate()
+
+    expect(store.generatedKey).toBeNull()
+    expect(store.parsedParams).toEqual(MOCK_KEY_PARSE_RESPONSE)
+  })
+
+  it('calls getJson with the entered key when parse is dispatched', async () => {
+    vi.mocked(getJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
+    const store = useKeyStore()
+    store.keyInput = 'HR1·a1b2'
+
+    await store.parse()
+
+    expect(getJson).toHaveBeenCalledWith('/key/parse', { key: 'HR1·a1b2' })
+  })
+
+  it('sets parseStatus to loading while the parse request is in flight', () => {
+    vi.mocked(getJson).mockReturnValue(new Promise(() => {}))
+    const store = useKeyStore()
+    store.keyInput = 'HR1·a1b2'
+
+    void store.parse()
+
+    expect(store.parseStatus).toBe('loading')
+  })
+
+  it('stores the parsed params and sets parseStatus to success on a successful parse', async () => {
+    vi.mocked(getJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
+    const store = useKeyStore()
+    store.keyInput = 'HR1·a1b2'
+
+    await store.parse()
+
+    expect(store.parsedParams).toEqual(MOCK_KEY_PARSE_RESPONSE)
+    expect(store.parseStatus).toBe('success')
+    expect(store.parseErrorMessage).toBeNull()
+  })
+
+  it('stores the error message and sets parseStatus to error on a failed parse', async () => {
+    vi.mocked(getJson).mockRejectedValue(new ApiError('unsupported key version', 'http', 400))
+    const store = useKeyStore()
+    store.keyInput = 'HR9·zzzz'
+
+    await store.parse()
+
+    expect(store.parseStatus).toBe('error')
+    expect(store.parseErrorMessage).toBe('unsupported key version')
+    expect(store.parsedParams).toBeNull()
+  })
+
+  it('clears the previous parsed params when a new parse is dispatched, without touching generate state', async () => {
+    vi.mocked(getJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
+    vi.mocked(postJson).mockResolvedValue(MOCK_KEY_GENERATE_RESPONSE)
+    const store = useKeyStore()
+    store.keyInput = 'HR1·a1b2'
+    await store.parse()
+    await store.generate()
+    expect(store.generatedKey).toBe(MOCK_KEY_GENERATE_RESPONSE.key)
+
+    vi.mocked(getJson).mockReturnValue(new Promise(() => {}))
+    void store.parse()
+
+    expect(store.parsedParams).toBeNull()
+    expect(store.generatedKey).toBe(MOCK_KEY_GENERATE_RESPONSE.key)
+  })
+
+  it('restores default state when reset is called', async () => {
+    vi.mocked(postJson).mockResolvedValue(MOCK_KEY_GENERATE_RESPONSE)
+    vi.mocked(getJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
+    const store = useKeyStore()
+    await store.generate()
+    store.keyInput = 'HR1·a1b2'
+    await store.parse()
+
+    store.reset()
+
+    expect(store.generatedKey).toBeNull()
+    expect(store.generateStatus).toBe('idle')
+    expect(store.keyInput).toBe('')
+    expect(store.parsedParams).toBeNull()
+    expect(store.parseStatus).toBe('idle')
+  })
+})

--- a/frontend/src/stores/key.ts
+++ b/frontend/src/stores/key.ts
@@ -1,0 +1,109 @@
+import { defineStore } from 'pinia'
+import { postJson, getJson, ApiError } from '../api/client'
+import type { ReadingOrder } from '../constants/reading-orders'
+
+export type RotationDirection = 'cw' | 'ccw'
+export type KeyStatus = 'idle' | 'loading' | 'success' | 'error'
+
+/** Mirrors backend/src/api/key.service.ts's KeyParseResult. */
+export interface KeyParseResult {
+  pivotBlockSize: number
+  rotationSequence: number[]
+  rotationDirection: RotationDirection
+  readingOrder: string
+}
+
+interface KeyState {
+  pivotBlockSize: number
+  rotationSequence: number[]
+  rotationDirection: RotationDirection
+  readingOrder: ReadingOrder
+  generateStatus: KeyStatus
+  generatedKey: string | null
+  generateErrorMessage: string | null
+  generateErrorCode: 'network' | 'unknown' | null
+
+  keyInput: string
+  parseStatus: KeyStatus
+  parsedParams: KeyParseResult | null
+  parseErrorMessage: string | null
+  parseErrorCode: 'network' | 'unknown' | null
+}
+
+function initialState(): KeyState {
+  return {
+    pivotBlockSize: 5,
+    rotationSequence: [0, 1, 2, 3],
+    rotationDirection: 'cw',
+    readingOrder: 'LR-TB',
+    generateStatus: 'idle',
+    generatedKey: null,
+    generateErrorMessage: null,
+    generateErrorCode: null,
+
+    keyInput: '',
+    parseStatus: 'idle',
+    parsedParams: null,
+    parseErrorMessage: null,
+    parseErrorCode: null,
+  }
+}
+
+export const useKeyStore = defineStore('key', {
+  state: initialState,
+  actions: {
+    async generate(): Promise<void> {
+      this.generateStatus = 'loading'
+      this.generatedKey = null
+      this.generateErrorMessage = null
+      this.generateErrorCode = null
+
+      try {
+        const response = await postJson<{ key: string }>('/key/generate', {
+          pivotBlockSize: this.pivotBlockSize,
+          rotationSequence: this.rotationSequence,
+          rotationDirection: this.rotationDirection,
+          readingOrder: this.readingOrder,
+        })
+        this.generatedKey = response.key
+        this.generateStatus = 'success'
+      } catch (err) {
+        if (err instanceof ApiError && err.code === 'http') {
+          this.generateErrorMessage = err.message
+        } else if (err instanceof ApiError && err.code === 'network') {
+          this.generateErrorMessage = null
+          this.generateErrorCode = 'network'
+        } else {
+          this.generateErrorMessage = null
+          this.generateErrorCode = 'unknown'
+        }
+        this.generateStatus = 'error'
+      }
+    },
+    async parse(): Promise<void> {
+      this.parseStatus = 'loading'
+      this.parsedParams = null
+      this.parseErrorMessage = null
+      this.parseErrorCode = null
+
+      try {
+        this.parsedParams = await getJson<KeyParseResult>('/key/parse', { key: this.keyInput })
+        this.parseStatus = 'success'
+      } catch (err) {
+        if (err instanceof ApiError && err.code === 'http') {
+          this.parseErrorMessage = err.message
+        } else if (err instanceof ApiError && err.code === 'network') {
+          this.parseErrorMessage = null
+          this.parseErrorCode = 'network'
+        } else {
+          this.parseErrorMessage = null
+          this.parseErrorCode = 'unknown'
+        }
+        this.parseStatus = 'error'
+      }
+    },
+    reset(): void {
+      Object.assign(this, initialState())
+    },
+  },
+})

--- a/frontend/src/utils/key-format.spec.ts
+++ b/frontend/src/utils/key-format.spec.ts
@@ -7,6 +7,7 @@ describe('isValidKeyFormat', () => {
     ['HR1·a1b2'],
     ['HR1·0000'],
     ['HR9·zzzz'],
+    ['HR1·A1B2'],
   ])('accepts a well-formed key: %s', (key) => {
     expect(isValidKeyFormat(key)).toBe(true)
   })
@@ -18,7 +19,6 @@ describe('isValidKeyFormat', () => {
     ['payload too short', 'HR1·a1b'],
     ['payload too long', 'HR1·a1b23'],
     ['empty string', ''],
-    ['uppercase payload characters', 'HR1·A1B2'],
   ])('rejects %s', (_label, key) => {
     expect(isValidKeyFormat(key)).toBe(false)
   })

--- a/frontend/src/utils/key-format.ts
+++ b/frontend/src/utils/key-format.ts
@@ -4,7 +4,7 @@
  * KeyCodec.decode() remains the sole source of truth for whether a
  * well-formed-looking key actually decodes to valid parameters.
  */
-const KEY_FORMAT_REGEX = /^HR\d·[0-9a-z]{4}$/
+const KEY_FORMAT_REGEX = /^HR\d·[0-9A-Za-z]{4}$/
 
 export function isValidKeyFormat(key: string): boolean {
   return KEY_FORMAT_REGEX.test(key.trim())

--- a/frontend/src/views/KeyView.spec.ts
+++ b/frontend/src/views/KeyView.spec.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createI18n } from 'vue-i18n'
+import KeyView from './KeyView.vue'
+import { useKeyStore } from '../stores/key'
+import en from '../locales/en.json'
+import { MOCK_KEY_GENERATE_RESPONSE, MOCK_KEY_PARSE_RESPONSE, MALFORMED_KEY } from '../__fixtures__/frontend.fixtures'
+import { ApiError } from '../api/client'
+
+vi.mock('../api/client', async () => {
+  const actual = await vi.importActual<typeof import('../api/client')>('../api/client')
+  return { ...actual, postJson: vi.fn(), getJson: vi.fn() }
+})
+
+import { postJson, getJson } from '../api/client'
+
+function mountView() {
+  const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
+  return mount(KeyView, {
+    global: { plugins: [createPinia(), i18n] },
+  })
+}
+
+describe('KeyView', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.mocked(postJson).mockReset()
+    vi.mocked(getJson).mockReset()
+  })
+
+  describe('key generator section', () => {
+    it('renders all parameter controls', () => {
+      const wrapper = mountView()
+      expect(wrapper.find('input[type="number"]').exists()).toBe(true)
+      expect(wrapper.find('select[name="rotationDirection"]').exists()).toBe(true)
+      expect(wrapper.find('select[name="readingOrder"]').exists()).toBe(true)
+    })
+
+    it('renders the generate button', () => {
+      const wrapper = mountView()
+      expect(wrapper.findAll('button[type="submit"]').length).toBe(2)
+    })
+
+    it('calls the key generate API when the generate button is clicked', async () => {
+      vi.mocked(postJson).mockResolvedValue(MOCK_KEY_GENERATE_RESPONSE)
+      const wrapper = mountView()
+
+      await wrapper.find('.key-generator-form').trigger('submit')
+      await flushPromises()
+
+      expect(postJson).toHaveBeenCalledWith('/key/generate', expect.any(Object))
+    })
+
+    it('displays the returned HR key after a successful generate response', async () => {
+      vi.mocked(postJson).mockResolvedValue(MOCK_KEY_GENERATE_RESPONSE)
+      const wrapper = mountView()
+
+      await wrapper.find('.key-generator-form').trigger('submit')
+      await flushPromises()
+
+      expect(wrapper.text()).toContain(MOCK_KEY_GENERATE_RESPONSE.key)
+    })
+
+    it('renders a copy-to-clipboard button next to the key', async () => {
+      vi.mocked(postJson).mockResolvedValue(MOCK_KEY_GENERATE_RESPONSE)
+      const wrapper = mountView()
+
+      await wrapper.find('.key-generator-form').trigger('submit')
+      await flushPromises()
+
+      expect(wrapper.find('.key-generator-form__result button').exists()).toBe(true)
+    })
+
+    it('provides visual feedback after clipboard copy', async () => {
+      vi.mocked(postJson).mockResolvedValue(MOCK_KEY_GENERATE_RESPONSE)
+      Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } })
+      const wrapper = mountView()
+
+      await wrapper.find('.key-generator-form').trigger('submit')
+      await flushPromises()
+      await wrapper.find('.key-generator-form__result button').trigger('click')
+      await flushPromises()
+
+      expect(wrapper.find('.key-generator-form__result button').text()).toBe(en.key.generator.result.copied)
+    })
+  })
+
+  describe('key parser section', () => {
+    it('renders the key input field', () => {
+      const wrapper = mountView()
+      expect(wrapper.find('.key-parser-form input[type="text"]').exists()).toBe(true)
+    })
+
+    it('renders the parse button', () => {
+      const wrapper = mountView()
+      expect(wrapper.find('.key-parser-form button[type="submit"]').exists()).toBe(true)
+    })
+
+    it('calls the key parse API when the parse button is clicked', async () => {
+      vi.mocked(getJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
+      const wrapper = mountView()
+
+      await wrapper.find('.key-parser-form input[type="text"]').setValue('HR1·a1b2')
+      await wrapper.find('.key-parser-form').trigger('submit')
+      await flushPromises()
+
+      expect(getJson).toHaveBeenCalledWith('/key/parse', { key: 'HR1·a1b2' })
+    })
+
+    it('displays all decoded parameters after a successful parse response', async () => {
+      vi.mocked(getJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
+      const wrapper = mountView()
+
+      await wrapper.find('.key-parser-form input[type="text"]').setValue('HR1·a1b2')
+      await wrapper.find('.key-parser-form').trigger('submit')
+      await flushPromises()
+
+      expect(wrapper.text()).toContain(String(MOCK_KEY_PARSE_RESPONSE.pivotBlockSize))
+    })
+
+    it('displays a clear error message for a malformed key (client-side validation)', async () => {
+      const wrapper = mountView()
+
+      await wrapper.find('.key-parser-form input[type="text"]').setValue(MALFORMED_KEY)
+
+      expect(wrapper.find('.key-parser-form__error').exists()).toBe(true)
+      expect(getJson).not.toHaveBeenCalled()
+    })
+
+    it('displays a clear error message when the API returns 400', async () => {
+      vi.mocked(getJson).mockRejectedValue(new ApiError('unsupported key version', 'http', 400))
+      const wrapper = mountView()
+
+      await wrapper.find('.key-parser-form input[type="text"]').setValue('HR9·zzzz')
+      await wrapper.find('.key-parser-form').trigger('submit')
+      await flushPromises()
+
+      expect(wrapper.text()).toContain('unsupported key version')
+    })
+  })
+
+  describe('unmount', () => {
+    it('resets the store when the view unmounts', async () => {
+      vi.mocked(postJson).mockResolvedValue(MOCK_KEY_GENERATE_RESPONSE)
+      const wrapper = mountView()
+
+      await wrapper.find('.key-generator-form').trigger('submit')
+      await flushPromises()
+
+      const store = useKeyStore()
+      expect(store.generatedKey).toBe(MOCK_KEY_GENERATE_RESPONSE.key)
+
+      wrapper.unmount()
+
+      expect(store.generatedKey).toBeNull()
+      expect(store.generateStatus).toBe('idle')
+    })
+  })
+
+  describe('i18n', () => {
+    it('renders no raw string literals - the generate button text comes from the locale file', () => {
+      const wrapper = mountView()
+      expect(wrapper.find('.key-generator-form button[type="submit"]').text()).toBe(en.key.generator.form.submit.label)
+    })
+  })
+})

--- a/frontend/src/views/KeyView.vue
+++ b/frontend/src/views/KeyView.vue
@@ -1,3 +1,30 @@
+<script setup lang="ts">
+import { onUnmounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useKeyStore } from '../stores/key'
+import KeyGeneratorForm from '../components/KeyGeneratorForm.vue'
+import KeyParserForm from '../components/KeyParserForm.vue'
+
+const store = useKeyStore()
+const { t } = useI18n()
+
+onUnmounted(() => {
+  store.reset()
+})
+</script>
+
 <template>
-  <div>KeyView</div>
+  <div class="key-view">
+    <h1>{{ t('key.title') }}</h1>
+    <KeyGeneratorForm />
+    <KeyParserForm />
+  </div>
 </template>
+
+<style scoped>
+.key-view {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+</style>


### PR DESCRIPTION
## Summary

Implements FEAT-016, the last of the three V1 frontend views: a key generator (parameters → HR key, with copy-to-clipboard) and a key parser (HR key → decoded parameters), reusing the shared infra from FEAT-014/015 (router, api/client.ts, Pinia store-per-view, RotationSequencePicker, isValidKeyFormat).

## Critical fix included

The final whole-branch review caught a real bug before merge: `isValidKeyFormat`'s regex only accepted lowercase base36 key payloads, but the backend always emits uppercase ones — so the parser section rejected ~97.6% of keys the generator itself produced (only the all-numeric default key happened to pass, which is why automated tests missed it). Fixed the regex to be case-insensitive, matching the backend's own validation, and updated the affected test cases and fixtures to use realistic uppercase payloads.

## Testing

- 132/132 Vitest tests passing (13 new for the store, 7 + 6 for the two form components, 14 for the view)
- Typecheck, lint, and build all clean
- Real functional test via `docker-compose up`: generated a key with non-default parameters (pivot 7, counter-clockwise, RL-TB) → got `HR1·01S7` (an uppercase payload — exactly the case that was broken) → pasted it into the parser → round-tripped to the exact same parameters. Also verified the malformed-key client-side error path.

## Notes

- `BACKLOG.md`: FEAT-016 flipped to `done` in this branch.
- README.md/README.fr.md roadmap updated — all three V1 frontend views (encode, decode, key) are now done.
- Deferred, non-blocking (see PR diff / ledger for detail): a few Minor polish items (shared error-classification helper across the three stores, `aria-live` on async results, trimming `keyInput` before send) — good REFACTOR-001 candidates, not required for this feature.
- Does not touch the previously-flagged backend Express body-size limit bug — unrelated to this feature's endpoints. 
