### PR TITLE
refactor(frontend): invalidate a stale encode result on parameter change

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1562,7 +1562,7 @@ since they are a different kind of work.
 - **type:** refactor
 - **id:** REFACTOR-003
 - **milestone:** v2
-- **status:** ready
+- **status:** done
 - **priority:** medium
 - **domain:** frontend
 - **complexity:** S

--- a/frontend/src/components/EncodeParamsForm.vue
+++ b/frontend/src/components/EncodeParamsForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useEncodeStore } from '../stores/encode'
 import { READING_ORDERS } from '../constants/reading-orders'
@@ -9,6 +9,21 @@ import LoadingSpinner from './LoadingSpinner.vue'
 
 const store = useEncodeStore()
 const { t } = useI18n()
+
+watch(
+  () => [
+    store.mode,
+    store.message,
+    store.pivotBlockSize,
+    store.rotationSequence,
+    store.rotationDirection,
+    store.readingOrder,
+    store.size,
+    store.overrideWeaknessWarning,
+    store.keyInput,
+  ],
+  () => store.invalidateResult(),
+)
 
 const keyFormatError = computed(() => {
   if (store.mode !== 'key' || store.keyInput.length === 0) return null

--- a/frontend/src/stores/encode.spec.ts
+++ b/frontend/src/stores/encode.spec.ts
@@ -127,4 +127,36 @@ describe('useEncodeStore', () => {
     expect(store.status).toBe('idle')
     expect(store.result).toBeNull()
   })
+
+  describe('invalidateResult', () => {
+    it('clears a successful result back to idle', async () => {
+      vi.mocked(postJson).mockResolvedValue(MOCK_ENCODE_RESPONSE)
+      const store = useEncodeStore()
+      await store.submit()
+
+      store.invalidateResult()
+
+      expect(store.status).toBe('idle')
+      expect(store.result).toBeNull()
+    })
+
+    it('does nothing when there is no successful result to invalidate', () => {
+      const store = useEncodeStore()
+
+      store.invalidateResult()
+
+      expect(store.status).toBe('idle')
+      expect(store.result).toBeNull()
+    })
+
+    it('does not clear an in-flight request', () => {
+      vi.mocked(postJson).mockReturnValue(new Promise(() => {}))
+      const store = useEncodeStore()
+      void store.submit()
+
+      store.invalidateResult()
+
+      expect(store.status).toBe('loading')
+    })
+  })
 })

--- a/frontend/src/stores/encode.ts
+++ b/frontend/src/stores/encode.ts
@@ -97,5 +97,11 @@ export const useEncodeStore = defineStore('encode', {
     reset(): void {
       Object.assign(this, initialState())
     },
+    /** Clears a previous result once the parameters that produced it have changed. */
+    invalidateResult(): void {
+      if (this.status !== 'success') return
+      this.status = 'idle'
+      this.result = null
+    },
   },
 })

--- a/frontend/src/views/EncodeView.spec.ts
+++ b/frontend/src/views/EncodeView.spec.ts
@@ -183,6 +183,52 @@ describe('EncodeView', () => {
     })
   })
 
+  describe('stale result invalidation', () => {
+    async function submitAndResolve() {
+      vi.mocked(postJson).mockResolvedValue(MOCK_ENCODE_RESPONSE)
+      const wrapper = mountView()
+      await wrapper.find('textarea').setValue('hello world')
+      await wrapper.find('form').trigger('submit')
+      await flushPromises()
+      return wrapper
+    }
+
+    it('clears the result when the message is edited after a successful encode', async () => {
+      const wrapper = await submitAndResolve()
+      expect(wrapper.text()).toContain(MOCK_ENCODE_RESPONSE.key)
+
+      await wrapper.find('textarea').setValue('a completely different message')
+
+      expect(wrapper.text()).not.toContain(MOCK_ENCODE_RESPONSE.key)
+      expect(wrapper.find('.encode-result-panel__svg').exists()).toBe(false)
+    })
+
+    it('clears the result when the pivot block size is edited after a successful encode', async () => {
+      const wrapper = await submitAndResolve()
+
+      await wrapper.find('input[type="number"]').setValue(99)
+
+      expect(wrapper.find('.encode-result-panel__svg').exists()).toBe(false)
+    })
+
+    it('clears the result when the mode is switched after a successful encode', async () => {
+      const wrapper = await submitAndResolve()
+
+      await wrapper.find('input[type="radio"][value="key"]').setValue()
+
+      expect(wrapper.find('.encode-result-panel__svg').exists()).toBe(false)
+    })
+
+    it('does not clear anything before a result exists', async () => {
+      const wrapper = mountView()
+
+      await wrapper.find('textarea').setValue('hello world')
+
+      const store = useEncodeStore()
+      expect(store.status).toBe('idle')
+    })
+  })
+
   describe('warnings and unknown chars', () => {
     it('displays weakness warnings when the API response includes them', async () => {
       vi.mocked(postJson).mockResolvedValue(MOCK_ENCODE_RESPONSE_WITH_WARNINGS)


### PR DESCRIPTION
## Summary

REFACTOR-003: the Encode result (cryptogram + key) no longer lingers on screen after the parameters that produced it change.

Editing the message or any transform parameter after a successful encode previously left the old cryptogram and key on screen, still fully downloadable and copyable, with no indication they no longer matched the current form state - a user could produce a key/image pair that would never decode together.

Three approaches were on the table (clear the result / dim it and disable its actions / auto-resubmit); clearing was chosen for simplicity and to avoid introducing a new visual "stale" state, consistent with how the app already behaves on a fresh submit.

## What changed

- `stores/encode.ts`: new `invalidateResult()` action, resets `status`/`result` back to `idle` only when a result currently exists (no-op otherwise, and never interrupts an in-flight request)
- `components/EncodeParamsForm.vue`: watches every field that feeds the encode payload (mode, message, pivotBlockSize, rotationSequence, rotationDirection, readingOrder, size, overrideWeaknessWarning, keyInput) and calls
`invalidateResult()` on change

## Scope note

Scoped to Encode only, per the backlog item - Decode's result is a re-derivable message and Key's is a re-generatable key, neither carries the same mismatched-artifact risk as an Encode key/cryptogram pair. 

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] `npm run test` - 183/183 passing (7 new tests: the store action directly, plus message/pivot-size/mode-switch all clearing a displayed result, and a guard test that nothing happens before a result exists) 
- [x] Verified live: encode a message, edit the pivot block size afterward - the entire result panel (preview, key card, download buttons) disappears immediately
