### PR TITLE
test(backend): enforce coverage thresholds on the algorithmic core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         run: npm run lint
 
       - name: Test
-        run: npm run test
+        run: npm run test:cov
 
   frontend:
     name: Frontend — install, lint, test

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -938,7 +938,7 @@ can query dimensions without knowing the concrete implementation.
 - **type:** test
 - **id:** TEST-001
 - **milestone:** v1
-- **status:** ready
+- **status:** done
 - **priority:** high
 - **domain:** cipher
 - **complexity:** M

--- a/backend/package.json
+++ b/backend/package.json
@@ -71,8 +71,35 @@
       "^.+\\.(t|j)s$": "ts-jest"
     },
     "collectCoverageFrom": [
-      "**/*.(t|j)s"
+      "**/*.(t|j)s",
+      "!**/*.module.ts"
     ],
+    "coverageThreshold": {
+      "src/cipher/**/*.ts": {
+        "branches": 90,
+        "functions": 90,
+        "lines": 90,
+        "statements": 90
+      },
+      "src/key/**/*.ts": {
+        "branches": 90,
+        "functions": 90,
+        "lines": 90,
+        "statements": 90
+      },
+      "src/rotation/**/*.ts": {
+        "branches": 90,
+        "functions": 90,
+        "lines": 90,
+        "statements": 90
+      },
+      "src/reading-order/**/*.ts": {
+        "branches": 90,
+        "functions": 90,
+        "lines": 90,
+        "statements": 90
+      }
+    },
     "coverageDirectory": "../coverage",
     "testEnvironment": "node"
   },

--- a/backend/src/cipher/decode-grid.spec.ts
+++ b/backend/src/cipher/decode-grid.spec.ts
@@ -43,4 +43,9 @@ describe('decodeGrid', () => {
     ];
     expect(decodeGrid(grid, alphabet)).toBe('AB');
   });
+
+  it('returns an empty string for an empty grid without accessing a missing row', () => {
+    const grid: ColorGrid = [];
+    expect(decodeGrid(grid, alphabet)).toBe('');
+  });
 });

--- a/docs/tests/index.md
+++ b/docs/tests/index.md
@@ -21,10 +21,10 @@ only in a dedicated test environment.
 |---|---|---|
 | Algorithmic core (cipher, rotation, key, reading-order) | **90%** | branch coverage |
 | Peripheral modules (renderer, validation, API controllers) | **75%** | branch coverage |
-| Global (backend + frontend combined) | **> 75%** | branch coverage |
+| Global (backend + frontend combined) | **≥ 85%** | branch coverage |
 
 These thresholds are enforced in CI (Jest `--coverage` with `coverageThreshold` in
-`jest.config.ts`, Vitest equivalent for the frontend).
+`package.json`'s `jest` block, Vitest equivalent for the frontend).
 
 ---
 


### PR DESCRIPTION
## Summary

Implements TEST-001. The Jest unit suite for cipher/key/rotation/reading-order already existed and was already near-complete (inherited incrementally from FEAT-002/004/005/006/007/008's own TDD process) — the real gap was that no coverage threshold was ever actually configured or enforced, despite `docs/tests/index.md` claiming it was.

- **`coverageThreshold`** added to `backend/package.json`'s `jest` block: 90% branches/functions/lines/statements on `cipher/`, `key/`, `rotation/`, `reading-order/`. All four were already at 92-100% branch coverage before this PR.
- **`*.module.ts` excluded from `collectCoverageFrom`**: these are bare NestJS `@Module({...})` declarations with zero logic, permanently stuck at 0% — including them was dragging every coverage aggregate down for no real signal. This affects every future coverage calculation (TEST-002, TEST-003), not just this one.
- **One real gap closed**: `decode-grid.ts`'s empty-grid guard (`grid.length === 0`) had no test — added one. (A second flagged branch, `rotation-engine.ts`'s injected constructor, turned out to be a TypeScript decorator/parameter-property compilation artifact with no real conditional logic behind it — confirmed by testing several `istanbul ignore` placements, none of which changed anything, and by checking that `RotationEngine` is the only class in this scope with this shape. Left as-is: 94.73% branch already clears the 90% bar comfortably, and forcing it to 100% would mean chasing a compiler artifact rather than testing real behavior.)
- **CI now actually enforces this**: the backend job's Test step runs `npm run test:cov` instead of `npm run test`, so a coverage regression below threshold now fails the build, as `docs/tests/index.md` already (incorrectly, until now) claimed.
- **`docs/tests/index.md`**: bumped the "Global (backend + frontend combined)" threshold from `>75%` to `≥85%` per your explicit ask (this session), and fixed a stale reference to a `jest.config.ts` file that doesn't exist — the config lives in `package.json`.

## Testing

370/370 backend tests passing, lint clean (0 errors — pre-existing warnings untouched), `npm run test:cov` exits 0. Verified the threshold is actually enforced, not just present: temporarily set an unreachable 99% branch target on `rotation/`, confirmed the build failed with a clear message, then reverted.

## Notes

- `BACKLOG.md`: TEST-001 flipped to `done` in this branch.
- Sets up the groundwork for TEST-002 (backend API/peripheral coverage) and TEST-003 (frontend coverage), agreed as the next two items in sequence to reach a real, verified ≥85% global combined number.
