### PR TITLE
docs: complete README API examples and fix stale content

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1030,7 +1030,7 @@ transitions, and API call mocking.
 - **type:** docs
 - **id:** DOCS-001
 - **milestone:** v1
-- **status:** ready
+- **status:** done
 - **priority:** medium
 - **domain:** docs
 - **complexity:** M

--- a/README.fr.md
+++ b/README.fr.md
@@ -44,16 +44,19 @@ La même clé déchiffre tous les messages qu'elle a servi à chiffrer.
 
 ## Démarrage rapide
 
-**Prérequis :** Docker et Docker Compose.
+**Prérequis :** Docker, Docker Compose, et un reverse proxy Traefik local (le
+développement local passe par Traefik pour refléter la production — voir
+[CONTRIBUTING.fr.md](CONTRIBUTING.fr.md#environnement-de-développement-local) pour
+la configuration initiale, notamment l'entrée `/etc/hosts` requise).
 
 ```bash
 git clone https://github.com/MarvinLeRouge/HexaRot.git && cd HexaRot
 cp .env.example .env
-docker-compose up
+docker compose up
 ```
 
-L'interface web est disponible sur `http://localhost:5173`.
-L'API est disponible sur `http://localhost:3000`.
+L'interface web est disponible sur `http://hexarot.marvinlerouge.local`.
+L'API est disponible sur `http://hexarot.marvinlerouge.local/api`.
 
 ---
 
@@ -92,11 +95,60 @@ POST /api/encode
 }
 ```
 
+**Exemple — `POST /decode`**
+
+```json
+POST /api/decode
+{
+  "cryptogram": "<PNG encodé en base64 ou chaîne SVG brute>",
+  "format": "png",
+  "key": "HR1·57C3",
+  "size": "medium"
+}
+```
+
+```json
+{
+  "message": "HELLO WORLD"
+}
+```
+
+**Exemple — `POST /key/generate`**
+
+```json
+POST /api/key/generate
+{
+  "pivotBlockSize": 5,
+  "rotationSequence": [0, 1, 2, 3],
+  "rotationDirection": "cw",
+  "readingOrder": "LR-TB"
+}
+```
+
+```json
+{
+  "key": "HR1·57C3"
+}
+```
+
+**Exemple — `GET /key/parse`**
+
+```
+GET /api/key/parse?key=HR1·57C3
+```
+
+```json
+{
+  "pivotBlockSize": 5,
+  "rotationSequence": [0, 90, 180, 270],
+  "rotationDirection": "cw",
+  "readingOrder": "LR-TB"
+}
+```
+
 ---
 
 ## Format de la clé
-
-> ⚠️ *Spécification d'encodage exacte en cours (FEAT-004). Les valeurs ci-dessous sont illustratives.*
 
 Une clé HexaRot condense tous les paramètres de chiffrement dans une courte chaîne base36 :
 
@@ -118,8 +170,10 @@ Les paramètres condensés dans la clé, avec exemples de valeurs :
 | Ordre de lecture | `LR-TB` | Gauche-droite, haut-bas |
 
 La clé est **indépendante du message** — la même clé chiffre et déchiffre autant de messages
-que souhaité. La longueur du message est stockée dans l'en-tête du cryptogramme, pas dans
-la clé.
+que souhaité. Le cryptogramme ne contient aucune métadonnée de longueur par conception (un
+choix délibéré anti-fuite) : le décodage traite toujours la grille entière, en remplissant
+le padding éventuel par un caractère `?` plutôt que de stocker ou de laisser fuiter la
+longueur d'origine.
 
 ---
 
@@ -141,7 +195,7 @@ la clé.
 ```
 backend/
 ├── alphabet/        # Interface VisualAlphabet + implémentation HexahueAlphabet
-├── cipher/          # Pré-traitement, construction de grille, en-tête de métadonnées
+├── cipher/          # Pré-traitement, construction de grille (pas d'en-tête de métadonnées, par conception)
 ├── rotation/        # Moteur de rotation de blocs (encodage + inverse)
 ├── key/             # KeyCodec — encode/décode/valide en base36
 ├── reading-order/   # Implémentations de ReadingOrderStrategy

--- a/README.md
+++ b/README.md
@@ -44,16 +44,19 @@ The same key decodes any message it was used to encode.
 
 ## Quick start
 
-**Prerequisites:** Docker and Docker Compose.
+**Prerequisites:** Docker, Docker Compose, and a local Traefik reverse proxy (local
+dev is routed through Traefik to mirror production — see
+[CONTRIBUTING.md](CONTRIBUTING.md#local-development-environment) for the one-time
+setup, including the required `/etc/hosts` entry).
 
 ```bash
 git clone https://github.com/MarvinLeRouge/HexaRot.git && cd HexaRot
 cp .env.example .env
-docker-compose up
+docker compose up
 ```
 
-The web interface is available at `http://localhost:5173`.
-The API is available at `http://localhost:3000`.
+The web interface is available at `http://hexarot.marvinlerouge.local`.
+The API is available at `http://hexarot.marvinlerouge.local/api`.
 
 ---
 
@@ -92,11 +95,60 @@ POST /api/encode
 }
 ```
 
+**Example — `POST /decode`**
+
+```json
+POST /api/decode
+{
+  "cryptogram": "<base64-encoded PNG or raw SVG string>",
+  "format": "png",
+  "key": "HR1·57C3",
+  "size": "medium"
+}
+```
+
+```json
+{
+  "message": "HELLO WORLD"
+}
+```
+
+**Example — `POST /key/generate`**
+
+```json
+POST /api/key/generate
+{
+  "pivotBlockSize": 5,
+  "rotationSequence": [0, 1, 2, 3],
+  "rotationDirection": "cw",
+  "readingOrder": "LR-TB"
+}
+```
+
+```json
+{
+  "key": "HR1·57C3"
+}
+```
+
+**Example — `GET /key/parse`**
+
+```
+GET /api/key/parse?key=HR1·57C3
+```
+
+```json
+{
+  "pivotBlockSize": 5,
+  "rotationSequence": [0, 90, 180, 270],
+  "rotationDirection": "cw",
+  "readingOrder": "LR-TB"
+}
+```
+
 ---
 
 ## The key format
-
-> ⚠️ *Exact encoding specification in progress (FEAT-004). The values below are illustrative.*
 
 A HexaRot key encodes all encryption parameters into a short base36 string:
 
@@ -118,7 +170,9 @@ The parameters packed into the key, with example values:
 | Reading order | `LR-TB` | Left-right, top-bottom |
 
 The key is **message-independent** — the same key encrypts and decrypts any number of
-messages. Message length is stored in the cryptogram header, not in the key.
+messages. The cryptogram carries no message-length metadata by design (a deliberate
+anti-leakage choice): decoding always processes the full grid, filling any padding
+with a `?` placeholder rather than storing or leaking the original length anywhere.
 
 ---
 
@@ -140,7 +194,7 @@ messages. Message length is stored in the cryptogram header, not in the key.
 ```
 backend/
 ├── alphabet/        # VisualAlphabet interface + HexahueAlphabet implementation
-├── cipher/          # Pre-processing, grid construction, metadata header
+├── cipher/          # Pre-processing, grid construction (no metadata header, by design)
 ├── rotation/        # Block rotation engine (encode + inverse)
 ├── key/             # KeyCodec — base36 encode/decode/validate
 ├── reading-order/   # ReadingOrderStrategy implementations


### PR DESCRIPTION
## Summary

Implements DOCS-001, closing three real gaps found by auditing both README files against the backlog's acceptance criteria (not a from-scratch rewrite — most of the README was already accurate and complete from prior FEATs):

- **Quick Start was broken** since CHORE-006 merged: it pointed at `localhost:5173`/`localhost:3000`, but those ports are no longer published — the stack is Traefik-only now. Updated to the real access path (`hexarot.marvinlerouge.local`), with a link to `CONTRIBUTING.md`'s local dev section for the one-time Traefik/`/etc/hosts` setup.
- **Missing API examples**: the backlog requires examples for encode, decode, *and* key generation - only encode was documented. Added `POST /decode`, `POST /key/generate`, and `GET /key/parse`, each with a real request/response shape matched against the actual DTOs and controller.
- **Stale/placeholder content**: removed the "exact encoding specification in progress (FEAT-004)" disclaimer (FEAT-004 shipped long ago), and fixed two references to a cryptogram "metadata header" that was never shipped — the project deliberately has no length header, by design, for anti-leakage reasons. This directly contradicted the Roadmap section two lines below it in the same file.

## Testing

Docs-only change, no code touched. Verification: every JSON example was checked to parse as valid JSON (the three request examples that include a `POST /api/...` prefix line are intentionally not standalone JSON, matching the pre-existing style); anchor links to `CONTRIBUTING.md`/`CONTRIBUTING.fr.md` were checked against the actual heading text; the Quick Start's `docker compose up` + Traefik flow was already verified live during CHORE-006.

## Notes

- `BACKLOG.md`: DOCS-001 flipped to `done` in this branch.
