### PR TITLE
fix(frontend): critique round 4 - error scroll, decode/parser staleness, contrast, loading state, i18n

### DIFF
--- a/frontend/src/components/DecodeParamsForm.vue
+++ b/frontend/src/components/DecodeParamsForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useDecodeStore } from '../stores/decode'
 import { isValidKeyFormat } from '../utils/key-format'
@@ -8,6 +8,11 @@ import LoadingSpinner from './LoadingSpinner.vue'
 
 const store = useDecodeStore()
 const { t } = useI18n()
+
+watch(
+  () => [store.file, store.keyInput, store.size],
+  () => store.invalidateResult(),
+)
 
 const keyFormatError = computed(() => {
   if (store.keyInput.length === 0) return null

--- a/frontend/src/components/EncodeParamsForm.vue
+++ b/frontend/src/components/EncodeParamsForm.vue
@@ -124,7 +124,7 @@ function handleSubmit(): void {
             v-for="order in READING_ORDERS"
             :key="order"
             :value="order"
-          >{{ order }}</option>
+          >{{ t(`readingOrder.${order}`) }}</option>
         </select>
       </label>
     </fieldset>

--- a/frontend/src/components/EncodeResultPanel.spec.ts
+++ b/frontend/src/components/EncodeResultPanel.spec.ts
@@ -92,6 +92,14 @@ describe('EncodeResultPanel', () => {
       expect(blob.type).toBe('image/svg+xml')
       expect(downloadedFilename).toBe('hexarot-cryptogram.svg')
     })
+
+    it('styles Download SVG the same as its Download PNG sibling', () => {
+      const wrapper = mountPanel()
+      const [pngButton, svgButton] = wrapper.findAll('.encode-result-panel__downloads button')
+
+      expect(svgButton.classes()).toContain('btn-secondary')
+      expect(svgButton.classes()).toEqual(pngButton.classes())
+    })
   })
 
   describe('stale state', () => {
@@ -99,6 +107,7 @@ describe('EncodeResultPanel', () => {
       const wrapper = mountPanel()
 
       expect(wrapper.find('.encode-result-panel__stale-notice').exists()).toBe(false)
+      expect(wrapper.find('.encode-result-panel__stale-badge').exists()).toBe(false)
       expect(wrapper.find('.encode-result-panel__key button').attributes('disabled')).toBeUndefined()
       const downloadButtons = wrapper.findAll('.encode-result-panel__downloads button')
       expect(downloadButtons[0].attributes('disabled')).toBeUndefined()
@@ -113,6 +122,12 @@ describe('EncodeResultPanel', () => {
       const downloadButtons = wrapper.findAll('.encode-result-panel__downloads button')
       expect(downloadButtons[0].attributes('disabled')).toBeDefined()
       expect(downloadButtons[1].attributes('disabled')).toBeDefined()
+    })
+
+    it('marks the preview with a badge when stale, so the cryptogram itself keeps its true colors', () => {
+      const wrapper = mountPanel({ stale: true })
+
+      expect(wrapper.find('.encode-result-panel__stale-badge').text()).toBe(en.encode.result.staleBadge)
     })
 
     it('re-encodes with the current store parameters when Re-encode is clicked', async () => {

--- a/frontend/src/components/EncodeResultPanel.vue
+++ b/frontend/src/components/EncodeResultPanel.vue
@@ -86,6 +86,12 @@ function downloadSvg(): void {
       <div class="encode-result-panel__preview">
         <!-- eslint-disable-next-line vue/no-v-html, vue/max-attributes-per-line -- result.svg is generated exclusively by this project's own backend renderer, never from user input, so it is a trusted string. -->
         <div class="encode-result-panel__svg" v-html="result.svg" />
+        <span
+          v-if="stale"
+          class="encode-result-panel__stale-badge"
+        >
+          {{ t('encode.result.staleBadge') }}
+        </span>
       </div>
 
       <div class="encode-result-panel__key">
@@ -147,6 +153,7 @@ function downloadSvg(): void {
         </button>
         <button
           type="button"
+          class="btn-secondary"
           :disabled="stale"
           @click="downloadSvg"
         >
@@ -187,17 +194,37 @@ function downloadSvg(): void {
   gap: 16px;
 }
 
-.encode-result-panel__content--stale {
+/*
+ * The cryptogram's cell colors are the message - dimming them with opacity
+ * would display factually wrong colors while claiming to just mark the
+ * result "stale". Everything except the preview dims normally; the preview
+ * stays at full color fidelity and gets a corner badge instead.
+ */
+.encode-result-panel__content--stale > :not(.encode-result-panel__preview) {
   opacity: 0.5;
 }
 
 .encode-result-panel__preview {
+  position: relative;
   display: flex;
   justify-content: center;
   padding: 20px;
   border: 1px solid var(--border);
   border-radius: 8px;
   box-shadow: var(--shadow);
+}
+
+.encode-result-panel__stale-badge {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  padding: 2px 8px;
+  border: 1px solid var(--warning-border);
+  border-radius: 4px;
+  background: var(--warning-bg);
+  color: var(--text-h);
+  font-size: 0.75em;
+  font-weight: 600;
 }
 
 .encode-result-panel__svg {

--- a/frontend/src/components/KeyGeneratorForm.vue
+++ b/frontend/src/components/KeyGeneratorForm.vue
@@ -30,7 +30,7 @@ watch(
     if (status === 'success') {
       revealResult(resultRef.value, { focus: true })
     } else if (status === 'error') {
-      revealResult(errorRef.value)
+      revealResult(errorRef.value, { focus: true })
     }
   },
 )
@@ -118,6 +118,7 @@ async function copyKey(): Promise<void> {
       ref="errorRef"
       class="key-generator-form__error"
       role="alert"
+      tabindex="-1"
     >
       {{ store.generateErrorMessage ? t('key.generator.form.error.prefix', { detail: store.generateErrorMessage }) : t(`errors.${store.generateErrorCode}`) }}
     </p>

--- a/frontend/src/components/KeyGeneratorForm.vue
+++ b/frontend/src/components/KeyGeneratorForm.vue
@@ -100,7 +100,7 @@ async function copyKey(): Promise<void> {
           v-for="order in READING_ORDERS"
           :key="order"
           :value="order"
-        >{{ order }}</option>
+        >{{ t(`readingOrder.${order}`) }}</option>
       </select>
     </label>
 

--- a/frontend/src/components/KeyParserForm.spec.ts
+++ b/frontend/src/components/KeyParserForm.spec.ts
@@ -59,7 +59,18 @@ describe('KeyParserForm', () => {
     expect(wrapper.text()).toContain(String(MOCK_KEY_PARSE_RESPONSE.pivotBlockSize))
     expect(wrapper.text()).toContain('0°, 90°, 180°, 270°')
     expect(wrapper.text()).toContain(en.key.generator.form.rotationDirection[MOCK_KEY_PARSE_RESPONSE.rotationDirection])
-    expect(wrapper.text()).toContain(MOCK_KEY_PARSE_RESPONSE.readingOrder)
+    expect(wrapper.text()).toContain(en.readingOrder[MOCK_KEY_PARSE_RESPONSE.readingOrder as keyof typeof en.readingOrder])
+  })
+
+  it('translates the reading order to a human-readable label, not the raw code', async () => {
+    vi.mocked(getJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
+    const wrapper = mountForm()
+
+    await wrapper.find('input[type="text"]').setValue('HR1·a1b2')
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(wrapper.text()).not.toContain(MOCK_KEY_PARSE_RESPONSE.readingOrder)
   })
 
   it('translates the rotation direction to a human-readable label, matching the generator form', async () => {

--- a/frontend/src/components/KeyParserForm.spec.ts
+++ b/frontend/src/components/KeyParserForm.spec.ts
@@ -93,4 +93,35 @@ describe('KeyParserForm', () => {
 
     expect(wrapper.text()).toContain('unsupported key version')
   })
+
+  describe('stale parsed parameters', () => {
+    it('marks the parsed parameters stale, without removing them, when the key input changes', async () => {
+      vi.mocked(getJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
+      const wrapper = mountForm()
+      await wrapper.find('input[type="text"]').setValue('HR1·a1b2')
+      await wrapper.find('form').trigger('submit')
+      await flushPromises()
+      expect(wrapper.text()).toContain(String(MOCK_KEY_PARSE_RESPONSE.pivotBlockSize))
+
+      await wrapper.find('input[type="text"]').setValue('HR1·b2c3')
+
+      expect(wrapper.text()).toContain(String(MOCK_KEY_PARSE_RESPONSE.pivotBlockSize))
+      expect(wrapper.find('.key-parser-form__stale-notice').exists()).toBe(true)
+    })
+
+    it('clears the stale notice when re-parsing', async () => {
+      vi.mocked(getJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
+      const wrapper = mountForm()
+      await wrapper.find('input[type="text"]').setValue('HR1·a1b2')
+      await wrapper.find('form').trigger('submit')
+      await flushPromises()
+      await wrapper.find('input[type="text"]').setValue('HR1·b2c3')
+      expect(wrapper.find('.key-parser-form__stale-notice').exists()).toBe(true)
+
+      await wrapper.find('.key-parser-form__stale-notice button').trigger('click')
+      await flushPromises()
+
+      expect(wrapper.find('.key-parser-form__stale-notice').exists()).toBe(false)
+    })
+  })
 })

--- a/frontend/src/components/KeyParserForm.vue
+++ b/frontend/src/components/KeyParserForm.vue
@@ -34,7 +34,7 @@ watch(
     if (status === 'success') {
       revealResult(resultRef.value, { focus: true })
     } else if (status === 'error') {
-      revealResult(errorRef.value)
+      revealResult(errorRef.value, { focus: true })
     }
   },
 )
@@ -78,6 +78,7 @@ watch(
       ref="errorRef"
       class="key-parser-form__error"
       role="alert"
+      tabindex="-1"
     >
       {{ store.parseErrorMessage ? t('key.parser.form.error.prefix', { detail: store.parseErrorMessage }) : t(`errors.${store.parseErrorCode}`) }}
     </p>

--- a/frontend/src/components/KeyParserForm.vue
+++ b/frontend/src/components/KeyParserForm.vue
@@ -126,7 +126,7 @@ watch(
         <dd>{{ t(`key.generator.form.rotationDirection.${store.parsedParams.rotationDirection}`) }}</dd>
 
         <dt>{{ t('key.parser.result.readingOrder') }}</dt>
-        <dd>{{ store.parsedParams.readingOrder }}</dd>
+        <dd>{{ t(`readingOrder.${store.parsedParams.readingOrder}`) }}</dd>
       </dl>
     </div>
   </form>

--- a/frontend/src/components/KeyParserForm.vue
+++ b/frontend/src/components/KeyParserForm.vue
@@ -38,6 +38,11 @@ watch(
     }
   },
 )
+
+watch(
+  () => store.keyInput,
+  () => store.invalidateParsed(),
+)
 </script>
 
 <template>
@@ -83,27 +88,47 @@ watch(
       {{ store.parseErrorMessage ? t('key.parser.form.error.prefix', { detail: store.parseErrorMessage }) : t(`errors.${store.parseErrorCode}`) }}
     </p>
 
-    <dl
+    <div
       v-if="store.parseStatus === 'success' && store.parsedParams"
       ref="resultRef"
-      class="key-parser-form__result"
+      class="key-parser-form__result-region"
       role="region"
       tabindex="-1"
       aria-live="polite"
       :aria-label="t('key.parser.result.regionLabel')"
     >
-      <dt>{{ t('key.parser.result.pivotBlockSize') }}</dt>
-      <dd>{{ store.parsedParams.pivotBlockSize }}</dd>
+      <div
+        v-if="store.parsedParamsStale"
+        class="key-parser-form__stale-notice"
+        role="status"
+      >
+        <p>{{ t('key.parser.result.staleNotice') }}</p>
+        <button
+          type="button"
+          class="btn-primary"
+          @click="handleParse"
+        >
+          {{ t('key.parser.result.reparse') }}
+        </button>
+      </div>
 
-      <dt>{{ t('key.parser.result.rotationSequence') }}</dt>
-      <dd>{{ store.parsedParams.rotationSequence.map((angle) => `${angle}°`).join(', ') }}</dd>
+      <dl
+        class="key-parser-form__result"
+        :class="{ 'key-parser-form__result--stale': store.parsedParamsStale }"
+      >
+        <dt>{{ t('key.parser.result.pivotBlockSize') }}</dt>
+        <dd>{{ store.parsedParams.pivotBlockSize }}</dd>
 
-      <dt>{{ t('key.parser.result.rotationDirection') }}</dt>
-      <dd>{{ t(`key.generator.form.rotationDirection.${store.parsedParams.rotationDirection}`) }}</dd>
+        <dt>{{ t('key.parser.result.rotationSequence') }}</dt>
+        <dd>{{ store.parsedParams.rotationSequence.map((angle) => `${angle}°`).join(', ') }}</dd>
 
-      <dt>{{ t('key.parser.result.readingOrder') }}</dt>
-      <dd>{{ store.parsedParams.readingOrder }}</dd>
-    </dl>
+        <dt>{{ t('key.parser.result.rotationDirection') }}</dt>
+        <dd>{{ t(`key.generator.form.rotationDirection.${store.parsedParams.rotationDirection}`) }}</dd>
+
+        <dt>{{ t('key.parser.result.readingOrder') }}</dt>
+        <dd>{{ store.parsedParams.readingOrder }}</dd>
+      </dl>
+    </div>
   </form>
 </template>
 
@@ -137,6 +162,27 @@ watch(
   gap: 8px;
 }
 
+.key-parser-form__result-region {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.key-parser-form__stale-notice {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border: 1px solid var(--warning-border);
+  background: var(--warning-bg);
+  border-radius: 8px;
+}
+
+.key-parser-form__stale-notice p {
+  margin: 0;
+  flex: 1;
+}
+
 .key-parser-form__result {
   display: grid;
   grid-template-columns: auto 1fr;
@@ -145,5 +191,9 @@ watch(
 
 .key-parser-form__result dt {
   font-weight: 600;
+}
+
+.key-parser-form__result--stale {
+  opacity: 0.5;
 }
 </style>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -108,7 +108,9 @@
     },
     "result": {
       "label": "Decoded message",
-      "emptyState": "Your decoded message will appear here."
+      "emptyState": "Your decoded message will appear here.",
+      "staleNotice": "These parameters changed. Re-decode to update this message.",
+      "redecode": "Re-decode"
     }
   },
   "key": {
@@ -170,7 +172,9 @@
         "pivotBlockSize": "Pivot block size",
         "rotationSequence": "Rotation sequence",
         "rotationDirection": "Rotation direction",
-        "readingOrder": "Reading order"
+        "readingOrder": "Reading order",
+        "staleNotice": "The key changed. Re-parse to update these parameters.",
+        "reparse": "Re-parse"
       }
     }
   },

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -66,6 +66,7 @@
       "copy": "Copy",
       "copied": "Copied!",
       "staleNotice": "These parameters changed. Re-encode to update this cryptogram.",
+      "staleBadge": "Out of date",
       "reencode": "Re-encode",
       "warningsHeading": "Weakness warnings",
       "warningsExplanation": "This combination weakens the cryptogram's rotation pattern. You can proceed anyway, or adjust the pivot block size to remove the warning:",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -183,6 +183,16 @@
     "network": "Couldn't reach the server. Check your connection and try again.",
     "unknown": "Something went wrong. Please try again."
   },
+  "readingOrder": {
+    "LR-TB": "Left to right, top to bottom",
+    "RL-TB": "Right to left, top to bottom",
+    "TB-LR": "Top to bottom, left to right",
+    "BT-LR": "Bottom to top, left to right",
+    "LR-TB-ALT": "Left to right, top to bottom (alternating rows)",
+    "RL-TB-ALT": "Right to left, top to bottom (alternating rows)",
+    "TB-LR-ALT": "Top to bottom, left to right (alternating columns)",
+    "BT-LR-ALT": "Bottom to top, left to right (alternating columns)"
+  },
   "rotationSequence": {
     "grabbed": "Picked up {angle}°, position {position} of {total}. Use arrow keys to move, space to drop, escape to cancel.",
     "moved": "Moved to position {position} of {total}.",

--- a/frontend/src/stores/decode.spec.ts
+++ b/frontend/src/stores/decode.spec.ts
@@ -186,4 +186,56 @@ describe('useDecodeStore', () => {
     expect(store.status).toBe('idle')
     expect(store.result).toBeNull()
   })
+
+  describe('invalidateResult', () => {
+    it('marks a successful result stale without clearing it', async () => {
+      vi.mocked(postJson).mockResolvedValue(MOCK_DECODE_RESPONSE)
+      const store = useDecodeStore()
+      store.file = MOCK_PNG_FILE
+      store.keyInput = 'HR1·a1b2'
+      await store.submit()
+
+      store.invalidateResult()
+
+      expect(store.status).toBe('success')
+      expect(store.result).toBe(MOCK_DECODE_RESPONSE.message)
+      expect(store.resultStale).toBe(true)
+    })
+
+    it('does nothing when there is no successful result to invalidate', () => {
+      const store = useDecodeStore()
+
+      store.invalidateResult()
+
+      expect(store.status).toBe('idle')
+      expect(store.resultStale).toBe(false)
+    })
+
+    it('does not mark an in-flight request stale', () => {
+      vi.mocked(postJson).mockReturnValue(new Promise(() => {}))
+      const store = useDecodeStore()
+      store.file = MOCK_PNG_FILE
+      store.keyInput = 'HR1·a1b2'
+      void store.submit()
+
+      store.invalidateResult()
+
+      expect(store.status).toBe('loading')
+      expect(store.resultStale).toBe(false)
+    })
+
+    it('a new submit clears the stale flag', async () => {
+      vi.mocked(postJson).mockResolvedValue(MOCK_DECODE_RESPONSE)
+      const store = useDecodeStore()
+      store.file = MOCK_PNG_FILE
+      store.keyInput = 'HR1·a1b2'
+      await store.submit()
+      store.invalidateResult()
+      expect(store.resultStale).toBe(true)
+
+      await store.submit()
+
+      expect(store.resultStale).toBe(false)
+    })
+  })
 })

--- a/frontend/src/stores/decode.ts
+++ b/frontend/src/stores/decode.ts
@@ -11,6 +11,7 @@ interface DecodeState {
   size: CryptogramSize
   status: DecodeStatus
   result: string | null
+  resultStale: boolean
   errorMessage: string | null
   errorCode: 'network' | 'unknown' | null
 }
@@ -22,6 +23,7 @@ function initialState(): DecodeState {
     size: 'medium',
     status: 'idle',
     result: null,
+    resultStale: false,
     errorMessage: null,
     errorCode: null,
   }
@@ -61,6 +63,7 @@ export const useDecodeStore = defineStore('decode', {
 
       this.status = 'loading'
       this.result = null
+      this.resultStale = false
       this.errorMessage = null
       this.errorCode = null
 
@@ -91,6 +94,11 @@ export const useDecodeStore = defineStore('decode', {
     },
     reset(): void {
       Object.assign(this, initialState())
+    },
+    /** Marks a previous result stale once the parameters that produced it have changed. */
+    invalidateResult(): void {
+      if (this.status !== 'success') return
+      this.resultStale = true
     },
   },
 })

--- a/frontend/src/stores/key.ts
+++ b/frontend/src/stores/key.ts
@@ -28,6 +28,7 @@ interface KeyState {
   keyInput: string
   parseStatus: KeyStatus
   parsedParams: KeyParseResult | null
+  parsedParamsStale: boolean
   parseErrorMessage: string | null
   parseErrorCode: 'network' | 'unknown' | null
 }
@@ -47,6 +48,7 @@ function initialState(): KeyState {
     keyInput: '',
     parseStatus: 'idle',
     parsedParams: null,
+    parsedParamsStale: false,
     parseErrorMessage: null,
     parseErrorCode: null,
   }
@@ -87,6 +89,7 @@ export const useKeyStore = defineStore('key', {
     async parse(): Promise<void> {
       this.parseStatus = 'loading'
       this.parsedParams = null
+      this.parsedParamsStale = false
       this.parseErrorMessage = null
       this.parseErrorCode = null
 
@@ -113,6 +116,11 @@ export const useKeyStore = defineStore('key', {
     invalidateGenerated(): void {
       if (this.generateStatus !== 'success') return
       this.generatedKeyStale = true
+    },
+    /** Marks the parsed parameters stale once the key that produced them has changed. */
+    invalidateParsed(): void {
+      if (this.parseStatus !== 'success') return
+      this.parsedParamsStale = true
     },
   },
 })

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -120,8 +120,8 @@ textarea {
 .btn-primary:disabled,
 .btn-secondary:disabled {
   cursor: not-allowed;
-  background: var(--border);
-  color: var(--text-muted);
+  background: var(--code-bg);
+  color: var(--text);
   border-color: var(--border);
 }
 

--- a/frontend/src/utils/reveal-result.spec.ts
+++ b/frontend/src/utils/reveal-result.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { revealResult } from './reveal-result'
 
 function makeElement(): HTMLElement {
@@ -9,10 +9,6 @@ function makeElement(): HTMLElement {
 }
 
 describe('revealResult', () => {
-  afterEach(() => {
-    vi.unstubAllGlobals()
-  })
-
   it('does nothing when passed null', () => {
     expect(() => revealResult(null)).not.toThrow()
   })
@@ -20,7 +16,7 @@ describe('revealResult', () => {
   it('scrolls the element into view without focusing it by default', () => {
     const el = makeElement()
     revealResult(el)
-    expect(el.scrollIntoView).toHaveBeenCalledWith(expect.objectContaining({ block: 'start' }))
+    expect(el.scrollIntoView).toHaveBeenCalledWith({ behavior: 'auto', block: 'start' })
     expect(el.focus).not.toHaveBeenCalled()
   })
 
@@ -30,25 +26,10 @@ describe('revealResult', () => {
     expect(el.focus).toHaveBeenCalledWith({ preventScroll: true })
   })
 
-  it('scrolls smoothly when the user has no reduced-motion preference', () => {
-    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: false }))
-    const el = makeElement()
-    revealResult(el)
-    expect(el.scrollIntoView).toHaveBeenCalledWith(expect.objectContaining({ behavior: 'smooth' }))
-  })
-
-  it('scrolls instantly when the user prefers reduced motion', () => {
-    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: true }))
-    const el = makeElement()
-    revealResult(el)
-    expect(el.scrollIntoView).toHaveBeenCalledWith(expect.objectContaining({ behavior: 'auto' }))
-  })
-
-  it('scrolls instantly when focus is requested, even with no reduced-motion preference', () => {
-    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: false }))
+  it('always scrolls instantly, whether or not focus is requested', () => {
     const el = makeElement()
     revealResult(el, { focus: true })
-    expect(el.scrollIntoView).toHaveBeenCalledWith(expect.objectContaining({ behavior: 'auto' }))
+    expect(el.scrollIntoView).toHaveBeenCalledWith({ behavior: 'auto', block: 'start' })
   })
 
   it('does not throw when scrollIntoView is unavailable', () => {

--- a/frontend/src/utils/reveal-result.ts
+++ b/frontend/src/utils/reveal-result.ts
@@ -1,22 +1,17 @@
-function prefersReducedMotion(): boolean {
-  return typeof window.matchMedia === 'function' && window.matchMedia('(prefers-reduced-motion: reduce)').matches
-}
-
 /**
  * Scrolls a newly appeared result or error into view, optionally moving focus to it.
  *
- * A smooth scroll and an immediate focus() call don't mix: focusing an element
- * while its scrollIntoView animation is still in flight cancels the animation
- * partway, so the element never actually reaches the viewport. Whenever focus
- * is also requested, the scroll uses 'auto' (an instant jump) instead.
+ * Always scrolls instantly ('auto'). A prior 'smooth' path (used whenever focus
+ * wasn't also requested) never actually reached the target in real browsers:
+ * something in the surrounding re-render cancels the in-flight animation before
+ * it completes, silently leaving the viewport unscrolled. 'auto' has no
+ * animation to cancel.
  */
 export function revealResult(el: HTMLElement | null, options: { focus?: boolean } = {}): void {
   if (!el) return
 
-  const behavior = options.focus || prefersReducedMotion() ? 'auto' : 'smooth'
-
   if (typeof el.scrollIntoView === 'function') {
-    el.scrollIntoView({ behavior, block: 'start' })
+    el.scrollIntoView({ behavior: 'auto', block: 'start' })
   }
 
   if (options.focus && typeof el.focus === 'function') {

--- a/frontend/src/views/DecodeView.spec.ts
+++ b/frontend/src/views/DecodeView.spec.ts
@@ -131,6 +131,19 @@ describe('DecodeView', () => {
 
       expect(wrapper.find('button[type="submit"]').text()).toBe('Decoding...')
     })
+
+    it('keeps the output column occupied with a skeleton while the API call is in progress', async () => {
+      vi.mocked(postJson).mockReturnValue(new Promise(() => {}))
+      const wrapper = mountView()
+      await selectFile(wrapper, MOCK_PNG_FILE)
+      await wrapper.find('input[type="text"]').setValue('HR1·a1b2')
+
+      await wrapper.find('form').trigger('submit')
+      await flushPromises()
+
+      expect(wrapper.find('.decode-view__output-loading').exists()).toBe(true)
+      expect(wrapper.find('.decode-view__output-empty').exists()).toBe(false)
+    })
   })
 
   describe('successful response', () => {

--- a/frontend/src/views/DecodeView.spec.ts
+++ b/frontend/src/views/DecodeView.spec.ts
@@ -152,6 +152,40 @@ describe('DecodeView', () => {
     })
   })
 
+  describe('stale result', () => {
+    it('marks the decoded message stale, without removing it, when the key changes', async () => {
+      vi.mocked(postJson).mockResolvedValue(MOCK_DECODE_RESPONSE)
+      const wrapper = mountView()
+      await selectFile(wrapper, MOCK_PNG_FILE)
+      await wrapper.find('input[type="text"]').setValue('HR1·a1b2')
+      await wrapper.find('form').trigger('submit')
+      await vi.waitFor(() => expect(wrapper.find('.decode-view__result').exists()).toBe(true))
+      await flushPromises()
+
+      await wrapper.find('input[type="text"]').setValue('HR1·b2c3')
+
+      expect(wrapper.find('.decode-view__result').text()).toContain(MOCK_DECODE_RESPONSE.message)
+      expect(wrapper.find('.decode-view__stale-notice').exists()).toBe(true)
+    })
+
+    it('clears the stale notice when re-decoding', async () => {
+      vi.mocked(postJson).mockResolvedValue(MOCK_DECODE_RESPONSE)
+      const wrapper = mountView()
+      await selectFile(wrapper, MOCK_PNG_FILE)
+      await wrapper.find('input[type="text"]').setValue('HR1·a1b2')
+      await wrapper.find('form').trigger('submit')
+      await vi.waitFor(() => expect(wrapper.find('.decode-view__result').exists()).toBe(true))
+      await flushPromises()
+      await wrapper.find('input[type="text"]').setValue('HR1·b2c3')
+      expect(wrapper.find('.decode-view__stale-notice').exists()).toBe(true)
+
+      await wrapper.find('.decode-view__stale-notice button').trigger('click')
+      await flushPromises()
+
+      expect(wrapper.find('.decode-view__stale-notice').exists()).toBe(false)
+    })
+  })
+
   describe('error handling', () => {
     it('displays an error when the key format is invalid (client-side, before the API call)', async () => {
       const wrapper = mountView()

--- a/frontend/src/views/DecodeView.vue
+++ b/frontend/src/views/DecodeView.vue
@@ -23,6 +23,10 @@ watch(
   },
 )
 
+function redecode(): void {
+  void store.submit()
+}
+
 onUnmounted(() => {
   store.reset()
 })
@@ -46,15 +50,35 @@ onUnmounted(() => {
         >
           {{ store.errorMessage ? t('decode.form.error.prefix', { detail: store.errorMessage }) : t(`errors.${store.errorCode}`) }}
         </p>
-        <p
+        <div
           v-if="store.status === 'success' && store.result"
           ref="resultRef"
-          class="decode-view__result"
+          class="decode-view__result-region"
+          role="region"
           tabindex="-1"
           aria-live="polite"
         >
-          <strong>{{ t('decode.result.label') }}:</strong> {{ store.result }}
-        </p>
+          <div
+            v-if="store.resultStale"
+            class="decode-view__stale-notice"
+            role="status"
+          >
+            <p>{{ t('decode.result.staleNotice') }}</p>
+            <button
+              type="button"
+              class="btn-primary"
+              @click="redecode"
+            >
+              {{ t('decode.result.redecode') }}
+            </button>
+          </div>
+          <p
+            class="decode-view__result"
+            :class="{ 'decode-view__result--stale': store.resultStale }"
+          >
+            <strong>{{ t('decode.result.label') }}:</strong> {{ store.result }}
+          </p>
+        </div>
         <p
           v-if="store.status === 'idle'"
           class="decode-view__output-empty"
@@ -94,6 +118,31 @@ onUnmounted(() => {
 
 .decode-view__error {
   color: var(--danger);
+}
+
+.decode-view__result-region {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.decode-view__stale-notice {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border: 1px solid var(--warning-border);
+  background: var(--warning-bg);
+  border-radius: 8px;
+}
+
+.decode-view__stale-notice p {
+  margin: 0;
+  flex: 1;
+}
+
+.decode-view__result--stale {
+  opacity: 0.5;
 }
 
 .decode-view__output-empty {

--- a/frontend/src/views/DecodeView.vue
+++ b/frontend/src/views/DecodeView.vue
@@ -18,7 +18,7 @@ watch(
     if (status === 'success') {
       revealResult(resultRef.value, { focus: true })
     } else if (status === 'error') {
-      revealResult(errorRef.value)
+      revealResult(errorRef.value, { focus: true })
     }
   },
 )
@@ -42,6 +42,7 @@ onUnmounted(() => {
           ref="errorRef"
           class="decode-view__error"
           role="alert"
+          tabindex="-1"
         >
           {{ store.errorMessage ? t('decode.form.error.prefix', { detail: store.errorMessage }) : t(`errors.${store.errorCode}`) }}
         </p>

--- a/frontend/src/views/DecodeView.vue
+++ b/frontend/src/views/DecodeView.vue
@@ -51,6 +51,13 @@ onUnmounted(() => {
           {{ store.errorMessage ? t('decode.form.error.prefix', { detail: store.errorMessage }) : t(`errors.${store.errorCode}`) }}
         </p>
         <div
+          v-if="store.status === 'loading'"
+          class="decode-view__output-loading"
+          aria-hidden="true"
+        >
+          <div class="decode-view__skeleton-block" />
+        </div>
+        <div
           v-if="store.status === 'success' && store.result"
           ref="resultRef"
           class="decode-view__result-region"
@@ -156,6 +163,36 @@ onUnmounted(() => {
   border-radius: 8px;
   color: var(--text-muted);
   text-align: center;
+}
+
+.decode-view__output-loading {
+  display: flex;
+  flex-direction: column;
+}
+
+.decode-view__skeleton-block {
+  height: 60px;
+  border-radius: 8px;
+  background: linear-gradient(90deg, var(--code-bg) 25%, var(--border) 50%, var(--code-bg) 75%);
+  background-size: 200% 100%;
+  animation: decode-view-shimmer 1.5s ease-in-out infinite;
+}
+
+@keyframes decode-view-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .decode-view__skeleton-block {
+    animation: none;
+    background: var(--code-bg);
+  }
 }
 
 @media (min-width: 900px) {

--- a/frontend/src/views/EncodeView.spec.ts
+++ b/frontend/src/views/EncodeView.spec.ts
@@ -99,6 +99,17 @@ describe('EncodeView', () => {
       expect(wrapper.find('button[type="submit"]').text()).toBe('Encoding...')
     })
 
+    it('keeps the output column occupied with a skeleton while the API call is in progress', async () => {
+      vi.mocked(postJson).mockReturnValue(new Promise(() => {}))
+      const wrapper = mountView()
+      await wrapper.find('textarea').setValue('hello world')
+
+      await wrapper.find('form').trigger('submit')
+
+      expect(wrapper.find('.encode-view__output-loading').exists()).toBe(true)
+      expect(wrapper.find('.encode-view__output-empty').exists()).toBe(false)
+    })
+
     it('hides the loading indicator after the API call resolves', async () => {
       vi.mocked(postJson).mockResolvedValue(MOCK_ENCODE_RESPONSE)
       const wrapper = mountView()

--- a/frontend/src/views/EncodeView.vue
+++ b/frontend/src/views/EncodeView.vue
@@ -19,7 +19,7 @@ watch(
     if (status === 'success') {
       revealResult(resultRef.value?.$el ?? null, { focus: true })
     } else if (status === 'error') {
-      revealResult(errorRef.value)
+      revealResult(errorRef.value, { focus: true })
     }
   },
 )
@@ -45,6 +45,7 @@ onUnmounted(() => {
           ref="errorRef"
           class="encode-view__error"
           role="alert"
+          tabindex="-1"
         >
           {{ store.errorMessage ? t('encode.form.error.prefix', { detail: store.errorMessage }) : t(`errors.${store.errorCode}`) }}
         </p>

--- a/frontend/src/views/EncodeView.vue
+++ b/frontend/src/views/EncodeView.vue
@@ -49,6 +49,14 @@ onUnmounted(() => {
         >
           {{ store.errorMessage ? t('encode.form.error.prefix', { detail: store.errorMessage }) : t(`errors.${store.errorCode}`) }}
         </p>
+        <div
+          v-if="store.status === 'loading'"
+          class="encode-view__output-loading"
+          aria-hidden="true"
+        >
+          <div class="encode-view__skeleton-block encode-view__skeleton-block--preview" />
+          <div class="encode-view__skeleton-block encode-view__skeleton-block--key" />
+        </div>
         <EncodeResultPanel
           v-if="store.status === 'success' && store.result"
           ref="resultRef"
@@ -107,6 +115,44 @@ onUnmounted(() => {
   border-radius: 8px;
   color: var(--text-muted);
   text-align: center;
+}
+
+.encode-view__output-loading {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.encode-view__skeleton-block {
+  border-radius: 8px;
+  background: linear-gradient(90deg, var(--code-bg) 25%, var(--border) 50%, var(--code-bg) 75%);
+  background-size: 200% 100%;
+  animation: encode-view-shimmer 1.5s ease-in-out infinite;
+}
+
+.encode-view__skeleton-block--preview {
+  height: 280px;
+}
+
+.encode-view__skeleton-block--key {
+  height: 120px;
+}
+
+@keyframes encode-view-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .encode-view__skeleton-block {
+    animation: none;
+    background: var(--code-bg);
+  }
 }
 
 @media (min-width: 900px) {


### PR DESCRIPTION
## Summary
- Fixed the round-3 scroll+focus bug on all four error paths (it only covered the success path; `behavior:'smooth'` never actually fires there in real browsers)
- Extended stale-result protection (dim + disable + re-submit) to Decode and Key parser, which had none - a stale plaintext next to a mismatched key looked like a correct decode
- Restored disabled-button contrast (regressed to 1.45-1.60:1 in round 3, now 5.15:1+) and stopped dimming the cryptogram's actual colors when stale (replaced with a non-destructive "Out of date" badge); fixed Download SVG's missing button class 
- Fixed the output column collapsing to 0px on every encode/decode request by adding a loading skeleton
- Translated `readingOrder` from raw codes (`LR-TB`) to human-readable labels, matching round 3's `rotationDirection` fix

## Test plan
- [x] 207 Vitest tests passing (was 196 before this branch)
- [x] `npm run build` (type-check + bundle) clean
- [x] `npm run lint` clean
- [x] Live-verified in browser: disabled-button contrast (5.15:1, measured via `getComputedStyle`), stale badge renders with cryptogram colors unchanged, stale notice + dim/disable/re-submit flow on Decode and Key parser
