### PR TITLE
chore(coverage): enforce the Codecov project status now that a real number exists

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -27,14 +27,12 @@ flags:
 
 coverage:
   status:
-    # informational until the first real merged number is observed on a PR;
-    # flip to false once confirmed the true combined total clears 85% (see TEST-005)
     project:
       default:
         enabled: true
         target: 85%
         threshold: 2%
-        informational: true
+        informational: false
     patch:
       default:
         enabled: true


### PR DESCRIPTION
## Summary

Quick follow-up flagged in TEST-005's PR: `codecov.yml`'s `project` coverage status started `informational: true` since the true merged backend+frontend number had never been observed. Now confirmed: 98% on the `backend` flag, 95% on `frontend`, both comfortably clearing the 85% target. Flipping back to `informational: false` so the check goes back to actually blocking a regression.

## Notes

No backlog item for this — it was the explicitly pre-agreed next step from TEST-005/CI-005's own PR notes, not new scope.
