### PR TITLE
chore(infra): route local dev through Traefik instead of published ports

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1244,7 +1244,7 @@ at implementation time.
 - **type:** chore
 - **id:** CHORE-006
 - **milestone:** v1
-- **status:** ready
+- **status:** done
 - **priority:** high
 - **domain:** infra
 - **complexity:** M

--- a/CONTRIBUTING.fr.md
+++ b/CONTRIBUTING.fr.md
@@ -4,6 +4,32 @@
 
 # Contribuer à HexaRot
 
+## Environnement de développement local
+
+Le développement local passe par un reverse proxy Traefik local, sur le même principe
+qu'en production, plutôt que de publier les ports des conteneurs directement.
+
+### Prérequis
+
+- Une instance Traefik déjà lancée localement, rattachée à un réseau Docker externe
+  nommé `traefik-public`, avec un entrypoint `web` sur le port 80.
+- Une entrée dans `/etc/hosts` faisant pointer `hexarot.marvinlerouge.local` vers
+  `127.0.0.1` :
+  ```
+  127.0.0.1 hexarot.marvinlerouge.local
+  ```
+
+### Lancer la stack
+
+```bash
+docker compose up
+```
+
+- Frontend : `http://hexarot.marvinlerouge.local`
+- API backend : `http://hexarot.marvinlerouge.local/api/...`
+- PostgreSQL reste accessible directement sur `127.0.0.1:5433` pour l'outillage local
+  (Prisma Studio, `psql`) - non routé via Traefik.
+
 ## Configuration de GitHub Actions
 
 Le pipeline CI/CD nécessite un Personal Access Token (classic) stocké comme secret de

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,31 @@
 
 # Contributing to HexaRot
 
+## Local development environment
+
+Local development is routed through a local Traefik reverse proxy, mirroring the
+topology used in production, instead of publishing container ports directly.
+
+### Prerequisites
+
+- A Traefik instance already running locally, attached to an external Docker network
+  named `traefik-public`, with a `web` entrypoint on port 80.
+- An entry in `/etc/hosts` pointing `hexarot.marvinlerouge.local` to `127.0.0.1`:
+  ```
+  127.0.0.1 hexarot.marvinlerouge.local
+  ```
+
+### Running the stack
+
+```bash
+docker compose up
+```
+
+- Frontend: `http://hexarot.marvinlerouge.local`
+- Backend API: `http://hexarot.marvinlerouge.local/api/...`
+- PostgreSQL remains reachable directly at `127.0.0.1:5433` for local tooling
+  (Prisma Studio, `psql`) - it is not routed through Traefik.
+
 ## GitHub Actions setup
 
 The CI/CD pipeline requires a Personal Access Token (classic) stored as a repository secret.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
     ports:
-      - "5433:5432"
+      - "127.0.0.1:5433:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
@@ -14,13 +14,13 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    networks:
+      - internal
 
   backend:
     build:
       context: ./backend
       dockerfile: Dockerfile.dev
-    ports:
-      - "3000:3000"
     volumes:
       - ./backend:/app
       - /app/node_modules
@@ -31,13 +31,21 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=traefik-public"
+      - "traefik.http.routers.hexarot-api-dev.rule=Host(`hexarot.marvinlerouge.local`) && PathPrefix(`/api`)"
+      - "traefik.http.routers.hexarot-api-dev.entrypoints=web"
+      - "traefik.http.routers.hexarot-api-dev.service=hexarot-backend-dev"
+      - "traefik.http.services.hexarot-backend-dev.loadbalancer.server.port=3000"
+    networks:
+      - traefik-public
+      - internal
 
   frontend:
     build:
       context: ./frontend
       dockerfile: Dockerfile.dev
-    ports:
-      - "5173:5173"
     volumes:
       - ./frontend:/app
       - /app/node_modules
@@ -46,6 +54,20 @@ services:
       VITE_PROXY_TARGET: http://backend:3000
     depends_on:
       - backend
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=traefik-public"
+      - "traefik.http.routers.hexarot-frontend-dev.rule=Host(`hexarot.marvinlerouge.local`)"
+      - "traefik.http.routers.hexarot-frontend-dev.entrypoints=web"
+      - "traefik.http.services.hexarot-frontend-dev.loadbalancer.server.port=5173"
+    networks:
+      - traefik-public
 
 volumes:
   postgres_data:
+
+networks:
+  traefik-public:
+    external: true
+  internal:
+    driver: bridge

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     proxy: {
       '/api': process.env.VITE_PROXY_TARGET ?? 'http://localhost:3000',
     },
+    allowedHosts: ['hexarot.marvinlerouge.local'],
   },
   test: {
     environment: 'jsdom',


### PR DESCRIPTION
## Summary

Implements CHORE-006: local development now routes through the existing local Traefik reverse proxy at `hexarot.marvinlerouge.local`, mirroring the production topology, instead of publishing container ports directly (`3000`, `5173`). PostgreSQL keeps a `127.0.0.1`-bound port for local tooling only.

## Deviation from the backlog text (justified)

The backlog description said the `/api` prefix should be stripped by Traefik before reaching NestJS, copying the pattern used on another project. But `backend/src/main.ts` already sets `app.setGlobalPrefix('api')` — every backend route (and every e2e test) already expects `/api/...`. Stripping the prefix would have made every API call 404. Instead, the backend's Traefik router matches `Host + PathPrefix(/api)` and forwards the request unchanged — no middleware, no backend/test changes needed.

## Also needed (found during live verification)

`frontend/vite.config.ts` needed `server.allowedHosts: ['hexarot.marvinlerouge.local']` — Vite 7's dev server rejects unrecognized `Host` headers by default (DNS-rebinding protection), so the frontend route 403'd until this was added.

## Testing

- Full live verification via `docker compose up`: frontend served at `http://hexarot.marvinlerouge.local` (200), a real SPA route (`/key`) served correctly (200), and `POST http://hexarot.marvinlerouge.local/api/key/generate` returned a correct response (200) — confirmed against the actual shared `traefik-public` Docker network already running on this machine.
- 132/132 frontend Vitest tests, `vue-tsc`, and `eslint` all clean (run inside the frontend container — no backend or frontend source logic changed).
- `docker-compose.yml` config validated with `docker compose config`.

## Notes

- `BACKLOG.md`: CHORE-006 flipped to `done` in this branch.
- `CONTRIBUTING.md`/`CONTRIBUTING.fr.md`: documented prerequisite (local Traefik running, `/etc/hosts` entry for `hexarot.marvinlerouge.local`).
- No application code changed beyond the one-line `vite.config.ts` addition above.
