### PR TITLE
fix(frontend): snapshot the encode result size instead of reading it live (REFACTOR-007)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1698,7 +1698,7 @@ crypto-domain logic across the frontend/backend boundary.
 - **type:** refactor
 - **id:** REFACTOR-005
 - **milestone:** v2
-- **status:** backlog
+- **status:** ready
 - **priority:** high
 - **domain:** frontend
 - **complexity:** S
@@ -1773,7 +1773,7 @@ hint says "This key is not stored anywhere. Copy it now."
 - **type:** refactor
 - **id:** REFACTOR-007
 - **milestone:** v2
-- **status:** ready
+- **status:** done
 - **priority:** high
 - **domain:** frontend
 - **complexity:** S
@@ -1810,7 +1810,7 @@ critique rounds.
 - **type:** refactor
 - **id:** REFACTOR-008
 - **milestone:** v2
-- **status:** backlog
+- **status:** ready
 - **priority:** medium
 - **domain:** frontend
 - **complexity:** S

--- a/frontend/src/__fixtures__/frontend.fixtures.ts
+++ b/frontend/src/__fixtures__/frontend.fixtures.ts
@@ -12,6 +12,7 @@ export const MOCK_ENCODE_RESPONSE: EncodeResult = {
   key: 'HR1·A1B2',
   warnings: [],
   unknownChars: [],
+  size: 'medium',
 }
 
 export const MOCK_ENCODE_RESPONSE_WITH_WARNINGS: EncodeResult = {

--- a/frontend/src/components/EncodeResultPanel.spec.ts
+++ b/frontend/src/components/EncodeResultPanel.spec.ts
@@ -13,8 +13,9 @@ vi.mock('../api/client', async () => {
 
 import { postJson } from '../api/client'
 import { useEncodeStore } from '../stores/encode'
+import type { EncodeResult } from '../stores/encode'
 
-function mountPanel(props: { stale?: boolean } = {}) {
+function mountPanel(props: { stale?: boolean; result?: EncodeResult } = {}) {
   const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
   return mount(EncodeResultPanel, {
     props: { result: MOCK_ENCODE_RESPONSE, ...props },
@@ -30,13 +31,21 @@ describe('EncodeResultPanel', () => {
   })
 
   describe('cryptogram size', () => {
-    it('displays the size used to produce this result, next to the key', async () => {
-      const wrapper = mountPanel()
+    it('displays the size that produced this result, next to the key', () => {
+      const wrapper = mountPanel({ result: { ...MOCK_ENCODE_RESPONSE, size: 'large' } })
+
+      expect(wrapper.find('.encode-result-panel__key-size').text()).toContain(en.encode.form.size.large)
+    })
+
+    it('keeps showing the result size even after the live form field changes', async () => {
+      const wrapper = mountPanel({ result: { ...MOCK_ENCODE_RESPONSE, size: 'small' } })
       const store = useEncodeStore()
+
       store.size = 'large'
       await flushPromises()
 
-      expect(wrapper.find('.encode-result-panel__key-size').text()).toContain(en.encode.form.size.large)
+      expect(wrapper.find('.encode-result-panel__key-size').text()).toContain(en.encode.form.size.small)
+      expect(wrapper.find('.encode-result-panel__key-size').text()).not.toContain(en.encode.form.size.large)
     })
   })
 
@@ -120,7 +129,7 @@ describe('EncodeResultPanel', () => {
       expect(downloadedFilename).toBe('hexarot-medium.svg')
     })
 
-    it('uses the store size in the download filename', async () => {
+    it('uses the result size in the download filename, not the live form field', async () => {
       const createObjectURL = vi.fn().mockReturnValue('blob:png-url')
       const revokeObjectURL = vi.fn()
       vi.stubGlobal('URL', { ...URL, createObjectURL, revokeObjectURL })
@@ -129,9 +138,9 @@ describe('EncodeResultPanel', () => {
         downloadedFilename = this.download
       })
 
-      const wrapper = mountPanel()
+      const wrapper = mountPanel({ result: { ...MOCK_ENCODE_RESPONSE, size: 'large' } })
       const store = useEncodeStore()
-      store.size = 'large'
+      store.size = 'small'
       await flushPromises()
       const [pngButton] = wrapper.findAll('.encode-result-panel__downloads button')
       await pngButton.trigger('click')

--- a/frontend/src/components/EncodeResultPanel.vue
+++ b/frontend/src/components/EncodeResultPanel.vue
@@ -45,8 +45,10 @@ function triggerDownload(blob: Blob, filename: string): void {
 function downloadFilename(extension: string): string {
   // Never include the key here: this file is the artifact the user hands to
   // someone else, and a cipher's key must travel on a separate channel from
-  // the cryptogram it decrypts.
-  return `hexarot-${store.size}.${extension}`
+  // the cryptogram it decrypts. Uses the snapshotted result size, not the
+  // live form field, so a filename never claims a size that doesn't match
+  // the cryptogram actually inside it.
+  return `hexarot-${props.result.size}.${extension}`
 }
 
 function downloadPng(): void {
@@ -105,7 +107,7 @@ function downloadSvg(): void {
         <span class="encode-result-panel__key-label">{{ t('encode.result.keyLabel') }}</span>
         <code class="encode-result-panel__key-value">{{ result.key }}</code>
         <p class="encode-result-panel__key-size">
-          {{ t('encode.result.sizeLabel') }}: <strong>{{ t(`encode.form.size.${store.size}`) }}</strong>
+          {{ t('encode.result.sizeLabel') }}: <strong>{{ t(`encode.form.size.${result.size}`) }}</strong>
         </p>
         <p class="encode-result-panel__key-hint">
           {{ t('encode.result.keyHint') }}

--- a/frontend/src/stores/encode.ts
+++ b/frontend/src/stores/encode.ts
@@ -8,13 +8,24 @@ export type RotationDirection = 'cw' | 'ccw'
 export type CryptogramSize = 'small' | 'medium' | 'large'
 export type EncodeStatus = 'idle' | 'loading' | 'success' | 'error'
 
-/** Mirrors backend/src/api/encode.service.ts's EncodeResult. */
-export interface EncodeResult {
+/** Mirrors backend/src/api/encode.service.ts's EncodeResult - the raw API response shape. */
+interface EncodeApiResult {
   png: string
   svg: string
   key: string
   warnings: string[]
   unknownChars: string[]
+}
+
+/**
+ * EncodeApiResult plus the size actually submitted with the request - a
+ * snapshot taken at request time, not a live read of `store.size`, so the
+ * displayed size (and any downloaded filename built from it) stays
+ * consistent with the key and cryptogram even if the form changes after a
+ * successful encode.
+ */
+export interface EncodeResult extends EncodeApiResult {
+  size: CryptogramSize
 }
 
 interface EncodeState {
@@ -82,7 +93,8 @@ export const useEncodeStore = defineStore('encode', {
             }
 
       try {
-        this.result = await postJson<EncodeResult>('/encode', payload)
+        const response = await postJson<EncodeApiResult>('/encode', payload)
+        this.result = { ...response, size: this.size }
         this.status = 'success'
       } catch (err) {
         if (err instanceof ApiError && err.code === 'http') {


### PR DESCRIPTION
## Summary
- EncodeResultPanel read the live store.size form field instead of the size actually submitted with the request. Changing the size dropdown after a   successful encode (without re-encoding) displayed a size that didn't match the key/cryptogram, presenting a mismatched credential pair as valid.
Critique #7, P1.
- EncodeResult now snapshots the size at request time, separate from the raw API response shape
- Unblocks REFACTOR-005 and REFACTOR-008 (both depended on this)

## Test plan
- [x] 211 Vitest tests passing (was 210 before this branch)
- [x] Build and lint clean
- [x] Live-verified: encoded at "Small", changed the size dropdown to "Large" without re-encoding — panel still correctly shows "Cryptogram size: Small"
