### PR TITLE
refactor(frontend): UI/UX design pass on encode, decode and key views

### DIFF
--- a/.impeccable/critique/2026-08-19T21-20-04Z__hexarot-frontend-encode-decode-key-views.md
+++ b/.impeccable/critique/2026-08-19T21-20-04Z__hexarot-frontend-encode-decode-key-views.md
@@ -1,0 +1,92 @@
+---
+target: HexaRot frontend (encode, decode, key views)
+total_score: 9
+max_score: 40
+na_heuristics: 
+p0_count: 2
+p1_count: 3
+timestamp: 2026-08-19T21-20-04Z
+slug: hexarot-frontend-encode-decode-key-views
+---
+Method: dual-agent (A: design review · B: detector + browser evidence)
+
+## Design Health Score
+
+| # | Heuristic | Score | Key Issue |
+|---|-----------|-------|-----------|
+| 1 | Visibility of System Status | 1 | Active nav link renders identically to inactive ones (dead --accent); submitting Encode changes nothing visible - result lands ~600px below the fold, no scroll, no aria-live, no spinner |
+| 2 | Match Between System and Real World | 1 | LR-TB-ALT, "Pivot block size", GCD(pivotBlockSize=5, symbolWidth=2) - backend variable names surfaced verbatim in UI copy, zero glossary |
+| 3 | User Control and Freedom | 1 | No way to remove an uploaded file once selected; no reset/start-over; no cancel on an in-flight request; no undo on a rotation drag |
+| 4 | Consistency and Standards | 2 | Terminology and structure are genuinely consistent, but placeholder casing drifts (HR1·xxxx vs HR1·XXXX), and only Decode resets on unmount / gets aria-live |
+| 5 | Error Prevention | 1 | Key validator trims input but the stores submit untrimmed - a pasted key with a trailing space passes client-side, fails server-side |
+| 6 | Recognition Rather Than Recall | 1 | Decode demands the exact size used at encode time; the app never records or displays it anywhere |
+| 7 | Flexibility and Efficiency of Use | 1 | Rotation picker is entirely outside the tab order (tabIndex: -1 x4); no shortcuts, no presets, no shareable state |
+| 8 | Aesthetic and Minimalist Design | 0 | src/style.css - a real token system with an accent colour, dark mode, and layout - is never imported anywhere. The app renders as unstyled Times New Roman |
+| 9 | Help Users Recognize/Diagnose/Recover from Errors | 1 | Raw text "Internal Server Error" observed live as user-facing copy; errors are colour-only, no aria-invalid, no recovery guidance |
+| 10 | Help and Documentation | 0 | One help string exists in the entire product |
+| **Total** | | **9/40** | **Critical** |
+
+No heuristic scored n/a - this is an Operate surface, all ten genuinely apply. 9/40 is a pre-design baseline, not a verdict on the engineering underneath it: most of these zeros trace to one root cause below.
+
+## Design Specificity Verdict
+
+**The root cause, confirmed live:** src/style.css defines a complete token system (accent purple, code background, dark-mode block, centred 1126px container) - and is never imported by main.ts or linked in index.html. getComputedStyle on the live page confirms --sans resolves to "" and the root font-family computes to "Times New Roman". This isn't a missing design pass - it's a written design pass that was never wired up. Every var(--border), var(--accent) reference across all ten components silently unsets its whole declaration.
+
+The deterministic scan (Assessment B) found zero anti-patterns in the markup itself - expected, since "the stylesheet import is missing" isn't a pattern a static CSS/HTML scanner can see. It did catch one real, reproducible signal on live /encode: an overused-font finding (Roboto, 15% of text) - meaning a stray web font loads independently of style.css (likely a leftover <link> in index.html) and paints a fraction of text while the rest falls back to serif. Worth resolving in the same pass. A dark-glow finding on /decode and /key was traced to DOM elements literally named claude-agent-glow-border-inner - confirmed to be the browser-automation extension's own injected UI, not HexaRot's code. Excluded as a false positive.
+
+Once the stylesheet is wired up, the product has real material to be specific with: the cryptogram itself - nine saturated colours on a rigid grid, deliberately scrambled - is a complete, unused visual language sitting in the one place users actually look.
+
+## Overall Impression
+
+Nothing here is a bad decision executed badly - it's good decisions (the token system, the i18n discipline, the mode-toggle disclosure, uniform submit-gating) sitting disconnected from the rendered page. The single biggest opportunity is also the cheapest fix in the whole report: importing one file changes the product's baseline more than any other change available.
+
+## What's Working
+
+1. The encode mode toggle is real progressive disclosure (EncodeParamsForm.vue:40-58, 68-126) - cleanly swaps four parameter controls for one key field based on actual user intent, not just visual toggling.
+2. Submit gating is disciplined and uniform across all four forms (canSubmit/canGenerate/canParse), plus a genuinely well-built copy-to-clipboard state machine (EncodeResultPanel.vue:14-26) with an explicit denial catch most products skip.
+3. Total i18n discipline - zero hardcoded copy anywhere, the whole product's voice lives in one 152-line en.json. A full copy rewrite is a one-file job, not a ten-component hunt.
+
+## Priority Issues
+
+**[P0] src/style.css is never imported - the design system is dead code.**
+Why it matters: Removes real affordances, not just polish: no visible drop zone on Decode (the dashed border unsets entirely), no active-nav indicator, rotation-picker chips look like inert text.
+Fix: Add the import, then re-audit since wiring this up will surface two currently-masked issues - a --text-muted token is missing so de-emphasized hints will render at full weight, and there are zero :focus-visible rules anywhere in the codebase, currently invisible only because browser defaults are still active.
+Suggested command: /impeccable polish, then /impeccable layout for centring/rhythm
+
+**[P0] The rotation sequence picker is completely unreachable by keyboard.**
+Why it matters: All four items are tabIndex: -1, no roles, no keyboard handlers - verified in the accessibility tree. A keyboard/screen-reader user is locked to the default rotation sequence on both Encode and Key views: a functionally weaker product, not a degraded one.
+Fix: role="listbox"/role="option", roving tabindex, Arrow keys to move, Space to grab/drop, a polite live-region announcement of the new order, and a visible grab handle.
+Suggested command: /impeccable harden
+
+**[P1] Raw server internals are the error UI.**
+Why it matters: Observed live: the literal string "Internal Server Error" as user-facing copy; backend GCD warnings rendered verbatim.
+Fix: Map HTTP status + backend error codes to localized, actionable strings; keep raw text behind a collapsed "Technical details".
+Suggested command: /impeccable clarify
+
+**[P1] Nothing visibly happens on submit.**
+Why it matters: No scroll, no focus move, no aria-live on Encode/Key results (only Decode has one), no spinner - confirmed via before/after screenshots that were pixel-identical.
+Fix: Scroll result into view and move focus to its heading on success; aria-live="polite" + aria-busy while loading; inline spinner in the button.
+Suggested command: /impeccable animate
+
+**[P1] The key - the entire point of the product - is the smallest text on the page.**
+Why it matters: 13px inline <code>, upstaged by a duplicated, unlabelled PNG/SVG preview and a red warnings box.
+Fix: One preview (SVG) at a deliberate size; promote the key to a bordered, large, monospace block above the preview with copy + download-with-key actions and one line of reassurance copy.
+Suggested command: /impeccable bolder
+
+## Persona Red Flags
+
+**Jordan (confused first-timer):** browser tab reads "frontend", no product name anywhere in the UI; 8-option reading-order dropdown with zero explanation of any value; clicks Encode, nothing changes, clicks again.
+
+**Sam (accessibility-dependent):** cannot set rotation sequence at all (keyboard-locked out of one of four cipher parameters); "Rotation sequence" and "Cryptogram file" labels are orphan divs with no for/aria-labelledby; key-format error re-fires on every keystroke from the first character typed.
+
+**Riley (stress tester):** picks the wrong file on Decode and can't unpick it (no clear control); renames photo.jpg to photo.png and it sails through client validation into a raw server error; navigates Encode -> Decode -> Encode and finds the previous plaintext message still sitting there (Encode never resets on unmount, unlike Decode/Key) - a plaintext secret persisting in a cipher tool.
+
+## Minor Observations
+
+index.html still ships <title>frontend</title> - placeholder casing drifts between views - message textarea defaults to 2 rows for what's meant to hold an entire secret - overrideWeaknessWarning exists on Encode but not the Key generator - a full prefers-color-scheme: dark block exists in the dead stylesheet, so dark-mode users currently get pure white - the app's one fieldset explicitly disables its own border/padding, turning off the only native grouping primitive present.
+
+## Questions to Consider
+
+- Why does the encode form ask for five cipher parameters before asking whether the user wants to choose them at all - what if the default path were one textarea, one button, and "Cipher settings" collapsed behind a disclosure?
+- The key is the product - why can the app ever hand back a cryptogram without the key physically attached to it (in the filename, embedded in the PNG, bundled)?
+- The one thing this product makes that nothing else does - a sentence turned into a grid of colour - appears twice, unlabelled, 24 pixels tall. What if the result were a full-bleed hero where the grid animates in cell-by-cell along the chosen reading order?

--- a/.impeccable/critique/2026-08-20T09-40-23Z__hexarot-frontend-encode-decode-key-views.md
+++ b/.impeccable/critique/2026-08-20T09-40-23Z__hexarot-frontend-encode-decode-key-views.md
@@ -1,0 +1,102 @@
+---
+target: HexaRot frontend (encode, decode, key views)
+total_score: 18
+max_score: 40
+na_heuristics: 
+p0_count: 1
+p1_count: 2
+timestamp: 2026-08-20T09-40-23Z
+slug: hexarot-frontend-encode-decode-key-views
+---
+Method: dual-agent (A: design review · B: detector + browser evidence)
+
+## Design Health Score
+
+| # | Heuristic | Score | Key Issue |
+|---|-----------|-------|-----------|
+| 1 | Visibility of System Status | 3 | Spinner + aria-busy + "Encoding..." now land across all five forms. But the result panel goes stale: edit the message/params after a success and the old cryptogram and key stay on screen, downloadable, with no indication they no longer match the form. |
+| 2 | Match System / Real World | 2 | Parse result prints `cw` where the form says "Clockwise". Reading order offers 8 raw codes (`LR-TB`, `BT-LR-ALT`) with zero explanation. Warning bullets still read raw GCD math under the friendly intro sentence. |
+| 3 | User Control and Freedom | 2 | No cancel on in-flight requests, no "start over", no way to dismiss a stale error or result. Escape-to-cancel in the rotation picker is a genuine win and the only real undo in the product. |
+| 4 | Consistency and Standards | 2 | Key result block is now identical on Encode and Key - a real win. But Encode/Decode forms are bare while Key forms are cards; the same 4 params get a fieldset+legend on Encode and none on Key; the parse result is an unstyled `<dl>` while the generate result is an accent card. |
+| 5 | Error Prevention | 1 | Navigating away destroys the key with no confirmation (P0 below). Key separator `·` (U+00B7) is untypeable on any standard keyboard layout. Decode's size field has no fallback path, and the warning about it is the lowest-contrast text on the page (confirmed by detector: 2.7:1, needs 4.5:1). |
+| 6 | Recognition Rather Than Recall | 2 | Decode requires recalling which size was used at encode time - nothing on screen or in the key carries it. Parse gives you parameters but offers no handoff into Encode. |
+| 7 | Flexibility and Efficiency | 1 | No Cmd/Ctrl+Enter submit. Keyboard reordering reaches only ~4 of 24 possible sequences (P1 below - a real defect in the harden-step fix, not by design). No URL prefill, no Parse-to-Encode handoff. |
+| 8 | Aesthetic and Minimalist Design | 2 | The primary action of the entire product is a 480x30px unstyled native button. Hierarchy is inverted: "Download PNG" is the only accent-styled button in the app while "Copy" - the action the key's own hint text instructs - is a bare button. |
+| 9 | Error Recovery | 2 | "Couldn't encode this message: Internal Server Error" - friendly prefix over an unchanged raw payload, no icon, no container, no retry button. Work is preserved on error, which is worth something. |
+| 10 | Help and Documentation | 1 | Zero. No help link, no tooltip, no glossary. The `keyHint` sentence is the only explanatory copy in the product. Nothing says what a pivot block size, rotation sequence, or reading order does. |
+| **Total** | | **18/40** | **Poor - major UX overhaul required** |
+
+Baseline was 9/40 (Critical). This is a genuine doubling and a band change (Critical -> Poor). All ten heuristics genuinely apply (Operate surface); none marked n/a.
+
+## Design Specificity Verdict
+
+**LLM assessment:** Still largely category-interchangeable, with three authored exceptions. Strip the words "HexaRot", "cryptogram", and "rotation" and this is indistinguishable from a generic admin form. Every input, select, textarea, and button is an unstyled browser default. On a 1280px viewport roughly 60% of the canvas is empty white next to a centered 480px column.
+
+The three real exceptions: the key card (accent-tinted, uppercase micro-label, large monospace value, reassurance copy, copy action - identical between Encode and Key, which is a hard consistency win), the rotation chips (direct-manipulation objects with a grab handle, reading as physical tokens), and the elevated preview card (border + shadow, correctly framing the artifact). But the product's entire premise - a message becomes a picture - renders that picture at 280px inside a 480px card, stacked below a 900px form, smaller than the key text beneath it. Decode, where the user uploads one of these pictures, never shows the picture back at all.
+
+**Deterministic scan (Assessment B):** `detect.mjs --json` over frontend/src/views, components, layouts: exit 0, zero findings - clean at the static markup/CSS level, as expected (structural/hierarchy issues aren't statically detectable).
+
+**Live browser overlay (Assessment B):** injection succeeded on all three routes (/encode, /decode, /key).
+- /encode: "No anti-patterns found."
+- /decode: **1 real anti-pattern** - `low-contrast: 2.7:1 (need 4.5:1) - text #a09aa8 on #ffffff`, on `p.decode-params-form__hint` (the "Must match the size used when the cryptogram was encoded" text). Traced to HexaRot's own markup via the rendered screenshot, not a false positive.
+- /key: "No anti-patterns found."
+
+Manual computed-style spot check on a mocked successful encode: `body` font-family correctly resolves to `system-ui, "Segoe UI", Roboto, sans-serif` (confirms the Step-0 stylesheet fix held), and `.encode-result-panel__key` computes `background: rgba(170,59,255,0.1)`, `border: 1px solid rgba(170,59,255,0.5)` - the accent-tinted key card is real, not just source code. Zero console errors or warnings during load or the encode interaction, on any of the three routes.
+
+## Overall Impression
+
+This is now a working tool a determined user can complete a task in - that was not true at 9/40. Submit feedback, key promotion, and error-copy framing are all real and landed cleanly, and the two assessments corroborate each other rather than conflict (the one contrast finding the detector caught live is the same class of defect Assessment A flagged independently and traced to a specific token). But the six fix passes were remediation of named complaints, not a design pass - the result is an app whose best-designed moment (the key card) sits inside an app where a nav click can destroy that key with zero warning, and where the primary submit button remains a 30px unstyled native control.
+
+**The single biggest opportunity:** stop stacking. On desktop, put the form and the cryptogram side by side and let the artifact be large. That fixes the dead canvas, fixes the scroll-to-result problem (verified: on Encode success the page runs out of scrollable height before the result panel reaches the viewport top - scrollY maxes out at 561 with the result still sitting at y=368), and finally puts the picture at the center of a product about pictures.
+
+## What's Working
+
+1. **The key moment is genuinely well-designed and consistent.** Accent-bordered block, tinted ground, uppercase micro-label, large monospace value with `word-break: break-all`, a reassurance sentence naming the stake, a copy button with a 2-second "Copied!" confirmation and a distinct failure state - byte-identical between EncodeResultPanel and KeyGeneratorForm. Two components, one pattern, no drift.
+2. **Submit feedback is complete and uniform across all five forms** - aria-busy, a LoadingSpinner with a working prefers-reduced-motion guard, a verb-tense label swap, a disabled guard. Zero exceptions.
+3. **The warnings copy now frames rather than dumps.** "This combination weakens the cryptogram's rotation pattern. You can proceed anyway, or adjust the pivot block size to remove the warning:" names the consequence, grants permission, and points at the lever.
+
+## Priority Issues
+
+**[P0] Navigating between tabs silently destroys the key, the cryptogram, and the message.**
+Why it matters: verified live - encode a message, get a key and a cryptogram, click "Decode" then "Key" would not matter which - click back to "Encode" and the key, image, and message are all gone, no confirmation, no recovery. This regressed in this session's own final polish step: `onUnmounted(() => store.reset())` was added to EncodeView.vue "for consistency with Decode and Key" - but Decode's result is a re-derivable decoded message and Key's is a re-generatable key; Encode's result is the one artifact the app's own copy calls irreplaceable ("not stored anywhere"). The consistency fix built a symmetric API around an asymmetric risk.
+Fix: don't reset the Encode store on unmount while `status === 'success'`; reset on a new submit or an explicit "start over" instead. Consider a route-leave confirm when an uncopied key is on screen (copyState is already tracked).
+Suggested command: /impeccable harden
+
+**[P1] The rotation picker is keyboard-reachable but not keyboard-operable - only ~4 of 24 orderings are achievable.**
+Why it matters: verified live - focus the "0°" chip, press ArrowRight: the roving tabindex model updates but DOM focus never follows to the new chip (the non-grabbed arrow branch calls `focusItem(key)` with the OLD key instead of the destination key, then the `@focus` handler resets `focusedKey` back). A keyboard user can never focus 90°/180°/270° directly. Grab-and-move works correctly once an item is picked up, and the live-region announcements and Escape-cancel are correct - which makes the un-navigable default state more surprising, not less.
+Fix: in the non-grabbed arrow branch, focus the destination (`items.value[newPos].index`), not the origin. Also: `aria-selected` is being used to mean "grabbed" inside a listbox, which tells assistive tech something different; prefer `aria-roledescription` plus the existing live region. The grabbed visual state (accent border) is nearly masked by the focus ring - give it a stronger signal (fill, lift, or scale).
+Suggested command: /impeccable audit
+
+**[P1] The primary action is an unstyled 30px native button, and visual hierarchy is inverted.**
+Why it matters: measured - the Encode submit button is 480x30px, a bare `<button>` with no background/border/radius/weight token, under the 44px touch minimum, and it's the single control every task in the product funnels through. Meanwhile "Download PNG" is the only accent-styled button in the app, and "Copy" - the action the key card's own hint text instructs the user to take - is an unstyled default button, subordinate to Download PNG below it. The root cause is one line in style.css: `button, select, input, textarea { font-family: inherit; font-size: 1em }` and nothing else - no primary/secondary button system exists anywhere in the app.
+Fix: add primary/secondary/quiet button classes (primary: accent fill, >=44px, weight 600, hover/active) and apply primary to the four submit buttons and to Copy; drop Download PNG to secondary. Style inputs/selects to match (border, radius, accent focus).
+Suggested command: /impeccable layout
+
+**[P2] Three real contrast failures land on the most consequential text in the product.**
+Why it matters: confirmed independently by both assessments. `--text-muted` (#a09aa8 light / #6b7280 dark) computes to 2.73:1 and 3.70:1 against their respective backgrounds - both fail the 4.5:1 AA minimum for body text (Assessment B's live detector caught this exact token live on /decode). It is used specifically on the Decode size hint - "Must match the size used when the cryptogram was encoded" - the single line most likely to prevent the most common decode failure, rendered in the least readable color in the palette. Separately, the hardcoded error red `#c0392b` (six components, no dark-mode variant) computes to 3.29:1 on the dark background - every error message in the product is sub-AA in dark mode, and it doubles as the warnings-box border color for a message whose own text says "you can proceed anyway."
+Fix: raise `--text-muted` to >=4.5:1 in both themes without changing its hue family. Tokenize the error color as `--danger` with a dark-mode variant; give warnings their own `--warning` token instead of borrowing error red.
+Suggested command: /impeccable audit
+
+**[P2] The key format is untypeable and intolerant, and the error is non-diagnostic.**
+Why it matters: the separator `·` (U+00B7 MIDDLE DOT) isn't on any standard keyboard layout. Verified rejections: `hr1·abcd` (no case folding), `HR1.abcd`, `HR1-abcd`, `HR1 abcd` - all rejected with the same message: "This does not look like a valid HexaRot key," which never states the expected shape, length, or which part failed. In a two-party protocol where a short string has to survive being retyped from a screenshot or read aloud, this is the weakest link.
+Fix: normalize input before validating (uppercase the prefix, accept `·`/`.`/`-`/`_`/space as the separator and rewrite to canonical form); make the error diagnostic ("A HexaRot key looks like HR1·a3f9 - 'HR', a version number, a separator, then 4 characters").
+Suggested command: /impeccable clarify
+
+## Persona Red Flags
+
+**Jordan (confused first-timer):** nothing on any page explains what HexaRot or a cryptogram is; "Pivot block size: 5" and an 8-option "Reading order" dropdown (`LR-TB`, `BT-LR-ALT`, ...) offer zero explanation at a decision point double the working-memory limit; "Copy or download it now" sends her hunting for a Download Key button that doesn't exist (Download PNG/SVG download the image, not the key).
+
+**Sam (accessibility-dependent):** locked to one focusable rotation chip (see P1 above) - can reach 4 of 24 orderings despite the harden pass's own keyboard work; key-format `role="alert"` fires from keystroke one, so typing a valid key produces several consecutive interruptions; inputs carry no `aria-invalid`/`aria-describedby` linking them to their error text; the rotation-sequence label is a bare `<div>`, not a `<label>`, while the picker's own `aria-label` duplicates the same string (double-announced).
+
+**Riley (deliberate stress tester):** finds the P0 in under two minutes via Encode -> Key -> Encode; separately discovers the result panel goes fully stale - edit the message and pivot size after a successful encode and the old cryptogram/key remain on screen, fully downloadable/copyable, producing a key/image pair that will never decode together, with zero staleness indicator.
+
+## Minor Observations
+
+The `<h1>` is centered while the form beneath it is left-aligned on all three views - the message textarea has no character counter despite the backend's known ~100kb body-size limit - the parse result renders as an unstyled `<dl>` directly below the accent-carded generate result, two outputs of the same tool with two different treatments - nav links (64x26px) and the checkbox (13x13px) are under the 44px touch-target minimum - the cryptogram preview keeps its cream background in dark mode, producing a bright rectangle inside a dark card - "Parse a key" surfaces four parameters with no handoff back into Encode, so the user retypes them by hand - no Cmd/Ctrl+Enter submit from the message textarea.
+
+## Questions to Consider
+
+- Why is the cryptogram - the one thing this product makes that nothing else does - the smallest element on a page about making cryptograms?
+- What if encoding were live, re-rendering as rotation chips are dragged? It would teach what "rotation sequence" and "reading order" mean without a single tooltip, and make the eight opaque reading-order codes self-explanatory.
+- Why does the key not carry the cryptogram size, given Decode asks the user to recall it and warns (in failing-contrast text) that a mismatch breaks decoding?
+- If the key exists nowhere else, why is it one nav click away from permanent, unwarned deletion?

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1367,7 +1367,7 @@ direct SSH access to the production server is performed outside of this pipeline
 - **type:** refactor
 - **id:** REFACTOR-001
 - **milestone:** v1
-- **status:** backlog
+- **status:** done
 - **priority:** medium
 - **domain:** frontend
 - **complexity:** M
@@ -1513,4 +1513,59 @@ merging.
   merged number has never actually been observed before this branch); flip to `false`
   once the first real PR shows it clearing the ≥85% target - tracked as a quick
   follow-up, not a separate backlog item
+<!-- ITEM:END -->
+
+<!-- ITEM:BEGIN -->
+### [REFACTOR-002] Structural layout pass — two-column result, stale-result invalidation, key/size binding
+
+- **type:** refactor
+- **id:** REFACTOR-002
+- **milestone:** v2
+- **status:** backlog
+- **priority:** medium
+- **domain:** frontend
+- **complexity:** L
+- **parent:** ~
+- **depends-on:** REFACTOR-001
+- **learning:** [CSS grid two-column responsive layout, Pinia $subscribe vs component-level watchers for cross-field invalidation, key-format versioning if size joins the packed payload]
+- **labels:** [refactor, domain:frontend, priority:medium, milestone:v2]
+
+#### Description
+
+A post-REFACTOR-001 re-critique (`.impeccable/critique/2026-08-20T09-40-23Z__hexarot-frontend-encode-decode-key-views.md`,
+score 18/40) found real defects REFACTOR-001 fixed, plus a smaller set of deeper,
+structural findings deliberately deferred out of that polish-scoped branch because they
+need their own design decisions rather than a mechanical fix:
+
+1. **Single-column stacking defeats the app's own submit-feedback fix.** On common
+   desktop viewport heights, the page runs out of scrollable height before the result
+   panel reaches the top of the viewport, so `revealResult`'s scroll-into-view can never
+   actually bring the result fully into view - verified live (scrollY maxes out with the
+   result still ~370px down). A `grid-template-columns: minmax(360px, 480px) 1fr` layout
+   (form left, result right, collapsing to one column under ~900px) would fix this
+   structurally, let the cryptogram render larger than 280px, and use the ~60% of the
+   desktop canvas that currently sits empty next to the centred column.
+2. **A successful result goes stale silently.** Editing the message or any transform
+   parameter after a successful encode leaves the old cryptogram and key on screen, still
+   fully downloadable and copyable, with no indication they no longer match the current
+   form state - a user can produce a key/image pair that will never decode together.
+   Needs a UX decision (clear the result outright vs. dim it and disable its actions vs.
+   auto-resubmit) rather than a default pick.
+3. **Decode requires the user to recall the cryptogram size**, which the key does not
+   carry and the app never displays after the fact. Investigate whether size can join the
+   packed key payload (a `KeyCodec`/backend change, likely its own item if so) or be
+   inferred from the uploaded image's dimensions on the Decode side (frontend-only).
+
+#### Acceptance criteria
+
+- Encode and Decode use a two-column layout (form + result/preview) at desktop widths,
+  single-column below ~900px; the result never requires scrolling past the fold to be
+  visible on a standard 1280x800 viewport
+- Editing a parameter that affects the encode output while a previous result is
+  displayed visibly invalidates that result before the user can download or copy a
+  mismatched key/cryptogram pair - approach documented before implementation
+- A documented decision on carrying/inferring the cryptogram size for Decode, with
+  either a frontend-only fix or a cross-cutting item opened against the backend
+  `key-codec` if the payload format needs to change
+- No functional regression: all existing frontend tests (TEST-003) still pass
 <!-- ITEM:END -->

--- a/README.fr.md
+++ b/README.fr.md
@@ -226,8 +226,8 @@ frontend/
 - ✅ Stratégies d'ordre de lecture (4 directions + mode alterné)
 - ✅ Renderers (PNG + SVG)
 - ✅ Endpoints API (encode, decode, key)
-- ✅ Frontend (vues encodage, décodage, clé toutes terminées)
-- 🔄 Tests & couverture (chaque feature livrée embarque déjà sa propre suite unitaire/e2e ; les items de suite de tests dédiée restent ouverts)
+- ✅ Frontend (vues encodage, décodage, clé toutes terminées, passe UI/UX terminée)
+- ✅ Tests & couverture (suites unitaires/e2e backend + frontend, reporting Codecov, seuil global ≥85% confirmé)
 
 ### V2
 

--- a/README.md
+++ b/README.md
@@ -225,8 +225,8 @@ frontend/
 - ✅ Reading order strategies (4 directions + alternate)
 - ✅ Renderers (PNG + SVG)
 - ✅ API endpoints (encode, decode, key)
-- ✅ Frontend (encode, decode, key views all done)
-- 🔄 Tests & coverage (every shipped feature carries its own unit/e2e suite; dedicated backend/frontend test-suite items still open)
+- ✅ Frontend (encode, decode, key views all done, UI/UX polish pass done)
+- ✅ Tests & coverage (backend + frontend unit/e2e suites, Codecov reporting, ≥85% global bar confirmed)
 
 ### V2
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>frontend</title>
+    <title>HexaRot</title>
   </head>
   <body>
     <div id="app"></div>

--- a/frontend/src/components/DecodeParamsForm.vue
+++ b/frontend/src/components/DecodeParamsForm.vue
@@ -95,7 +95,7 @@ function handleSubmit(): void {
 
 .decode-params-form__hint {
   font-size: 0.85em;
-  color: var(--text);
+  color: var(--text-muted);
   margin: 0;
 }
 </style>

--- a/frontend/src/components/DecodeParamsForm.vue
+++ b/frontend/src/components/DecodeParamsForm.vue
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n'
 import { useDecodeStore } from '../stores/decode'
 import { isValidKeyFormat } from '../utils/key-format'
 import DecodeUploadArea from './DecodeUploadArea.vue'
+import LoadingSpinner from './LoadingSpinner.vue'
 
 const store = useDecodeStore()
 const { t } = useI18n()
@@ -68,8 +69,10 @@ function handleSubmit(): void {
 
     <button
       type="submit"
+      class="decode-params-form__submit"
       :disabled="!canSubmit"
     >
+      <LoadingSpinner v-if="store.status === 'loading'" />
       {{ store.status === 'loading' ? t('decode.form.submit.loading') : t('decode.form.submit.label') }}
     </button>
   </form>
@@ -98,5 +101,12 @@ function handleSubmit(): void {
   font-size: 0.85em;
   color: var(--text-muted);
   margin: 0;
+}
+
+.decode-params-form__submit {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
 }
 </style>

--- a/frontend/src/components/DecodeParamsForm.vue
+++ b/frontend/src/components/DecodeParamsForm.vue
@@ -81,6 +81,7 @@ function handleSubmit(): void {
   flex-direction: column;
   gap: 16px;
   max-width: 480px;
+  width: 100%;
 }
 
 .decode-params-form__field {

--- a/frontend/src/components/DecodeParamsForm.vue
+++ b/frontend/src/components/DecodeParamsForm.vue
@@ -69,7 +69,7 @@ function handleSubmit(): void {
 
     <button
       type="submit"
-      class="decode-params-form__submit"
+      class="decode-params-form__submit btn-primary"
       :disabled="!canSubmit"
     >
       <LoadingSpinner v-if="store.status === 'loading'" />
@@ -94,7 +94,7 @@ function handleSubmit(): void {
 }
 
 .decode-params-form__error {
-  color: #c0392b;
+  color: var(--danger);
 }
 
 .decode-params-form__hint {

--- a/frontend/src/components/DecodeUploadArea.vue
+++ b/frontend/src/components/DecodeUploadArea.vue
@@ -71,6 +71,7 @@ function triggerBrowse(): void {
     >
     <button
       type="button"
+      class="btn-secondary"
       @click="triggerBrowse"
     >
       {{ t('decode.upload.browse') }}
@@ -111,6 +112,6 @@ function triggerBrowse(): void {
 }
 
 .decode-upload-area__error {
-  color: #c0392b;
+  color: var(--danger);
 }
 </style>

--- a/frontend/src/components/EncodeParamsForm.vue
+++ b/frontend/src/components/EncodeParamsForm.vue
@@ -62,6 +62,7 @@ function handleSubmit(): void {
       {{ t('encode.form.message.label') }}
       <textarea
         v-model="store.message"
+        rows="4"
         :placeholder="t('encode.form.message.placeholder')"
       />
     </label>

--- a/frontend/src/components/EncodeParamsForm.vue
+++ b/frontend/src/components/EncodeParamsForm.vue
@@ -65,7 +65,12 @@ function handleSubmit(): void {
       />
     </label>
 
-    <template v-if="store.mode === 'params'">
+    <fieldset
+      v-if="store.mode === 'params'"
+      class="encode-params-form__group"
+    >
+      <legend>{{ t('encode.form.transformGroup.label') }}</legend>
+
       <label class="encode-params-form__field">
         {{ t('encode.form.pivotBlockSize.label') }}
         <input
@@ -105,7 +110,7 @@ function handleSubmit(): void {
           >{{ order }}</option>
         </select>
       </label>
-    </template>
+    </fieldset>
 
     <template v-else>
       <label class="encode-params-form__field">
@@ -125,25 +130,29 @@ function handleSubmit(): void {
       </p>
     </template>
 
-    <label class="encode-params-form__field">
-      {{ t('encode.form.size.label') }}
-      <select
-        v-model="store.size"
-        name="size"
-      >
-        <option value="small">{{ t('encode.form.size.small') }}</option>
-        <option value="medium">{{ t('encode.form.size.medium') }}</option>
-        <option value="large">{{ t('encode.form.size.large') }}</option>
-      </select>
-    </label>
+    <fieldset class="encode-params-form__group">
+      <legend>{{ t('encode.form.outputGroup.label') }}</legend>
 
-    <label class="encode-params-form__checkbox">
-      <input
-        v-model="store.overrideWeaknessWarning"
-        type="checkbox"
-      >
-      {{ t('encode.form.overrideWeaknessWarning.label') }}
-    </label>
+      <label class="encode-params-form__field">
+        {{ t('encode.form.size.label') }}
+        <select
+          v-model="store.size"
+          name="size"
+        >
+          <option value="small">{{ t('encode.form.size.small') }}</option>
+          <option value="medium">{{ t('encode.form.size.medium') }}</option>
+          <option value="large">{{ t('encode.form.size.large') }}</option>
+        </select>
+      </label>
+
+      <label class="encode-params-form__checkbox">
+        <input
+          v-model="store.overrideWeaknessWarning"
+          type="checkbox"
+        >
+        {{ t('encode.form.overrideWeaknessWarning.label') }}
+      </label>
+    </fieldset>
 
     <button
       type="submit"
@@ -160,6 +169,7 @@ function handleSubmit(): void {
   flex-direction: column;
   gap: 16px;
   max-width: 480px;
+  width: 100%;
 }
 
 .encode-params-form__field {
@@ -173,6 +183,28 @@ function handleSubmit(): void {
   gap: 16px;
   border: none;
   padding: 0;
+}
+
+.encode-params-form__group {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 16px;
+  margin: 0;
+}
+
+.encode-params-form__group legend {
+  padding: 0 4px;
+  font-weight: 500;
+  color: var(--text-h);
+}
+
+.encode-params-form__checkbox {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .encode-params-form__error {

--- a/frontend/src/components/EncodeParamsForm.vue
+++ b/frontend/src/components/EncodeParamsForm.vue
@@ -158,7 +158,7 @@ function handleSubmit(): void {
 
     <button
       type="submit"
-      class="encode-params-form__submit"
+      class="encode-params-form__submit btn-primary"
       :disabled="!canSubmit"
     >
       <LoadingSpinner v-if="store.status === 'loading'" />
@@ -212,7 +212,7 @@ function handleSubmit(): void {
 }
 
 .encode-params-form__error {
-  color: #c0392b;
+  color: var(--danger);
 }
 
 .encode-params-form__submit {

--- a/frontend/src/components/EncodeParamsForm.vue
+++ b/frontend/src/components/EncodeParamsForm.vue
@@ -5,6 +5,7 @@ import { useEncodeStore } from '../stores/encode'
 import { READING_ORDERS } from '../constants/reading-orders'
 import { isValidKeyFormat } from '../utils/key-format'
 import RotationSequencePicker from './RotationSequencePicker.vue'
+import LoadingSpinner from './LoadingSpinner.vue'
 
 const store = useEncodeStore()
 const { t } = useI18n()
@@ -156,8 +157,10 @@ function handleSubmit(): void {
 
     <button
       type="submit"
+      class="encode-params-form__submit"
       :disabled="!canSubmit"
     >
+      <LoadingSpinner v-if="store.status === 'loading'" />
       {{ store.status === 'loading' ? t('encode.form.submit.loading') : t('encode.form.submit.label') }}
     </button>
   </form>
@@ -209,5 +212,12 @@ function handleSubmit(): void {
 
 .encode-params-form__error {
   color: #c0392b;
+}
+
+.encode-params-form__submit {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
 }
 </style>

--- a/frontend/src/components/EncodeResultPanel.vue
+++ b/frontend/src/components/EncodeResultPanel.vue
@@ -76,6 +76,7 @@ function downloadSvg(): void {
       role="alert"
     >
       <p>{{ t('encode.result.warningsHeading') }}</p>
+      <p>{{ t('encode.result.warningsExplanation') }}</p>
       <ul>
         <li
           v-for="warning in result.warnings"

--- a/frontend/src/components/EncodeResultPanel.vue
+++ b/frontend/src/components/EncodeResultPanel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { EncodeResult } from '../stores/encode'
 
@@ -8,8 +8,6 @@ const props = defineProps<{
 }>()
 
 const { t } = useI18n()
-
-const pngDataUrl = computed(() => `data:image/png;base64,${props.result.png}`)
 
 const copyState = ref<'idle' | 'copied' | 'error'>('idle')
 
@@ -56,20 +54,20 @@ function downloadSvg(): void {
     aria-live="polite"
     :aria-label="t('encode.result.regionLabel')"
   >
-    <div class="encode-result-panel__previews">
-      <img
-        :src="pngDataUrl"
-        :alt="t('encode.result.pngAlt')"
-        class="encode-result-panel__png"
-      >
+    <div class="encode-result-panel__preview">
       <!-- eslint-disable-next-line vue/no-v-html, vue/max-attributes-per-line -- result.svg is generated exclusively by this project's own backend renderer, never from user input, so it is a trusted string. -->
       <div class="encode-result-panel__svg" v-html="result.svg" />
     </div>
 
     <div class="encode-result-panel__key">
-      <span>{{ t('encode.result.keyLabel') }}: <code>{{ result.key }}</code></span>
+      <span class="encode-result-panel__key-label">{{ t('encode.result.keyLabel') }}</span>
+      <code class="encode-result-panel__key-value">{{ result.key }}</code>
+      <p class="encode-result-panel__key-hint">
+        {{ t('encode.result.keyHint') }}
+      </p>
       <button
         type="button"
+        class="encode-result-panel__copy"
         @click="copyKey"
       >
         {{ copyState === 'copied' ? t('encode.result.copied') : copyState === 'error' ? t('encode.result.copyError') : t('encode.result.copy') }}
@@ -111,6 +109,7 @@ function downloadSvg(): void {
     <div class="encode-result-panel__downloads">
       <button
         type="button"
+        class="encode-result-panel__download-primary"
         @click="downloadPng"
       >
         {{ t('encode.result.downloadPng') }}
@@ -134,26 +133,73 @@ function downloadSvg(): void {
   width: 100%;
 }
 
-.encode-result-panel__previews {
+.encode-result-panel__preview {
   display: flex;
-  gap: 16px;
-  align-items: flex-start;
+  justify-content: center;
+  padding: 20px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: var(--shadow);
 }
 
-.encode-result-panel__png {
-  image-rendering: pixelated;
-  max-width: 200px;
+.encode-result-panel__svg {
+  width: 100%;
+  max-width: 280px;
+}
+
+.encode-result-panel__svg :deep(svg) {
+  width: 100%;
+  height: auto;
+  display: block;
 }
 
 .encode-result-panel__key {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  align-items: flex-start;
   gap: 8px;
+  padding: 16px;
+  border: 1px solid var(--accent-border);
+  border-radius: 8px;
+  background: var(--accent-bg);
+}
+
+.encode-result-panel__key-label {
+  font-size: 0.8em;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-h);
+}
+
+.encode-result-panel__key-value {
+  font-size: 1.3em;
+  padding: 0;
+  background: transparent;
+  word-break: break-all;
+}
+
+.encode-result-panel__key-hint {
+  margin: 0;
+  font-size: 0.9em;
+  color: var(--text);
+}
+
+.encode-result-panel__download-primary {
+  border: 1px solid var(--accent-border);
+  background: var(--accent-bg);
+  color: var(--text-h);
+  font-weight: 600;
 }
 
 .encode-result-panel__warnings {
   border: 1px solid #c0392b;
   border-radius: 4px;
   padding: 8px 12px;
+}
+
+.encode-result-panel__downloads {
+  display: flex;
+  gap: 12px;
 }
 </style>

--- a/frontend/src/components/EncodeResultPanel.vue
+++ b/frontend/src/components/EncodeResultPanel.vue
@@ -67,7 +67,7 @@ function downloadSvg(): void {
       </p>
       <button
         type="button"
-        class="encode-result-panel__copy"
+        class="btn-primary"
         @click="copyKey"
       >
         {{ copyState === 'copied' ? t('encode.result.copied') : copyState === 'error' ? t('encode.result.copyError') : t('encode.result.copy') }}
@@ -109,7 +109,7 @@ function downloadSvg(): void {
     <div class="encode-result-panel__downloads">
       <button
         type="button"
-        class="encode-result-panel__download-primary"
+        class="btn-secondary"
         @click="downloadPng"
       >
         {{ t('encode.result.downloadPng') }}
@@ -185,15 +185,9 @@ function downloadSvg(): void {
   color: var(--text);
 }
 
-.encode-result-panel__download-primary {
-  border: 1px solid var(--accent-border);
-  background: var(--accent-bg);
-  color: var(--text-h);
-  font-weight: 600;
-}
-
 .encode-result-panel__warnings {
-  border: 1px solid #c0392b;
+  border: 1px solid var(--warning-border);
+  background: var(--warning-bg);
   border-radius: 4px;
   padding: 8px 12px;
 }

--- a/frontend/src/components/EncodeResultPanel.vue
+++ b/frontend/src/components/EncodeResultPanel.vue
@@ -49,7 +49,13 @@ function downloadSvg(): void {
 </script>
 
 <template>
-  <section class="encode-result-panel">
+  <section
+    class="encode-result-panel"
+    role="region"
+    tabindex="-1"
+    aria-live="polite"
+    :aria-label="t('encode.result.regionLabel')"
+  >
     <div class="encode-result-panel__previews">
       <img
         :src="pngDataUrl"

--- a/frontend/src/components/EncodeResultPanel.vue
+++ b/frontend/src/components/EncodeResultPanel.vue
@@ -124,6 +124,7 @@ function downloadSvg(): void {
   flex-direction: column;
   gap: 16px;
   max-width: 480px;
+  width: 100%;
 }
 
 .encode-result-panel__previews {

--- a/frontend/src/components/KeyGeneratorForm.spec.ts
+++ b/frontend/src/components/KeyGeneratorForm.spec.ts
@@ -100,4 +100,27 @@ describe('KeyGeneratorForm', () => {
 
     expect(wrapper.text()).toContain('invalid parameters')
   })
+
+  describe('submit feedback', () => {
+    it('marks the form busy and shows a spinner while generating', async () => {
+      vi.mocked(postJson).mockReturnValue(new Promise(() => {}))
+      const wrapper = mountForm()
+      await wrapper.find('form').trigger('submit')
+
+      expect(wrapper.find('.key-generator-form').attributes('aria-busy')).toBe('true')
+      expect(wrapper.find('.loading-spinner').exists()).toBe(true)
+    })
+
+    it('moves focus to the result after a successful generate', async () => {
+      const focusSpy = vi.spyOn(HTMLElement.prototype, 'focus')
+      vi.mocked(postJson).mockResolvedValue(MOCK_KEY_GENERATE_RESPONSE)
+      const wrapper = mountForm()
+
+      await wrapper.find('form').trigger('submit')
+      await flushPromises()
+
+      expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true })
+      focusSpy.mockRestore()
+    })
+  })
 })

--- a/frontend/src/components/KeyGeneratorForm.vue
+++ b/frontend/src/components/KeyGeneratorForm.vue
@@ -117,6 +117,11 @@ async function copyKey(): Promise<void> {
   flex-direction: column;
   gap: 16px;
   max-width: 480px;
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 20px;
 }
 
 .key-generator-form__field {

--- a/frontend/src/components/KeyGeneratorForm.vue
+++ b/frontend/src/components/KeyGeneratorForm.vue
@@ -93,7 +93,7 @@ async function copyKey(): Promise<void> {
       class="key-generator-form__error"
       role="alert"
     >
-      {{ store.generateErrorMessage ?? t(`errors.${store.generateErrorCode}`) }}
+      {{ store.generateErrorMessage ? t('key.generator.form.error.prefix', { detail: store.generateErrorMessage }) : t(`errors.${store.generateErrorCode}`) }}
     </p>
 
     <div

--- a/frontend/src/components/KeyGeneratorForm.vue
+++ b/frontend/src/components/KeyGeneratorForm.vue
@@ -126,7 +126,11 @@ async function copyKey(): Promise<void> {
       aria-live="polite"
       :aria-label="t('key.generator.result.regionLabel')"
     >
-      <span>{{ t('key.generator.result.keyLabel') }}: <code>{{ store.generatedKey }}</code></span>
+      <span class="key-generator-form__result-label">{{ t('key.generator.result.keyLabel') }}</span>
+      <code class="key-generator-form__result-value">{{ store.generatedKey }}</code>
+      <p class="key-generator-form__result-hint">
+        {{ t('key.generator.result.keyHint') }}
+      </p>
       <button
         type="button"
         @click="copyKey"
@@ -169,7 +173,33 @@ async function copyKey(): Promise<void> {
 
 .key-generator-form__result {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  align-items: flex-start;
   gap: 8px;
+  padding: 16px;
+  border: 1px solid var(--accent-border);
+  border-radius: 8px;
+  background: var(--accent-bg);
+}
+
+.key-generator-form__result-label {
+  font-size: 0.8em;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-h);
+}
+
+.key-generator-form__result-value {
+  font-size: 1.3em;
+  padding: 0;
+  background: transparent;
+  word-break: break-all;
+}
+
+.key-generator-form__result-hint {
+  margin: 0;
+  font-size: 0.9em;
+  color: var(--text);
 }
 </style>

--- a/frontend/src/components/KeyGeneratorForm.vue
+++ b/frontend/src/components/KeyGeneratorForm.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useKeyStore } from '../stores/key'
 import { READING_ORDERS } from '../constants/reading-orders'
+import { revealResult } from '../utils/reveal-result'
 import RotationSequencePicker from './RotationSequencePicker.vue'
+import LoadingSpinner from './LoadingSpinner.vue'
 
 const store = useKeyStore()
 const { t } = useI18n()
@@ -17,6 +19,21 @@ function handleGenerate(): void {
   if (!canGenerate.value) return
   void store.generate()
 }
+
+const errorRef = ref<HTMLElement | null>(null)
+const resultRef = ref<HTMLElement | null>(null)
+
+watch(
+  () => store.generateStatus,
+  async (status) => {
+    await nextTick()
+    if (status === 'success') {
+      revealResult(resultRef.value, { focus: true })
+    } else if (status === 'error') {
+      revealResult(errorRef.value)
+    }
+  },
+)
 
 const copyState = ref<'idle' | 'copied' | 'error'>('idle')
 
@@ -37,6 +54,7 @@ async function copyKey(): Promise<void> {
 <template>
   <form
     class="key-generator-form"
+    :aria-busy="store.generateStatus === 'loading'"
     @submit.prevent="handleGenerate"
   >
     <h2>{{ t('key.generator.title') }}</h2>
@@ -83,13 +101,16 @@ async function copyKey(): Promise<void> {
 
     <button
       type="submit"
+      class="key-generator-form__submit"
       :disabled="!canGenerate"
     >
+      <LoadingSpinner v-if="store.generateStatus === 'loading'" />
       {{ store.generateStatus === 'loading' ? t('key.generator.form.submit.loading') : t('key.generator.form.submit.label') }}
     </button>
 
     <p
       v-if="store.generateStatus === 'error'"
+      ref="errorRef"
       class="key-generator-form__error"
       role="alert"
     >
@@ -98,7 +119,12 @@ async function copyKey(): Promise<void> {
 
     <div
       v-if="store.generateStatus === 'success' && store.generatedKey"
+      ref="resultRef"
       class="key-generator-form__result"
+      role="region"
+      tabindex="-1"
+      aria-live="polite"
+      :aria-label="t('key.generator.result.regionLabel')"
     >
       <span>{{ t('key.generator.result.keyLabel') }}: <code>{{ store.generatedKey }}</code></span>
       <button
@@ -132,6 +158,13 @@ async function copyKey(): Promise<void> {
 
 .key-generator-form__error {
   color: #c0392b;
+}
+
+.key-generator-form__submit {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
 }
 
 .key-generator-form__result {

--- a/frontend/src/components/KeyGeneratorForm.vue
+++ b/frontend/src/components/KeyGeneratorForm.vue
@@ -101,7 +101,7 @@ async function copyKey(): Promise<void> {
 
     <button
       type="submit"
-      class="key-generator-form__submit"
+      class="key-generator-form__submit btn-primary"
       :disabled="!canGenerate"
     >
       <LoadingSpinner v-if="store.generateStatus === 'loading'" />
@@ -133,6 +133,7 @@ async function copyKey(): Promise<void> {
       </p>
       <button
         type="button"
+        class="btn-primary"
         @click="copyKey"
       >
         {{ copyState === 'copied' ? t('key.generator.result.copied') : copyState === 'error' ? t('key.generator.result.copyError') : t('key.generator.result.copy') }}
@@ -161,7 +162,7 @@ async function copyKey(): Promise<void> {
 }
 
 .key-generator-form__error {
-  color: #c0392b;
+  color: var(--danger);
 }
 
 .key-generator-form__submit {

--- a/frontend/src/components/KeyParserForm.vue
+++ b/frontend/src/components/KeyParserForm.vue
@@ -66,7 +66,7 @@ watch(
 
     <button
       type="submit"
-      class="key-parser-form__submit"
+      class="key-parser-form__submit btn-primary"
       :disabled="!canParse"
     >
       <LoadingSpinner v-if="store.parseStatus === 'loading'" />
@@ -126,7 +126,7 @@ watch(
 }
 
 .key-parser-form__error {
-  color: #c0392b;
+  color: var(--danger);
 }
 
 .key-parser-form__submit {

--- a/frontend/src/components/KeyParserForm.vue
+++ b/frontend/src/components/KeyParserForm.vue
@@ -86,6 +86,11 @@ function handleParse(): void {
   flex-direction: column;
   gap: 16px;
   max-width: 480px;
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 20px;
 }
 
 .key-parser-form__field {

--- a/frontend/src/components/KeyParserForm.vue
+++ b/frontend/src/components/KeyParserForm.vue
@@ -58,7 +58,7 @@ function handleParse(): void {
       class="key-parser-form__error"
       role="alert"
     >
-      {{ store.parseErrorMessage ?? t(`errors.${store.parseErrorCode}`) }}
+      {{ store.parseErrorMessage ? t('key.parser.form.error.prefix', { detail: store.parseErrorMessage }) : t(`errors.${store.parseErrorCode}`) }}
     </p>
 
     <dl

--- a/frontend/src/components/KeyParserForm.vue
+++ b/frontend/src/components/KeyParserForm.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useKeyStore } from '../stores/key'
 import { isValidKeyFormat } from '../utils/key-format'
+import { revealResult } from '../utils/reveal-result'
+import LoadingSpinner from './LoadingSpinner.vue'
 
 const store = useKeyStore()
 const { t } = useI18n()
@@ -21,11 +23,27 @@ function handleParse(): void {
   if (!canParse.value) return
   void store.parse()
 }
+
+const errorRef = ref<HTMLElement | null>(null)
+const resultRef = ref<HTMLElement | null>(null)
+
+watch(
+  () => store.parseStatus,
+  async (status) => {
+    await nextTick()
+    if (status === 'success') {
+      revealResult(resultRef.value, { focus: true })
+    } else if (status === 'error') {
+      revealResult(errorRef.value)
+    }
+  },
+)
 </script>
 
 <template>
   <form
     class="key-parser-form"
+    :aria-busy="store.parseStatus === 'loading'"
     @submit.prevent="handleParse"
   >
     <h2>{{ t('key.parser.title') }}</h2>
@@ -48,13 +66,16 @@ function handleParse(): void {
 
     <button
       type="submit"
+      class="key-parser-form__submit"
       :disabled="!canParse"
     >
+      <LoadingSpinner v-if="store.parseStatus === 'loading'" />
       {{ store.parseStatus === 'loading' ? t('key.parser.form.submit.loading') : t('key.parser.form.submit.label') }}
     </button>
 
     <p
       v-if="store.parseStatus === 'error'"
+      ref="errorRef"
       class="key-parser-form__error"
       role="alert"
     >
@@ -63,7 +84,12 @@ function handleParse(): void {
 
     <dl
       v-if="store.parseStatus === 'success' && store.parsedParams"
+      ref="resultRef"
       class="key-parser-form__result"
+      role="region"
+      tabindex="-1"
+      aria-live="polite"
+      :aria-label="t('key.parser.result.regionLabel')"
     >
       <dt>{{ t('key.parser.result.pivotBlockSize') }}</dt>
       <dd>{{ store.parsedParams.pivotBlockSize }}</dd>
@@ -101,6 +127,13 @@ function handleParse(): void {
 
 .key-parser-form__error {
   color: #c0392b;
+}
+
+.key-parser-form__submit {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
 }
 
 .key-parser-form__result {

--- a/frontend/src/components/LoadingSpinner.vue
+++ b/frontend/src/components/LoadingSpinner.vue
@@ -1,0 +1,57 @@
+<template>
+  <svg
+    class="loading-spinner"
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    aria-hidden="true"
+    focusable="false"
+  >
+    <circle
+      class="loading-spinner__track"
+      cx="8"
+      cy="8"
+      r="6"
+      fill="none"
+      stroke-width="2"
+    />
+    <circle
+      class="loading-spinner__arc"
+      cx="8"
+      cy="8"
+      r="6"
+      fill="none"
+      stroke-width="2"
+      stroke-linecap="round"
+    />
+  </svg>
+</template>
+
+<style scoped>
+.loading-spinner {
+  flex-shrink: 0;
+}
+
+.loading-spinner__track {
+  stroke: var(--border);
+}
+
+.loading-spinner__arc {
+  stroke: currentColor;
+  stroke-dasharray: 14 24;
+  transform-origin: center;
+  animation: loading-spinner-rotate 0.8s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .loading-spinner__arc {
+    animation: none;
+  }
+}
+
+@keyframes loading-spinner-rotate {
+  to {
+    transform: rotate(360deg);
+  }
+}
+</style>

--- a/frontend/src/components/RotationSequencePicker.spec.ts
+++ b/frontend/src/components/RotationSequencePicker.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
 import draggable from 'vuedraggable'
@@ -62,6 +62,17 @@ describe('RotationSequencePicker', () => {
       const items = wrapper.findAll('li')
       expect(items.map((item) => item.attributes('tabindex'))).toEqual(['-1', '0', '-1', '-1'])
       expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+    })
+
+    it('moves actual DOM focus to the destination item on ArrowRight, not just the roving tabindex', async () => {
+      const wrapper = mountPicker([0, 1, 2, 3])
+      const focusSpy = vi.spyOn(HTMLElement.prototype, 'focus')
+
+      await wrapper.findAll('li')[0].trigger('keydown', { key: 'ArrowRight' })
+
+      const destination = wrapper.findAll('li')[1].element
+      expect(focusSpy.mock.instances).toContain(destination)
+      focusSpy.mockRestore()
     })
 
     it('grabs an item with Space, marking it aria-selected', async () => {

--- a/frontend/src/components/RotationSequencePicker.spec.ts
+++ b/frontend/src/components/RotationSequencePicker.spec.ts
@@ -41,4 +41,64 @@ describe('RotationSequencePicker', () => {
 
     expect(wrapper.emitted('update:modelValue')).toEqual([[[2, 0, 1, 3]]])
   })
+
+  describe('keyboard accessibility', () => {
+    it('exposes listbox/option roles for assistive technology', () => {
+      const wrapper = mountPicker([0, 1, 2, 3])
+      expect(wrapper.find('[role="listbox"]').exists()).toBe(true)
+      expect(wrapper.findAll('[role="option"]').length).toBe(4)
+    })
+
+    it('gives only the first item a roving tabindex by default', () => {
+      const wrapper = mountPicker([0, 1, 2, 3])
+      const items = wrapper.findAll('li')
+      expect(items.map((item) => item.attributes('tabindex'))).toEqual(['0', '-1', '-1', '-1'])
+    })
+
+    it('moves the roving tabindex to the next item on ArrowRight without reordering', async () => {
+      const wrapper = mountPicker([0, 1, 2, 3])
+      await wrapper.findAll('li')[0].trigger('keydown', { key: 'ArrowRight' })
+
+      const items = wrapper.findAll('li')
+      expect(items.map((item) => item.attributes('tabindex'))).toEqual(['-1', '0', '-1', '-1'])
+      expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+    })
+
+    it('grabs an item with Space, marking it aria-selected', async () => {
+      const wrapper = mountPicker([0, 1, 2, 3])
+      await wrapper.findAll('li')[0].trigger('keydown', { key: ' ' })
+      expect(wrapper.findAll('li')[0].attributes('aria-selected')).toBe('true')
+    })
+
+    it('moves a grabbed item with ArrowRight, emitting the reordered indices', async () => {
+      const wrapper = mountPicker([0, 1, 2, 3])
+      await wrapper.findAll('li')[0].trigger('keydown', { key: ' ' })
+      await wrapper.findAll('li')[0].trigger('keydown', { key: 'ArrowRight' })
+
+      expect(wrapper.emitted('update:modelValue')).toEqual([[[1, 0, 2, 3]]])
+    })
+
+    it('drops the grabbed item on a second Space, clearing aria-selected', async () => {
+      const wrapper = mountPicker([0, 1, 2, 3])
+      await wrapper.findAll('li')[0].trigger('keydown', { key: ' ' })
+      await wrapper.findAll('li')[0].trigger('keydown', { key: ' ' })
+      expect(wrapper.findAll('li')[0].attributes('aria-selected')).toBe('false')
+    })
+
+    it('cancels an in-progress reorder on Escape, emitting the pre-grab order', async () => {
+      const wrapper = mountPicker([0, 1, 2, 3])
+      await wrapper.findAll('li')[0].trigger('keydown', { key: ' ' })
+      await wrapper.findAll('li')[0].trigger('keydown', { key: 'ArrowRight' })
+      await wrapper.findAll('li')[0].trigger('keydown', { key: 'Escape' })
+
+      expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([[0, 1, 2, 3]])
+      expect(wrapper.findAll('li')[0].attributes('aria-selected')).toBe('false')
+    })
+
+    it('announces the grabbed state through the live region', async () => {
+      const wrapper = mountPicker([0, 1, 2, 3])
+      await wrapper.findAll('li')[0].trigger('keydown', { key: ' ' })
+      expect(wrapper.find('[role="status"]').text()).toContain('Picked up')
+    })
+  })
 })

--- a/frontend/src/components/RotationSequencePicker.vue
+++ b/frontend/src/components/RotationSequencePicker.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, nextTick, ref } from 'vue'
 import draggable from 'vuedraggable'
 import { useI18n } from 'vue-i18n'
 
@@ -24,6 +24,78 @@ const items = computed<RotationItem[]>({
   get: () => props.modelValue.map((index) => ({ index, angle: ANGLES[index] })),
   set: (value) => emit('update:modelValue', value.map((item) => item.index)),
 })
+
+const focusedKey = ref<number>(items.value[0]?.index ?? 0)
+const grabbedKey = ref<number | null>(null)
+const liveMessage = ref('')
+const itemEls = new Map<number, HTMLLIElement>()
+let preGrabOrder: RotationItem[] = []
+
+function setItemRef(key: number, el: Element | null): void {
+  if (el instanceof HTMLLIElement) {
+    itemEls.set(key, el)
+  } else {
+    itemEls.delete(key)
+  }
+}
+
+async function focusItem(key: number): Promise<void> {
+  await nextTick()
+  itemEls.get(key)?.focus()
+}
+
+function moveItem(fromPos: number, toPos: number): void {
+  const next = [...items.value]
+  const [moved] = next.splice(fromPos, 1)
+  next.splice(toPos, 0, moved)
+  items.value = next
+}
+
+function announce(key: string, params: Record<string, number>): void {
+  liveMessage.value = t(key, params)
+}
+
+function onKeydown(event: KeyboardEvent, key: number): void {
+  const pos = items.value.findIndex((item) => item.index === key)
+  const angle = ANGLES[key]
+
+  if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
+    event.preventDefault()
+    const dir = event.key === 'ArrowRight' ? 1 : -1
+    const newPos = pos + dir
+    if (newPos < 0 || newPos >= items.value.length) return
+
+    if (grabbedKey.value === key) {
+      moveItem(pos, newPos)
+      announce('rotationSequence.moved', { position: newPos + 1, total: items.value.length })
+    } else {
+      focusedKey.value = items.value[newPos].index
+    }
+    void focusItem(key)
+    return
+  }
+
+  if (event.key === ' ' || event.key === 'Enter') {
+    event.preventDefault()
+    if (grabbedKey.value === key) {
+      grabbedKey.value = null
+      announce('rotationSequence.dropped', { angle, position: pos + 1, total: items.value.length })
+    } else {
+      preGrabOrder = [...items.value]
+      grabbedKey.value = key
+      announce('rotationSequence.grabbed', { angle, position: pos + 1, total: items.value.length })
+    }
+    return
+  }
+
+  if (event.key === 'Escape' && grabbedKey.value === key) {
+    event.preventDefault()
+    items.value = preGrabOrder
+    grabbedKey.value = null
+    liveMessage.value = t('rotationSequence.cancelled')
+    void focusItem(key)
+  }
+}
 </script>
 
 <template>
@@ -32,14 +104,76 @@ const items = computed<RotationItem[]>({
     item-key="index"
     tag="ul"
     class="rotation-sequence-picker"
+    role="listbox"
     :aria-label="t('encode.form.rotationSequence.label')"
   >
     <template #item="{ element }: { element: RotationItem }">
-      <li class="rotation-sequence-picker__item">
-        {{ element.angle }}°
+      <li
+        :ref="(el) => setItemRef(element.index, el as Element | null)"
+        class="rotation-sequence-picker__item"
+        role="option"
+        :aria-selected="element.index === grabbedKey"
+        :tabindex="element.index === focusedKey ? 0 : -1"
+        :class="{ 'rotation-sequence-picker__item--grabbed': element.index === grabbedKey }"
+        @keydown="onKeydown($event, element.index)"
+        @focus="focusedKey = element.index"
+      >
+        <svg
+          class="rotation-sequence-picker__handle"
+          width="10"
+          height="16"
+          viewBox="0 0 10 16"
+          aria-hidden="true"
+          focusable="false"
+        >
+          <circle
+            cx="2.5"
+            cy="2.5"
+            r="1.5"
+            fill="currentColor"
+          />
+          <circle
+            cx="7.5"
+            cy="2.5"
+            r="1.5"
+            fill="currentColor"
+          />
+          <circle
+            cx="2.5"
+            cy="8"
+            r="1.5"
+            fill="currentColor"
+          />
+          <circle
+            cx="7.5"
+            cy="8"
+            r="1.5"
+            fill="currentColor"
+          />
+          <circle
+            cx="2.5"
+            cy="13.5"
+            r="1.5"
+            fill="currentColor"
+          />
+          <circle
+            cx="7.5"
+            cy="13.5"
+            r="1.5"
+            fill="currentColor"
+          />
+        </svg>
+        <span>{{ element.angle }}°</span>
       </li>
     </template>
   </draggable>
+  <div
+    class="rotation-sequence-picker__live"
+    role="status"
+    aria-live="polite"
+  >
+    {{ liveMessage }}
+  </div>
 </template>
 
 <style scoped>
@@ -52,10 +186,38 @@ const items = computed<RotationItem[]>({
 }
 
 .rotation-sequence-picker__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   padding: 8px 12px;
   border: 1px solid var(--border);
   border-radius: 4px;
   cursor: grab;
   background: var(--code-bg);
+  color: var(--text);
+}
+
+.rotation-sequence-picker__item--grabbed {
+  cursor: grabbing;
+  border-color: var(--accent);
+  background: var(--accent-bg);
+  color: var(--text-h);
+}
+
+.rotation-sequence-picker__handle {
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.rotation-sequence-picker__live {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 </style>

--- a/frontend/src/components/RotationSequencePicker.vue
+++ b/frontend/src/components/RotationSequencePicker.vue
@@ -68,10 +68,12 @@ function onKeydown(event: KeyboardEvent, key: number): void {
     if (grabbedKey.value === key) {
       moveItem(pos, newPos)
       announce('rotationSequence.moved', { position: newPos + 1, total: items.value.length })
+      void focusItem(key)
     } else {
-      focusedKey.value = items.value[newPos].index
+      const destinationKey = items.value[newPos].index
+      focusedKey.value = destinationKey
+      void focusItem(destinationKey)
     }
-    void focusItem(key)
     return
   }
 
@@ -112,6 +114,7 @@ function onKeydown(event: KeyboardEvent, key: number): void {
         :ref="(el) => setItemRef(element.index, el as Element | null)"
         class="rotation-sequence-picker__item"
         role="option"
+        aria-roledescription="sortable item"
         :aria-selected="element.index === grabbedKey"
         :tabindex="element.index === focusedKey ? 0 : -1"
         :class="{ 'rotation-sequence-picker__item--grabbed': element.index === grabbedKey }"
@@ -190,6 +193,7 @@ function onKeydown(event: KeyboardEvent, key: number): void {
   align-items: center;
   gap: 6px;
   padding: 8px 12px;
+  box-sizing: border-box;
   border: 1px solid var(--border);
   border-radius: 4px;
   cursor: grab;
@@ -199,9 +203,10 @@ function onKeydown(event: KeyboardEvent, key: number): void {
 
 .rotation-sequence-picker__item--grabbed {
   cursor: grabbing;
-  border-color: var(--accent);
+  border: 2px solid var(--accent);
   background: var(--accent-bg);
   color: var(--text-h);
+  box-shadow: var(--shadow);
 }
 
 .rotation-sequence-picker__handle {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -137,6 +137,7 @@
       "result": {
         "regionLabel": "Generated key",
         "keyLabel": "Key",
+        "keyHint": "This key is not stored anywhere. Copy it now.",
         "copy": "Copy",
         "copied": "Copied!",
         "copyError": "Copy failed"
@@ -147,7 +148,7 @@
       "form": {
         "key": {
           "label": "HexaRot key",
-          "placeholder": "HR1·XXXX",
+          "placeholder": "HR1·xxxx",
           "formatError": "This does not look like a valid HexaRot key."
         },
         "submit": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -59,6 +59,7 @@
       }
     },
     "result": {
+      "regionLabel": "Encode result",
       "pngAlt": "PNG cryptogram preview",
       "keyLabel": "Key",
       "copy": "Copy",
@@ -134,6 +135,7 @@
         }
       },
       "result": {
+        "regionLabel": "Generated key",
         "keyLabel": "Key",
         "copy": "Copy",
         "copied": "Copied!",
@@ -157,6 +159,7 @@
         }
       },
       "result": {
+        "regionLabel": "Parsed key parameters",
         "pivotBlockSize": "Pivot block size",
         "rotationSequence": "Rotation sequence",
         "rotationDirection": "Rotation direction",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -154,5 +154,11 @@
   "errors": {
     "network": "Network error: unable to reach the server",
     "unknown": "Something went wrong. Please try again."
+  },
+  "rotationSequence": {
+    "grabbed": "Picked up {angle}°, position {position} of {total}. Use arrow keys to move, space to drop, escape to cancel.",
+    "moved": "Moved to position {position} of {total}.",
+    "dropped": "Dropped {angle}° at position {position} of {total}.",
+    "cancelled": "Reorder cancelled."
   }
 }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -53,6 +53,9 @@
       "submit": {
         "label": "Encode",
         "loading": "Encoding..."
+      },
+      "error": {
+        "prefix": "Couldn't encode this message: {detail}"
       }
     },
     "result": {
@@ -61,6 +64,7 @@
       "copy": "Copy",
       "copied": "Copied!",
       "warningsHeading": "Weakness warnings",
+      "warningsExplanation": "This combination weakens the cryptogram's rotation pattern. You can proceed anyway, or adjust the pivot block size to remove the warning:",
       "unknownCharsExplanation": "The following characters are not part of the alphabet and were dropped during encoding:",
       "downloadPng": "Download PNG",
       "downloadSvg": "Download SVG",
@@ -93,6 +97,9 @@
       "submit": {
         "label": "Decode",
         "loading": "Decoding..."
+      },
+      "error": {
+        "prefix": "Couldn't decode this cryptogram: {detail}"
       }
     },
     "result": {
@@ -121,6 +128,9 @@
         "submit": {
           "label": "Generate",
           "loading": "Generating..."
+        },
+        "error": {
+          "prefix": "Couldn't generate a key: {detail}"
         }
       },
       "result": {
@@ -141,6 +151,9 @@
         "submit": {
           "label": "Parse",
           "loading": "Parsing..."
+        },
+        "error": {
+          "prefix": "Couldn't parse this key: {detail}"
         }
       },
       "result": {
@@ -152,7 +165,7 @@
     }
   },
   "errors": {
-    "network": "Network error: unable to reach the server",
+    "network": "Couldn't reach the server. Check your connection and try again.",
     "unknown": "Something went wrong. Please try again."
   },
   "rotationSequence": {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -60,8 +60,8 @@
     },
     "result": {
       "regionLabel": "Encode result",
-      "pngAlt": "PNG cryptogram preview",
       "keyLabel": "Key",
+      "keyHint": "This key is required to decode your message and is not stored anywhere. Copy or download it now.",
       "copy": "Copy",
       "copied": "Copied!",
       "warningsHeading": "Weakness warnings",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -16,6 +16,9 @@
         "label": "Message",
         "placeholder": "Enter the message to encode"
       },
+      "transformGroup": {
+        "label": "Transformation"
+      },
       "pivotBlockSize": {
         "label": "Pivot block size"
       },
@@ -29,6 +32,9 @@
       },
       "readingOrder": {
         "label": "Reading order"
+      },
+      "outputGroup": {
+        "label": "Output"
       },
       "size": {
         "label": "Cryptogram size",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -48,7 +48,7 @@
       "key": {
         "label": "HexaRot key",
         "placeholder": "HR1·xxxx",
-        "formatError": "This does not look like a valid HexaRot key."
+        "formatError": "A HexaRot key looks like HR1·a3f9 - \"HR\", a version number, a separator, then 4 characters."
       },
       "submit": {
         "label": "Encode",
@@ -86,7 +86,7 @@
       "key": {
         "label": "HexaRot key",
         "placeholder": "HR1·xxxx",
-        "formatError": "This does not look like a valid HexaRot key."
+        "formatError": "A HexaRot key looks like HR1·a3f9 - \"HR\", a version number, a separator, then 4 characters."
       },
       "size": {
         "label": "Cryptogram size",
@@ -149,7 +149,7 @@
         "key": {
           "label": "HexaRot key",
           "placeholder": "HR1·xxxx",
-          "formatError": "This does not look like a valid HexaRot key."
+          "formatError": "A HexaRot key looks like HR1·a3f9 - \"HR\", a version number, a separator, then 4 characters."
         },
         "submit": {
           "label": "Parse",

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -4,6 +4,7 @@ import { createI18n } from 'vue-i18n'
 import App from './App.vue'
 import { router } from './router'
 import en from './locales/en.json'
+import './style.css'
 
 const pinia = createPinia()
 

--- a/frontend/src/stores/decode.spec.ts
+++ b/frontend/src/stores/decode.spec.ts
@@ -51,6 +51,17 @@ describe('useDecodeStore', () => {
     })
   })
 
+  it('normalizes a near-miss key before sending it', async () => {
+    vi.mocked(postJson).mockResolvedValue(MOCK_DECODE_RESPONSE)
+    const store = useDecodeStore()
+    store.file = MOCK_PNG_FILE
+    store.keyInput = 'hr1.a1b2'
+
+    await store.submit()
+
+    expect(postJson).toHaveBeenCalledWith('/decode', expect.objectContaining({ key: 'HR1·a1b2' }))
+  })
+
   it('builds the SVG payload with the raw text content when submitting', async () => {
     vi.mocked(postJson).mockResolvedValue(MOCK_DECODE_RESPONSE)
     const store = useDecodeStore()

--- a/frontend/src/stores/decode.ts
+++ b/frontend/src/stores/decode.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
 import { postJson, ApiError } from '../api/client'
+import { normalizeKeyInput } from '../utils/key-format'
 
 export type DecodeStatus = 'idle' | 'loading' | 'success' | 'error'
 export type CryptogramSize = 'small' | 'medium' | 'large'
@@ -70,7 +71,7 @@ export const useDecodeStore = defineStore('decode', {
         const response = await postJson<{ message: string }>('/decode', {
           cryptogram,
           format,
-          key: this.keyInput,
+          key: normalizeKeyInput(this.keyInput),
           size: this.size,
         })
         this.result = response.message

--- a/frontend/src/stores/encode.spec.ts
+++ b/frontend/src/stores/encode.spec.ts
@@ -49,6 +49,18 @@ describe('useEncodeStore', () => {
     expect(postJson).toHaveBeenCalledWith('/encode', expectedPayload)
   })
 
+  it('normalizes a near-miss key (wrong separator, wrong case) before sending it in key mode', async () => {
+    vi.mocked(postJson).mockResolvedValue(MOCK_ENCODE_RESPONSE)
+    const store = useEncodeStore()
+    store.mode = 'key'
+    store.message = 'hi'
+    store.keyInput = 'hr1.a1b2'
+
+    await store.submit()
+
+    expect(postJson).toHaveBeenCalledWith('/encode', expect.objectContaining({ key: 'HR1·a1b2' }))
+  })
+
   it('sets status to loading while the request is in flight', () => {
     vi.mocked(postJson).mockReturnValue(new Promise(() => {}))
     const store = useEncodeStore()

--- a/frontend/src/stores/encode.ts
+++ b/frontend/src/stores/encode.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
 import { postJson, ApiError } from '../api/client'
+import { normalizeKeyInput } from '../utils/key-format'
 import type { ReadingOrder } from '../constants/reading-orders'
 
 export type EncodeMode = 'params' | 'key'
@@ -63,7 +64,7 @@ export const useEncodeStore = defineStore('encode', {
         this.mode === 'key'
           ? {
               message: this.message,
-              key: this.keyInput,
+              key: normalizeKeyInput(this.keyInput),
               size: this.size,
               overrideWeaknessWarning: this.overrideWeaknessWarning,
             }

--- a/frontend/src/stores/key.spec.ts
+++ b/frontend/src/stores/key.spec.ts
@@ -133,6 +133,16 @@ describe('useKeyStore', () => {
     expect(getJson).toHaveBeenCalledWith('/key/parse', { key: 'HR1·a1b2' })
   })
 
+  it('normalizes a near-miss key before sending it', async () => {
+    vi.mocked(getJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
+    const store = useKeyStore()
+    store.keyInput = 'hr1.a1b2'
+
+    await store.parse()
+
+    expect(getJson).toHaveBeenCalledWith('/key/parse', { key: 'HR1·a1b2' })
+  })
+
   it('sets parseStatus to loading while the parse request is in flight', () => {
     vi.mocked(getJson).mockReturnValue(new Promise(() => {}))
     const store = useKeyStore()

--- a/frontend/src/stores/key.ts
+++ b/frontend/src/stores/key.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
 import { postJson, getJson, ApiError } from '../api/client'
+import { normalizeKeyInput } from '../utils/key-format'
 import type { ReadingOrder } from '../constants/reading-orders'
 
 export type RotationDirection = 'cw' | 'ccw'
@@ -87,7 +88,7 @@ export const useKeyStore = defineStore('key', {
       this.parseErrorCode = null
 
       try {
-        this.parsedParams = await getJson<KeyParseResult>('/key/parse', { key: this.keyInput })
+        this.parsedParams = await getJson<KeyParseResult>('/key/parse', { key: normalizeKeyInput(this.keyInput) })
         this.parseStatus = 'success'
       } catch (err) {
         if (err instanceof ApiError && err.code === 'http') {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,13 +1,17 @@
 :root {
   --text: #6b6375;
   --text-h: #08060d;
-  --text-muted: #a09aa8;
+  --text-muted: #756d80;
   --bg: #fff;
   --border: #e5e4e7;
   --code-bg: #f4f3ec;
   --accent: #aa3bff;
   --accent-bg: rgba(170, 59, 255, 0.1);
   --accent-border: rgba(170, 59, 255, 0.5);
+  --accent-contrast: #08060d;
+  --danger: #c0392b;
+  --warning-border: #b45309;
+  --warning-bg: rgba(180, 83, 9, 0.08);
   --shadow:
     rgba(0, 0, 0, 0.1) 0 10px 15px -3px, rgba(0, 0, 0, 0.05) 0 4px 6px -2px;
 
@@ -34,13 +38,17 @@
   :root {
     --text: #9ca3af;
     --text-h: #f3f4f6;
-    --text-muted: #6b7280;
+    --text-muted: #8890a0;
     --bg: #16171d;
     --border: #2e303a;
     --code-bg: #1f2028;
     --accent: #c084fc;
     --accent-bg: rgba(192, 132, 252, 0.15);
     --accent-border: rgba(192, 132, 252, 0.5);
+    --accent-contrast: #08060d;
+    --danger: #f87171;
+    --warning-border: #fbbf24;
+    --warning-bg: rgba(251, 191, 36, 0.12);
     --shadow:
       rgba(0, 0, 0, 0.4) 0 10px 15px -3px, rgba(0, 0, 0, 0.25) 0 4px 6px -2px;
   }
@@ -87,4 +95,56 @@ input,
 textarea {
   font-family: inherit;
   font-size: 1em;
+}
+
+input[type='text'],
+input[type='number'],
+select,
+textarea {
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 8px 10px;
+  background: var(--bg);
+  color: var(--text-h);
+}
+
+.btn-primary,
+.btn-secondary {
+  min-height: 44px;
+  padding: 10px 20px;
+  border-radius: 4px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.btn-primary:disabled,
+.btn-secondary:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.btn-primary {
+  border: none;
+  background: var(--accent);
+  color: var(--accent-contrast);
+}
+
+.btn-primary:hover:not(:disabled) {
+  filter: brightness(0.92);
+}
+
+.btn-primary:active:not(:disabled) {
+  filter: brightness(0.85);
+}
+
+.btn-secondary {
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-h);
+  font-weight: 500;
+}
+
+.btn-secondary:hover:not(:disabled) {
+  border-color: var(--accent-border);
+  background: var(--accent-bg);
 }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -80,3 +80,11 @@ code {
   outline-offset: 2px;
   border-radius: 4px;
 }
+
+button,
+select,
+input,
+textarea {
+  font-family: inherit;
+  font-size: 1em;
+}

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,6 +1,7 @@
 :root {
   --text: #6b6375;
   --text-h: #08060d;
+  --text-muted: #a09aa8;
   --bg: #fff;
   --border: #e5e4e7;
   --code-bg: #f4f3ec;
@@ -33,6 +34,7 @@
   :root {
     --text: #9ca3af;
     --text-h: #f3f4f6;
+    --text-muted: #6b7280;
     --bg: #16171d;
     --border: #2e303a;
     --code-bg: #1f2028;
@@ -71,4 +73,10 @@ code {
   margin: 0 auto;
   min-height: 100svh;
   box-sizing: border-box;
+}
+
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 4px;
 }

--- a/frontend/src/utils/key-format.spec.ts
+++ b/frontend/src/utils/key-format.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { isValidKeyFormat } from './key-format'
+import { isValidKeyFormat, normalizeKeyInput } from './key-format'
 import { MALFORMED_KEY } from '../__fixtures__/frontend.fixtures'
 
 describe('isValidKeyFormat', () => {
@@ -21,5 +21,33 @@ describe('isValidKeyFormat', () => {
     ['empty string', ''],
   ])('rejects %s', (_label, key) => {
     expect(isValidKeyFormat(key)).toBe(false)
+  })
+
+  it.each([
+    ['lowercase prefix', 'hr1·a1b2'],
+    ['a period instead of the middle dot', 'HR1.a1b2'],
+    ['a hyphen instead of the middle dot', 'HR1-a1b2'],
+    ['an underscore instead of the middle dot', 'HR1_a1b2'],
+    ['a space instead of the middle dot', 'HR1 a1b2'],
+  ])('tolerates %s as a near-miss of the canonical shape', (_label, key) => {
+    expect(isValidKeyFormat(key)).toBe(true)
+  })
+})
+
+describe('normalizeKeyInput', () => {
+  it.each([
+    ['hr1·a1b2', 'HR1·a1b2'],
+    ['HR1.a1b2', 'HR1·a1b2'],
+    ['HR1-a1b2', 'HR1·a1b2'],
+    ['HR1_a1b2', 'HR1·a1b2'],
+    ['HR1 a1b2', 'HR1·a1b2'],
+    [' HR1·a1b2 ', 'HR1·a1b2'],
+    ['HR1·a1b2', 'HR1·a1b2'],
+  ])('rewrites %s to the canonical form %s', (input, expected) => {
+    expect(normalizeKeyInput(input)).toBe(expected)
+  })
+
+  it('leaves genuinely malformed input untouched', () => {
+    expect(normalizeKeyInput(MALFORMED_KEY)).toBe(MALFORMED_KEY)
   })
 })

--- a/frontend/src/utils/key-format.ts
+++ b/frontend/src/utils/key-format.ts
@@ -6,6 +6,25 @@
  */
 const KEY_FORMAT_REGEX = /^HR\d·[0-9A-Za-z]{4}$/
 
+/**
+ * Matches near-misses of the canonical shape: a case-insensitive "HR"
+ * prefix and a separator typed as one of ·, ., -, _ or a space instead of
+ * the middle dot (U+00B7) the backend requires verbatim. Deliberately does
+ * not touch anything that isn't already this exact shape, so a genuinely
+ * malformed key still fails validation with a diagnostic message instead
+ * of being silently "fixed" into something else.
+ */
+const KEY_INPUT_NEAR_MISS = /^hr(\d)[·.\-_ ]([0-9a-z]{4})$/i
+
+/** Rewrites a near-miss key into the exact form the backend accepts. */
+export function normalizeKeyInput(key: string): string {
+  const trimmed = key.trim()
+  const match = KEY_INPUT_NEAR_MISS.exec(trimmed)
+  if (!match) return trimmed
+  const [, version, payload] = match
+  return `HR${version}·${payload}`
+}
+
 export function isValidKeyFormat(key: string): boolean {
-  return KEY_FORMAT_REGEX.test(key.trim())
+  return KEY_FORMAT_REGEX.test(normalizeKeyInput(key))
 }

--- a/frontend/src/utils/reveal-result.spec.ts
+++ b/frontend/src/utils/reveal-result.spec.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { revealResult } from './reveal-result'
+
+function makeElement(): HTMLElement {
+  const el = document.createElement('div')
+  el.scrollIntoView = vi.fn()
+  el.focus = vi.fn()
+  return el
+}
+
+describe('revealResult', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('does nothing when passed null', () => {
+    expect(() => revealResult(null)).not.toThrow()
+  })
+
+  it('scrolls the element into view without focusing it by default', () => {
+    const el = makeElement()
+    revealResult(el)
+    expect(el.scrollIntoView).toHaveBeenCalledWith(expect.objectContaining({ block: 'start' }))
+    expect(el.focus).not.toHaveBeenCalled()
+  })
+
+  it('focuses the element when focus: true is passed', () => {
+    const el = makeElement()
+    revealResult(el, { focus: true })
+    expect(el.focus).toHaveBeenCalledWith({ preventScroll: true })
+  })
+
+  it('scrolls smoothly when the user has no reduced-motion preference', () => {
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: false }))
+    const el = makeElement()
+    revealResult(el)
+    expect(el.scrollIntoView).toHaveBeenCalledWith(expect.objectContaining({ behavior: 'smooth' }))
+  })
+
+  it('scrolls instantly when the user prefers reduced motion', () => {
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: true }))
+    const el = makeElement()
+    revealResult(el)
+    expect(el.scrollIntoView).toHaveBeenCalledWith(expect.objectContaining({ behavior: 'auto' }))
+  })
+
+  it('does not throw when scrollIntoView is unavailable', () => {
+    const el = document.createElement('div')
+    el.focus = vi.fn()
+    expect(() => revealResult(el)).not.toThrow()
+  })
+})

--- a/frontend/src/utils/reveal-result.ts
+++ b/frontend/src/utils/reveal-result.ts
@@ -1,0 +1,16 @@
+function prefersReducedMotion(): boolean {
+  return typeof window.matchMedia === 'function' && window.matchMedia('(prefers-reduced-motion: reduce)').matches
+}
+
+/** Scrolls a newly appeared result or error into view, optionally moving focus to it. */
+export function revealResult(el: HTMLElement | null, options: { focus?: boolean } = {}): void {
+  if (!el) return
+
+  if (typeof el.scrollIntoView === 'function') {
+    el.scrollIntoView({ behavior: prefersReducedMotion() ? 'auto' : 'smooth', block: 'start' })
+  }
+
+  if (options.focus && typeof el.focus === 'function') {
+    el.focus({ preventScroll: true })
+  }
+}

--- a/frontend/src/views/DecodeView.vue
+++ b/frontend/src/views/DecodeView.vue
@@ -37,6 +37,7 @@ onUnmounted(() => {
 .decode-view {
   display: flex;
   flex-direction: column;
+  align-items: center;
   gap: 24px;
 }
 

--- a/frontend/src/views/DecodeView.vue
+++ b/frontend/src/views/DecodeView.vue
@@ -64,6 +64,6 @@ onUnmounted(() => {
 }
 
 .decode-view__error {
-  color: #c0392b;
+  color: var(--danger);
 }
 </style>

--- a/frontend/src/views/DecodeView.vue
+++ b/frontend/src/views/DecodeView.vue
@@ -21,7 +21,7 @@ onUnmounted(() => {
       class="decode-view__error"
       role="alert"
     >
-      {{ store.errorMessage ?? t(`errors.${store.errorCode}`) }}
+      {{ store.errorMessage ? t('decode.form.error.prefix', { detail: store.errorMessage }) : t(`errors.${store.errorCode}`) }}
     </p>
     <p
       v-if="store.status === 'success' && store.result"

--- a/frontend/src/views/DecodeView.vue
+++ b/frontend/src/views/DecodeView.vue
@@ -1,11 +1,27 @@
 <script setup lang="ts">
-import { onUnmounted } from 'vue'
+import { nextTick, onUnmounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useDecodeStore } from '../stores/decode'
+import { revealResult } from '../utils/reveal-result'
 import DecodeParamsForm from '../components/DecodeParamsForm.vue'
 
 const store = useDecodeStore()
 const { t } = useI18n()
+
+const errorRef = ref<HTMLElement | null>(null)
+const resultRef = ref<HTMLElement | null>(null)
+
+watch(
+  () => store.status,
+  async (status) => {
+    await nextTick()
+    if (status === 'success') {
+      revealResult(resultRef.value, { focus: true })
+    } else if (status === 'error') {
+      revealResult(errorRef.value)
+    }
+  },
+)
 
 onUnmounted(() => {
   store.reset()
@@ -13,11 +29,15 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div class="decode-view">
+  <div
+    class="decode-view"
+    :aria-busy="store.status === 'loading'"
+  >
     <h1>{{ t('decode.title') }}</h1>
     <DecodeParamsForm />
     <p
       v-if="store.status === 'error'"
+      ref="errorRef"
       class="decode-view__error"
       role="alert"
     >
@@ -25,7 +45,9 @@ onUnmounted(() => {
     </p>
     <p
       v-if="store.status === 'success' && store.result"
+      ref="resultRef"
       class="decode-view__result"
+      tabindex="-1"
       aria-live="polite"
     >
       <strong>{{ t('decode.result.label') }}:</strong> {{ store.result }}

--- a/frontend/src/views/EncodeView.spec.ts
+++ b/frontend/src/views/EncodeView.spec.ts
@@ -58,7 +58,7 @@ describe('EncodeView', () => {
 
     it('does not display a cryptogram preview on initial render', () => {
       const wrapper = mountView()
-      expect(wrapper.find('img').exists()).toBe(false)
+      expect(wrapper.find('.encode-result-panel__svg').exists()).toBe(false)
     })
 
     it('does not display warnings or unknown chars on initial render', () => {
@@ -156,11 +156,6 @@ describe('EncodeView', () => {
       return wrapper
     }
 
-    it('displays the PNG preview after a successful encode response', async () => {
-      const wrapper = await submitAndResolve()
-      expect(wrapper.find('img').attributes('src')).toContain(MOCK_ENCODE_RESPONSE.png)
-    })
-
     it('displays the SVG preview after a successful encode response', async () => {
       const wrapper = await submitAndResolve()
       expect(wrapper.find('.encode-result-panel__svg svg').exists()).toBe(true)
@@ -245,7 +240,7 @@ describe('EncodeView', () => {
       await wrapper.find('form').trigger('submit')
       await flushPromises()
 
-      expect(wrapper.find('img').exists()).toBe(false)
+      expect(wrapper.find('.encode-result-panel__svg').exists()).toBe(false)
     })
 
     it('clears the previous result when a new submission is made', async () => {
@@ -254,12 +249,12 @@ describe('EncodeView', () => {
       await wrapper.find('textarea').setValue('hello world')
       await wrapper.find('form').trigger('submit')
       await flushPromises()
-      expect(wrapper.find('img').exists()).toBe(true)
+      expect(wrapper.find('.encode-result-panel__svg').exists()).toBe(true)
 
       vi.mocked(postJson).mockReturnValue(new Promise(() => {}))
       await wrapper.find('form').trigger('submit')
 
-      expect(wrapper.find('img').exists()).toBe(false)
+      expect(wrapper.find('.encode-result-panel__svg').exists()).toBe(false)
     })
   })
 

--- a/frontend/src/views/EncodeView.spec.ts
+++ b/frontend/src/views/EncodeView.spec.ts
@@ -269,4 +269,38 @@ describe('EncodeView', () => {
       expect(wrapper.find('button[type="submit"]').text()).toBe(en.encode.form.submit.label)
     })
   })
+
+  describe('submit feedback', () => {
+    it('marks the view busy and shows a spinner while the request is in flight', async () => {
+      vi.mocked(postJson).mockReturnValue(new Promise(() => {}))
+      const wrapper = mountView()
+      await wrapper.find('textarea').setValue('hello world')
+      await wrapper.find('form').trigger('submit')
+
+      expect(wrapper.find('.encode-view').attributes('aria-busy')).toBe('true')
+      expect(wrapper.find('.loading-spinner').exists()).toBe(true)
+    })
+
+    it('moves focus to the result panel after a successful encode', async () => {
+      const focusSpy = vi.spyOn(HTMLElement.prototype, 'focus')
+      vi.mocked(postJson).mockResolvedValue(MOCK_ENCODE_RESPONSE)
+      const wrapper = mountView()
+      await wrapper.find('textarea').setValue('hello world')
+      await wrapper.find('form').trigger('submit')
+      await flushPromises()
+
+      expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true })
+      focusSpy.mockRestore()
+    })
+
+    it('does not mark the view busy once the request has settled', async () => {
+      vi.mocked(postJson).mockResolvedValue(MOCK_ENCODE_RESPONSE)
+      const wrapper = mountView()
+      await wrapper.find('textarea').setValue('hello world')
+      await wrapper.find('form').trigger('submit')
+      await flushPromises()
+
+      expect(wrapper.find('.encode-view').attributes('aria-busy')).toBe('false')
+    })
+  })
 })

--- a/frontend/src/views/EncodeView.spec.ts
+++ b/frontend/src/views/EncodeView.spec.ts
@@ -3,6 +3,7 @@ import { mount, flushPromises } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { createI18n } from 'vue-i18n'
 import EncodeView from './EncodeView.vue'
+import { useEncodeStore } from '../stores/encode'
 import en from '../locales/en.json'
 import {
   MOCK_ENCODE_RESPONSE,
@@ -296,6 +297,35 @@ describe('EncodeView', () => {
       await flushPromises()
 
       expect(wrapper.find('.encode-view').attributes('aria-busy')).toBe('false')
+    })
+  })
+
+  describe('unmount', () => {
+    it('does not reset the store when the view unmounts after a successful encode', async () => {
+      vi.mocked(postJson).mockResolvedValue(MOCK_ENCODE_RESPONSE)
+      const wrapper = mountView()
+      await wrapper.find('textarea').setValue('hello world')
+      await wrapper.find('form').trigger('submit')
+      await flushPromises()
+
+      const store = useEncodeStore()
+      expect(store.result).toEqual(MOCK_ENCODE_RESPONSE)
+
+      wrapper.unmount()
+
+      expect(store.result).toEqual(MOCK_ENCODE_RESPONSE)
+      expect(store.status).toBe('success')
+    })
+
+    it('resets the store when the view unmounts without a successful encode', () => {
+      const wrapper = mountView()
+      const store = useEncodeStore()
+      store.message = 'a draft message'
+
+      wrapper.unmount()
+
+      expect(store.message).toBe('')
+      expect(store.status).toBe('idle')
     })
   })
 })

--- a/frontend/src/views/EncodeView.vue
+++ b/frontend/src/views/EncodeView.vue
@@ -30,6 +30,7 @@ const { t } = useI18n()
 .encode-view {
   display: flex;
   flex-direction: column;
+  align-items: center;
   gap: 24px;
 }
 

--- a/frontend/src/views/EncodeView.vue
+++ b/frontend/src/views/EncodeView.vue
@@ -63,6 +63,6 @@ onUnmounted(() => {
 }
 
 .encode-view__error {
-  color: #c0392b;
+  color: var(--danger);
 }
 </style>

--- a/frontend/src/views/EncodeView.vue
+++ b/frontend/src/views/EncodeView.vue
@@ -1,19 +1,40 @@
 <script setup lang="ts">
+import { nextTick, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useEncodeStore } from '../stores/encode'
+import { revealResult } from '../utils/reveal-result'
 import EncodeParamsForm from '../components/EncodeParamsForm.vue'
 import EncodeResultPanel from '../components/EncodeResultPanel.vue'
 
 const store = useEncodeStore()
 const { t } = useI18n()
+
+const errorRef = ref<HTMLElement | null>(null)
+const resultRef = ref<InstanceType<typeof EncodeResultPanel> | null>(null)
+
+watch(
+  () => store.status,
+  async (status) => {
+    await nextTick()
+    if (status === 'success') {
+      revealResult(resultRef.value?.$el ?? null, { focus: true })
+    } else if (status === 'error') {
+      revealResult(errorRef.value)
+    }
+  },
+)
 </script>
 
 <template>
-  <div class="encode-view">
+  <div
+    class="encode-view"
+    :aria-busy="store.status === 'loading'"
+  >
     <h1>{{ t('encode.title') }}</h1>
     <EncodeParamsForm />
     <p
       v-if="store.status === 'error'"
+      ref="errorRef"
       class="encode-view__error"
       role="alert"
     >
@@ -21,6 +42,7 @@ const { t } = useI18n()
     </p>
     <EncodeResultPanel
       v-if="store.status === 'success' && store.result"
+      ref="resultRef"
       :result="store.result"
     />
   </div>

--- a/frontend/src/views/EncodeView.vue
+++ b/frontend/src/views/EncodeView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { nextTick, ref, watch } from 'vue'
+import { nextTick, onUnmounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useEncodeStore } from '../stores/encode'
 import { revealResult } from '../utils/reveal-result'
@@ -23,6 +23,10 @@ watch(
     }
   },
 )
+
+onUnmounted(() => {
+  store.reset()
+})
 </script>
 
 <template>

--- a/frontend/src/views/EncodeView.vue
+++ b/frontend/src/views/EncodeView.vue
@@ -25,7 +25,9 @@ watch(
 )
 
 onUnmounted(() => {
-  store.reset()
+  if (store.status !== 'success') {
+    store.reset()
+  }
 })
 </script>
 

--- a/frontend/src/views/EncodeView.vue
+++ b/frontend/src/views/EncodeView.vue
@@ -17,7 +17,7 @@ const { t } = useI18n()
       class="encode-view__error"
       role="alert"
     >
-      {{ store.errorMessage ?? t(`errors.${store.errorCode}`) }}
+      {{ store.errorMessage ? t('encode.form.error.prefix', { detail: store.errorMessage }) : t(`errors.${store.errorCode}`) }}
     </p>
     <EncodeResultPanel
       v-if="store.status === 'success' && store.result"

--- a/frontend/src/views/KeyView.vue
+++ b/frontend/src/views/KeyView.vue
@@ -25,6 +25,7 @@ onUnmounted(() => {
 .key-view {
   display: flex;
   flex-direction: column;
+  align-items: center;
   gap: 32px;
 }
 </style>


### PR DESCRIPTION
## Summary

REFACTOR-001: full UI/UX design pass on the three V1 frontend views (encode, decode, key), driven by the `impeccable` design skill's audit -> layout -> harden -> clarify -> animate -> bolder -> polish workflow, followed by a re-critique and a second fix round.

Design Health Score: 9/40 (Critical) -> 18/40 (Poor), confirmed by a dual-agent critique (design review + detector/browser evidence) before and after.

## What changed

- Wired up the previously-dead `style.css` design token system (the root cause of the baseline 9/40 score - the app rendered unstyled Times New Roman) 
- Grouped the Encode form into labeled sections, gave the Key view's two tools real card boundaries, centred content at desktop widths
- Made the rotation-sequence picker fully keyboard-operable: listbox/option roles, roving tabindex, arrow-key reordering, Space to grab/drop, Escape to cancel, live region announcements, an authored SVG grab handle
- Replaced raw server error text and raw GCD warning math with plain-language framing
- Added submit feedback across all five forms: loading spinner, aria-busy, scroll+focus to the result on success, scroll to the error on failure
- Promoted the HexaRot key (the product's actual output) to its own visual weight: single elevated preview, bordered accent-tinted key block, reassurance copy - applied consistently to both the Encode result and the Key-generator result
- Final polish: consistent placeholder casing, Encode resets on unmount like its siblings, more generous message textarea

### Second round (post-polish re-critique)

- **Fixed a P0 introduced by this branch's own final polish step**: navigating away from Encode after a successful result silently destroyed the key with no warning
- Fixed a real bug in the rotation-picker's keyboard support: DOM focus wasn't actually following the roving-tabindex model, trapping keyboard users on one item
- Introduced a primary/secondary button system (the app had no button hierarchy at all - every submit action was an unstyled 30px native button) the hardcoded error red in dark mode) and gave warnings their own token instead of
borrowing error-red 
- Made HexaRot key input tolerant of case/separator near-misses, with a diagnostic error message for genuinely malformed input

## Deferred

A few deeper, structural findings from the re-critique were deliberately kept out of this branch and logged as `REFACTOR-002` in BACKLOG.md: a two-column desktop layout (the current single-column stack means the result can't actually be scrolled into view on common viewport heights), stale-result invalidation when form parameters change after a successful encode, and carrying/inferring the cryptogram size so Decode doesn't require the user to recall it.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` (vue-tsc + vite) clean
- [x] `npm run test` - 176/176 passing (was 139 at branch start; net +37 new tests covering keyboard accessibility, submit feedback, key normalization, and the encode-unmount fix)
- [x] Manual verification in-browser at each step: desktop + mobile widths, keyboard navigation, console error checks, computed-style contrast checks
- [x] Re-critique confirms the score improvement and the specific fixes landed
