### PR TITLE
fix(api): move key parsing off a GET query string (REFACTOR-004)

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -71,7 +71,7 @@ Tous les endpoints sont préfixés par `/api`.
 | `POST` | `/encode` | Encoder un message → cryptogramme PNG + SVG |
 | `POST` | `/decode` | Décoder un cryptogramme → texte en clair |
 | `POST` | `/key/generate` | Générer une clé HR depuis des paramètres |
-| `GET` | `/key/parse?key=HR…` | Analyser une clé HR → paramètres structurés |
+| `POST` | `/key/parse` | Analyser une clé HR → paramètres structurés |
 
 **Exemple — `POST /encode`**
 
@@ -133,10 +133,13 @@ POST /api/key/generate
 }
 ```
 
-**Exemple — `GET /key/parse`**
+**Exemple — `POST /key/parse`**
 
-```
-GET /api/key/parse?key=HR1·57C3
+```json
+POST /api/key/parse
+{
+  "key": "HR1·57C3"
+}
 ```
 
 ```json

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ All endpoints are prefixed with `/api`.
 | `POST` | `/encode` | Encode a message → PNG + SVG cryptogram |
 | `POST` | `/decode` | Decode a cryptogram → plaintext |
 | `POST` | `/key/generate` | Generate an HR key from parameters |
-| `GET` | `/key/parse?key=HR…` | Parse an HR key → structured parameters |
+| `POST` | `/key/parse` | Parse an HR key → structured parameters |
 
 **Example — `POST /encode`**
 
@@ -133,10 +133,13 @@ POST /api/key/generate
 }
 ```
 
-**Example — `GET /key/parse`**
+**Example — `POST /key/parse`**
 
-```
-GET /api/key/parse?key=HR1·57C3
+```json
+POST /api/key/parse
+{
+  "key": "HR1·57C3"
+}
 ```
 
 ```json

--- a/backend/src/api/dto/key-generate-request.dto.ts
+++ b/backend/src/api/dto/key-generate-request.dto.ts
@@ -25,7 +25,7 @@ export class KeyGenerateRequestDto {
 
   /**
    * Permutation indices (0-3), NOT angles - each index maps to
-   * [0, 90, 180, 270] degrees respectively. Contrast with GET /key/parse's
+   * [0, 90, 180, 270] degrees respectively. Contrast with POST /key/parse's
    * response, which returns this same concept as literal angle values.
    */
   @IsOptional()

--- a/backend/src/api/dto/key-parse-request.dto.ts
+++ b/backend/src/api/dto/key-parse-request.dto.ts
@@ -1,7 +1,7 @@
 import { IsString, IsNotEmpty } from 'class-validator';
 
-/** Query params for GET /key/parse. */
-export class KeyParseQueryDto {
+/** Request body for POST /key/parse. */
+export class KeyParseRequestDto {
   @IsString()
   @IsNotEmpty()
   key!: string;

--- a/backend/src/api/key.controller.ts
+++ b/backend/src/api/key.controller.ts
@@ -1,10 +1,10 @@
-import { Controller, Post, Get, Body, Query, HttpCode } from '@nestjs/common';
+import { Controller, Post, Body, HttpCode } from '@nestjs/common';
 import { KeyService } from './key.service';
 import type { KeyParseResult } from './key.service';
 import { KeyGenerateRequestDto } from './dto/key-generate-request.dto';
-import { KeyParseQueryDto } from './dto/key-parse-query.dto';
+import { KeyParseRequestDto } from './dto/key-parse-request.dto';
 
-/** Handles POST /key/generate and GET /key/parse - key generation and parsing, no cipher/rendering pipeline involvement. */
+/** Handles POST /key/generate and POST /key/parse - key generation and parsing, no cipher/rendering pipeline involvement. */
 @Controller('key')
 export class KeyController {
   constructor(private readonly keyService: KeyService) {}
@@ -24,11 +24,17 @@ export class KeyController {
   /**
    * Parses a key string into its constituent parameters.
    *
-   * @param query - Validated query parameters containing the key string.
+   * POST rather than GET: the key is a decryption secret, and a GET query
+   * string is written by default into server access logs, reverse-proxy
+   * logs, and browser history/cache - a durable, shared leak channel a
+   * secret must not travel through.
+   *
+   * @param dto - Validated request body containing the key string.
    * @returns The decoded key parameters.
    */
-  @Get('parse')
-  parse(@Query() query: KeyParseQueryDto): KeyParseResult {
-    return this.keyService.parse(query.key);
+  @Post('parse')
+  @HttpCode(200)
+  parse(@Body() dto: KeyParseRequestDto): KeyParseResult {
+    return this.keyService.parse(dto.key);
   }
 }

--- a/backend/src/api/key.service.ts
+++ b/backend/src/api/key.service.ts
@@ -9,7 +9,7 @@ const DEFAULT_ROTATION_SEQUENCE: RotationSequence = Object.freeze([
 const DEFAULT_ROTATION_DIRECTION: 'cw' | 'ccw' = 'cw';
 const DEFAULT_READING_ORDER: KeyParams['readingOrder'] = 'LR-TB';
 
-/** Response shape for GET /key/parse. */
+/** Response shape for POST /key/parse. */
 export interface KeyParseResult {
   pivotBlockSize: number;
   /**

--- a/backend/test/key.e2e-spec.ts
+++ b/backend/test/key.e2e-spec.ts
@@ -112,7 +112,7 @@ describe('Key endpoints (e2e)', () => {
     });
   });
 
-  describe('GET /api/key/parse', () => {
+  describe('POST /api/key/parse', () => {
     it('returns 200 with all decoded params for a valid HR key', async () => {
       const generateRes = await request(app.getHttpServer())
         .post('/api/key/generate')
@@ -125,8 +125,8 @@ describe('Key endpoints (e2e)', () => {
       const { key } = generateRes.body as KeyGenerateResult;
 
       const res = await request(app.getHttpServer())
-        .get('/api/key/parse')
-        .query({ key });
+        .post('/api/key/parse')
+        .send({ key });
 
       expect(res.status).toBe(200);
       const body = res.body as KeyParseResult;
@@ -138,8 +138,8 @@ describe('Key endpoints (e2e)', () => {
 
     it('returns 400 for a malformed key string', async () => {
       const res = await request(app.getHttpServer())
-        .get('/api/key/parse')
-        .query({ key: 'not-a-key' });
+        .post('/api/key/parse')
+        .send({ key: 'not-a-key' });
       expect(res.status).toBe(400);
     });
 
@@ -147,21 +147,23 @@ describe('Key endpoints (e2e)', () => {
       'returns 400 for malformed key: %s',
       async (malformedKey) => {
         const res = await request(app.getHttpServer())
-          .get('/api/key/parse')
-          .query({ key: malformedKey });
+          .post('/api/key/parse')
+          .send({ key: malformedKey });
         expect(res.status).toBe(400);
       },
     );
 
     it('returns 400 for an empty key query param', async () => {
       const res = await request(app.getHttpServer())
-        .get('/api/key/parse')
-        .query({ key: '' });
+        .post('/api/key/parse')
+        .send({ key: '' });
       expect(res.status).toBe(400);
     });
 
-    it('returns 400 when the key query param is missing', async () => {
-      const res = await request(app.getHttpServer()).get('/api/key/parse');
+    it('returns 400 when the key field is missing from the body', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/key/parse')
+        .send({});
       expect(res.status).toBe(400);
     });
   });
@@ -181,8 +183,8 @@ describe('Key endpoints (e2e)', () => {
       const { key } = generateRes.body as KeyGenerateResult;
 
       const parseRes = await request(app.getHttpServer())
-        .get('/api/key/parse')
-        .query({ key });
+        .post('/api/key/parse')
+        .send({ key });
 
       expect(parseRes.status).toBe(200);
       const parseBody = parseRes.body as KeyParseResult;

--- a/docs/tests/api.md
+++ b/docs/tests/api.md
@@ -1,7 +1,7 @@
 # HexaRot — Test Spec: API Domain
 
 Covers: FEAT-011 (POST /encode), FEAT-012 (POST /decode), FEAT-013 (POST /key/generate,
-GET /key/parse).
+POST /key/parse).
 
 All tests in this document are **integration tests**. They use the NestJS testing module
 and supertest. They run against a real, seeded PostgreSQL test database (full Hexahue
@@ -96,16 +96,20 @@ describe('POST /key/generate')
 - it returns 400 when `readingOrder` is an unknown value
 - it returns 400 when `pivotBlockSize` is not a positive integer
 
-**Round-trip with GET /key/parse**
+**Round-trip with POST /key/parse**
 - it generates a key and parses it back to recover the original params without data loss
 
 ---
 
-## 4. GET /key/parse (FEAT-013)
+## 4. POST /key/parse (FEAT-013, REFACTOR-004)
 
 ```
-describe('GET /key/parse')
+describe('POST /key/parse')
 ```
+
+POST rather than GET: the key is a decryption secret, and a GET query string is
+written by default into server access logs, reverse-proxy logs, and browser
+history/cache - a secret must not travel through that channel (REFACTOR-004).
 
 - it returns 200 with all decoded params for a valid HR key
 - it returns the correct pivotBlockSize
@@ -113,8 +117,8 @@ describe('GET /key/parse')
 - it returns the correct rotationDirection ('cw' or 'ccw')
 - it returns the correct readingOrder string
 - it returns 400 for a malformed key string
-- it returns 400 for an empty `key` query param
-- it returns 400 when the `key` query param is missing
+- it returns 400 for an empty `key` field
+- it returns 400 when the `key` field is missing from the body
 
 ---
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3831,6 +3831,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/frontend/src/api/client.spec.ts
+++ b/frontend/src/api/client.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { postJson, getJson, ApiError } from './client'
+import { postJson, ApiError } from './client'
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -56,34 +56,5 @@ describe('postJson', () => {
     vi.mocked(fetch).mockRejectedValue(new TypeError('Failed to fetch'))
 
     await expect(postJson('/encode', {})).rejects.toBeInstanceOf(ApiError)
-  })
-})
-
-describe('getJson', () => {
-  beforeEach(() => {
-    vi.stubGlobal('fetch', vi.fn())
-  })
-
-  afterEach(() => {
-    vi.unstubAllGlobals()
-  })
-
-  it('appends query parameters to the URL', async () => {
-    vi.mocked(fetch).mockResolvedValue(jsonResponse({ ok: true }))
-
-    await getJson('/key/parse', { key: 'HR1·a1b2' })
-
-    expect(fetch).toHaveBeenCalledWith(
-      expect.stringContaining('/key/parse?key=HR1%C2%B7a1b2'),
-      expect.objectContaining({ method: 'GET' }),
-    )
-  })
-
-  it('returns the parsed JSON body on a successful response', async () => {
-    vi.mocked(fetch).mockResolvedValue(jsonResponse({ pivotBlockSize: 5 }))
-
-    const result = await getJson<{ pivotBlockSize: number }>('/key/parse', { key: 'HR1·a1b2' })
-
-    expect(result).toEqual({ pivotBlockSize: 5 })
   })
 })

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -63,14 +63,3 @@ export async function postJson<TResponse>(path: string, body: unknown): Promise<
   })
   return handleResponse<TResponse>(response)
 }
-
-export async function getJson<TResponse>(
-  path: string,
-  query?: Record<string, string>,
-): Promise<TResponse> {
-  const search = query ? `?${new URLSearchParams(query).toString()}` : ''
-  const response = await doFetch(`${resolveBaseUrl()}${path}${search}`, {
-    method: 'GET',
-  })
-  return handleResponse<TResponse>(response)
-}

--- a/frontend/src/components/KeyParserForm.spec.ts
+++ b/frontend/src/components/KeyParserForm.spec.ts
@@ -9,10 +9,10 @@ import { ApiError } from '../api/client'
 
 vi.mock('../api/client', async () => {
   const actual = await vi.importActual<typeof import('../api/client')>('../api/client')
-  return { ...actual, getJson: vi.fn() }
+  return { ...actual, postJson: vi.fn() }
 })
 
-import { getJson } from '../api/client'
+import { postJson } from '../api/client'
 
 function mountForm() {
   const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
@@ -24,7 +24,7 @@ function mountForm() {
 describe('KeyParserForm', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
-    vi.mocked(getJson).mockReset()
+    vi.mocked(postJson).mockReset()
   })
 
   it('renders the key input field', () => {
@@ -38,18 +38,18 @@ describe('KeyParserForm', () => {
   })
 
   it('calls the key parse API with the entered key when the parse button is clicked', async () => {
-    vi.mocked(getJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
+    vi.mocked(postJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
     const wrapper = mountForm()
 
     await wrapper.find('input[type="text"]').setValue('HR1·a1b2')
     await wrapper.find('form').trigger('submit')
     await flushPromises()
 
-    expect(getJson).toHaveBeenCalledWith('/key/parse', { key: 'HR1·a1b2' })
+    expect(postJson).toHaveBeenCalledWith('/key/parse', { key: 'HR1·a1b2' })
   })
 
   it('displays all decoded parameters after a successful parse response', async () => {
-    vi.mocked(getJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
+    vi.mocked(postJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
     const wrapper = mountForm()
 
     await wrapper.find('input[type="text"]').setValue('HR1·a1b2')
@@ -63,7 +63,7 @@ describe('KeyParserForm', () => {
   })
 
   it('translates the reading order to a human-readable label, not the raw code', async () => {
-    vi.mocked(getJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
+    vi.mocked(postJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
     const wrapper = mountForm()
 
     await wrapper.find('input[type="text"]').setValue('HR1·a1b2')
@@ -74,7 +74,7 @@ describe('KeyParserForm', () => {
   })
 
   it('translates the rotation direction to a human-readable label, matching the generator form', async () => {
-    vi.mocked(getJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
+    vi.mocked(postJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
     const wrapper = mountForm()
 
     await wrapper.find('input[type="text"]').setValue('HR1·a1b2')
@@ -91,11 +91,11 @@ describe('KeyParserForm', () => {
 
     expect(wrapper.find('.key-parser-form__error').exists()).toBe(true)
     expect(wrapper.find('button[type="submit"]').attributes('disabled')).toBeDefined()
-    expect(getJson).not.toHaveBeenCalled()
+    expect(postJson).not.toHaveBeenCalled()
   })
 
   it('displays a clear error message when the API returns 400', async () => {
-    vi.mocked(getJson).mockRejectedValue(new ApiError('unsupported key version', 'http', 400))
+    vi.mocked(postJson).mockRejectedValue(new ApiError('unsupported key version', 'http', 400))
     const wrapper = mountForm()
 
     await wrapper.find('input[type="text"]').setValue('HR9·zzzz')
@@ -107,7 +107,7 @@ describe('KeyParserForm', () => {
 
   describe('stale parsed parameters', () => {
     it('marks the parsed parameters stale, without removing them, when the key input changes', async () => {
-      vi.mocked(getJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
+      vi.mocked(postJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
       const wrapper = mountForm()
       await wrapper.find('input[type="text"]').setValue('HR1·a1b2')
       await wrapper.find('form').trigger('submit')
@@ -121,7 +121,7 @@ describe('KeyParserForm', () => {
     })
 
     it('clears the stale notice when re-parsing', async () => {
-      vi.mocked(getJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
+      vi.mocked(postJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
       const wrapper = mountForm()
       await wrapper.find('input[type="text"]').setValue('HR1·a1b2')
       await wrapper.find('form').trigger('submit')

--- a/frontend/src/stores/key.spec.ts
+++ b/frontend/src/stores/key.spec.ts
@@ -6,16 +6,15 @@ import { MOCK_KEY_GENERATE_RESPONSE, MOCK_KEY_PARSE_RESPONSE } from '../__fixtur
 
 vi.mock('../api/client', async () => {
   const actual = await vi.importActual<typeof import('../api/client')>('../api/client')
-  return { ...actual, postJson: vi.fn(), getJson: vi.fn() }
+  return { ...actual, postJson: vi.fn() }
 })
 
-import { postJson, getJson } from '../api/client'
+import { postJson } from '../api/client'
 
 describe('useKeyStore', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     vi.mocked(postJson).mockReset()
-    vi.mocked(getJson).mockReset()
   })
 
   it('initialises with default parameter values and no result or error on either side', () => {
@@ -109,7 +108,7 @@ describe('useKeyStore', () => {
 
   it('clears the previous generated key when a new generate is dispatched, without touching parse state', async () => {
     vi.mocked(postJson).mockResolvedValue(MOCK_KEY_GENERATE_RESPONSE)
-    vi.mocked(getJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
+    vi.mocked(postJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
     const store = useKeyStore()
     await store.generate()
     store.keyInput = 'HR1·a1b2'
@@ -123,28 +122,28 @@ describe('useKeyStore', () => {
     expect(store.parsedParams).toEqual(MOCK_KEY_PARSE_RESPONSE)
   })
 
-  it('calls getJson with the entered key when parse is dispatched', async () => {
-    vi.mocked(getJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
+  it('calls postJson with the entered key when parse is dispatched', async () => {
+    vi.mocked(postJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
     const store = useKeyStore()
     store.keyInput = 'HR1·a1b2'
 
     await store.parse()
 
-    expect(getJson).toHaveBeenCalledWith('/key/parse', { key: 'HR1·a1b2' })
+    expect(postJson).toHaveBeenCalledWith('/key/parse', { key: 'HR1·a1b2' })
   })
 
   it('normalizes a near-miss key before sending it', async () => {
-    vi.mocked(getJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
+    vi.mocked(postJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
     const store = useKeyStore()
     store.keyInput = 'hr1.a1b2'
 
     await store.parse()
 
-    expect(getJson).toHaveBeenCalledWith('/key/parse', { key: 'HR1·a1b2' })
+    expect(postJson).toHaveBeenCalledWith('/key/parse', { key: 'HR1·a1b2' })
   })
 
   it('sets parseStatus to loading while the parse request is in flight', () => {
-    vi.mocked(getJson).mockReturnValue(new Promise(() => {}))
+    vi.mocked(postJson).mockReturnValue(new Promise(() => {}))
     const store = useKeyStore()
     store.keyInput = 'HR1·a1b2'
 
@@ -154,7 +153,7 @@ describe('useKeyStore', () => {
   })
 
   it('stores the parsed params and sets parseStatus to success on a successful parse', async () => {
-    vi.mocked(getJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
+    vi.mocked(postJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
     const store = useKeyStore()
     store.keyInput = 'HR1·a1b2'
 
@@ -166,7 +165,7 @@ describe('useKeyStore', () => {
   })
 
   it('stores the error message and sets parseStatus to error on a failed parse', async () => {
-    vi.mocked(getJson).mockRejectedValue(new ApiError('unsupported key version', 'http', 400))
+    vi.mocked(postJson).mockRejectedValue(new ApiError('unsupported key version', 'http', 400))
     const store = useKeyStore()
     store.keyInput = 'HR9·zzzz'
 
@@ -178,7 +177,7 @@ describe('useKeyStore', () => {
   })
 
   it('sets parseErrorCode to network and leaves parseErrorMessage null on a network failure', async () => {
-    vi.mocked(getJson).mockRejectedValue(new ApiError('Network error: unable to reach the server', 'network'))
+    vi.mocked(postJson).mockRejectedValue(new ApiError('Network error: unable to reach the server', 'network'))
     const store = useKeyStore()
     store.keyInput = 'HR1·a1b2'
 
@@ -190,7 +189,7 @@ describe('useKeyStore', () => {
   })
 
   it('sets parseErrorCode to unknown and leaves parseErrorMessage null on a non-ApiError failure', async () => {
-    vi.mocked(getJson).mockRejectedValue(new Error('unexpected'))
+    vi.mocked(postJson).mockRejectedValue(new Error('unexpected'))
     const store = useKeyStore()
     store.keyInput = 'HR1·a1b2'
 
@@ -202,7 +201,7 @@ describe('useKeyStore', () => {
   })
 
   it('clears the previous parsed params when a new parse is dispatched, without touching generate state', async () => {
-    vi.mocked(getJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
+    vi.mocked(postJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
     vi.mocked(postJson).mockResolvedValue(MOCK_KEY_GENERATE_RESPONSE)
     const store = useKeyStore()
     store.keyInput = 'HR1·a1b2'
@@ -210,7 +209,7 @@ describe('useKeyStore', () => {
     await store.generate()
     expect(store.generatedKey).toBe(MOCK_KEY_GENERATE_RESPONSE.key)
 
-    vi.mocked(getJson).mockReturnValue(new Promise(() => {}))
+    vi.mocked(postJson).mockReturnValue(new Promise(() => {}))
     void store.parse()
 
     expect(store.parsedParams).toBeNull()
@@ -219,7 +218,7 @@ describe('useKeyStore', () => {
 
   it('restores default state when reset is called', async () => {
     vi.mocked(postJson).mockResolvedValue(MOCK_KEY_GENERATE_RESPONSE)
-    vi.mocked(getJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
+    vi.mocked(postJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
     const store = useKeyStore()
     await store.generate()
     store.keyInput = 'HR1·a1b2'

--- a/frontend/src/stores/key.ts
+++ b/frontend/src/stores/key.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { postJson, getJson, ApiError } from '../api/client'
+import { postJson, ApiError } from '../api/client'
 import { normalizeKeyInput } from '../utils/key-format'
 import type { ReadingOrder } from '../constants/reading-orders'
 
@@ -94,7 +94,7 @@ export const useKeyStore = defineStore('key', {
       this.parseErrorCode = null
 
       try {
-        this.parsedParams = await getJson<KeyParseResult>('/key/parse', { key: normalizeKeyInput(this.keyInput) })
+        this.parsedParams = await postJson<KeyParseResult>('/key/parse', { key: normalizeKeyInput(this.keyInput) })
         this.parseStatus = 'success'
       } catch (err) {
         if (err instanceof ApiError && err.code === 'http') {

--- a/frontend/src/views/KeyView.spec.ts
+++ b/frontend/src/views/KeyView.spec.ts
@@ -10,10 +10,10 @@ import { ApiError } from '../api/client'
 
 vi.mock('../api/client', async () => {
   const actual = await vi.importActual<typeof import('../api/client')>('../api/client')
-  return { ...actual, postJson: vi.fn(), getJson: vi.fn() }
+  return { ...actual, postJson: vi.fn() }
 })
 
-import { postJson, getJson } from '../api/client'
+import { postJson } from '../api/client'
 
 function mountView() {
   const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
@@ -26,7 +26,6 @@ describe('KeyView', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     vi.mocked(postJson).mockReset()
-    vi.mocked(getJson).mockReset()
   })
 
   describe('key generator section', () => {
@@ -98,18 +97,18 @@ describe('KeyView', () => {
     })
 
     it('calls the key parse API when the parse button is clicked', async () => {
-      vi.mocked(getJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
+      vi.mocked(postJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
       const wrapper = mountView()
 
       await wrapper.find('.key-parser-form input[type="text"]').setValue('HR1·a1b2')
       await wrapper.find('.key-parser-form').trigger('submit')
       await flushPromises()
 
-      expect(getJson).toHaveBeenCalledWith('/key/parse', { key: 'HR1·a1b2' })
+      expect(postJson).toHaveBeenCalledWith('/key/parse', { key: 'HR1·a1b2' })
     })
 
     it('displays all decoded parameters after a successful parse response', async () => {
-      vi.mocked(getJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
+      vi.mocked(postJson).mockResolvedValue(MOCK_KEY_PARSE_RESPONSE)
       const wrapper = mountView()
 
       await wrapper.find('.key-parser-form input[type="text"]').setValue('HR1·a1b2')
@@ -125,11 +124,11 @@ describe('KeyView', () => {
       await wrapper.find('.key-parser-form input[type="text"]').setValue(MALFORMED_KEY)
 
       expect(wrapper.find('.key-parser-form__error').exists()).toBe(true)
-      expect(getJson).not.toHaveBeenCalled()
+      expect(postJson).not.toHaveBeenCalled()
     })
 
     it('displays a clear error message when the API returns 400', async () => {
-      vi.mocked(getJson).mockRejectedValue(new ApiError('unsupported key version', 'http', 400))
+      vi.mocked(postJson).mockRejectedValue(new ApiError('unsupported key version', 'http', 400))
       const wrapper = mountView()
 
       await wrapper.find('.key-parser-form input[type="text"]').setValue('HR9·zzzz')


### PR DESCRIPTION
## Summary
- The decryption key was sent as GET /api/key/parse?key=... - written by default into server access logs, reverse-proxy logs, and browser history/cache.
Critique #7, P0.
- /api/key/parse is now POST with the key in the JSON body, matching /key/generate's shape
- Removed frontend/src/api/client.ts's getJson() helper (no longer had any caller)

## Test plan
- [x] 370 backend Jest unit tests passing
- [x] 72 backend e2e tests passing (verified against a real temporary Postgres instance, since no HexaRot DB was running locally)
- [x] 210 frontend Vitest tests passing
- [x] Backend + frontend build and lint clean
- [x] README.md, README.fr.md, docs/tests/api.md updated to match the new contract
