### PR TITLE
fix(frontend): keep Copy and Download enabled while a result is stale (REFACTOR-005)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1698,7 +1698,7 @@ crypto-domain logic across the frontend/backend boundary.
 - **type:** refactor
 - **id:** REFACTOR-005
 - **milestone:** v2
-- **status:** ready
+- **status:** done
 - **priority:** high
 - **domain:** frontend
 - **complexity:** S

--- a/frontend/src/components/EncodeResultPanel.spec.ts
+++ b/frontend/src/components/EncodeResultPanel.spec.ts
@@ -169,14 +169,14 @@ describe('EncodeResultPanel', () => {
       expect(downloadButtons[1].attributes('disabled')).toBeUndefined()
     })
 
-    it('shows a notice and disables Copy and both downloads when stale', () => {
+    it('shows a notice but keeps Copy and both downloads enabled when stale, so a still-valid result can still be saved', () => {
       const wrapper = mountPanel({ stale: true })
 
       expect(wrapper.find('.encode-result-panel__stale-notice').exists()).toBe(true)
-      expect(wrapper.find('.encode-result-panel__key button').attributes('disabled')).toBeDefined()
+      expect(wrapper.find('.encode-result-panel__key button').attributes('disabled')).toBeUndefined()
       const downloadButtons = wrapper.findAll('.encode-result-panel__downloads button')
-      expect(downloadButtons[0].attributes('disabled')).toBeDefined()
-      expect(downloadButtons[1].attributes('disabled')).toBeDefined()
+      expect(downloadButtons[0].attributes('disabled')).toBeUndefined()
+      expect(downloadButtons[1].attributes('disabled')).toBeUndefined()
     })
 
     it('marks the preview with a badge when stale, so the cryptogram itself keeps its true colors', () => {

--- a/frontend/src/components/EncodeResultPanel.vue
+++ b/frontend/src/components/EncodeResultPanel.vue
@@ -115,7 +115,6 @@ function downloadSvg(): void {
         <button
           type="button"
           class="btn-primary"
-          :disabled="stale"
           @click="copyKey"
         >
           {{ copyState === 'copied' ? t('encode.result.copied') : copyState === 'error' ? t('encode.result.copyError') : t('encode.result.copy') }}
@@ -158,7 +157,6 @@ function downloadSvg(): void {
         <button
           type="button"
           class="btn-secondary"
-          :disabled="stale"
           @click="downloadPng"
         >
           {{ t('encode.result.downloadPng') }}
@@ -166,7 +164,6 @@ function downloadSvg(): void {
         <button
           type="button"
           class="btn-secondary"
-          :disabled="stale"
           @click="downloadSvg"
         >
           {{ t('encode.result.downloadSvg') }}

--- a/frontend/src/components/KeyGeneratorForm.spec.ts
+++ b/frontend/src/components/KeyGeneratorForm.spec.ts
@@ -138,7 +138,7 @@ describe('KeyGeneratorForm', () => {
       expect(wrapper.find('.key-generator-form__stale-notice').exists()).toBe(true)
     })
 
-    it('disables Copy while the generated key is stale', async () => {
+    it('keeps Copy enabled while the generated key is stale, so a still-valid key can still be saved', async () => {
       vi.mocked(postJson).mockResolvedValue(MOCK_KEY_GENERATE_RESPONSE)
       const wrapper = mountForm()
       await wrapper.find('form').trigger('submit')
@@ -147,7 +147,7 @@ describe('KeyGeneratorForm', () => {
       await wrapper.find('input[type="number"]').setValue(99)
 
       const copyButton = wrapper.find('.key-generator-form__result-content button')
-      expect(copyButton.attributes('disabled')).toBeDefined()
+      expect(copyButton.attributes('disabled')).toBeUndefined()
     })
 
     it('clears the stale notice when re-generating', async () => {

--- a/frontend/src/components/KeyGeneratorForm.vue
+++ b/frontend/src/components/KeyGeneratorForm.vue
@@ -158,7 +158,6 @@ async function copyKey(): Promise<void> {
         <button
           type="button"
           class="btn-primary"
-          :disabled="store.generatedKeyStale"
           @click="copyKey"
         >
           {{ copyState === 'copied' ? t('key.generator.result.copied') : copyState === 'error' ? t('key.generator.result.copyError') : t('key.generator.result.copy') }}

--- a/frontend/src/views/DecodeView.spec.ts
+++ b/frontend/src/views/DecodeView.spec.ts
@@ -216,7 +216,7 @@ describe('DecodeView', () => {
       await vi.waitFor(() => expect(wrapper.find('.decode-view__stale-notice').exists()).toBe(false))
     })
 
-    it('disables Copy while the decoded message is stale', async () => {
+    it('keeps Copy enabled while the decoded message is stale, so a still-valid message can still be saved', async () => {
       vi.mocked(postJson).mockResolvedValue(MOCK_DECODE_RESPONSE)
       const wrapper = mountView()
       await selectFile(wrapper, MOCK_PNG_FILE)
@@ -227,7 +227,7 @@ describe('DecodeView', () => {
 
       await wrapper.find('input[type="text"]').setValue('HR1·b2c3')
 
-      expect(wrapper.find('.decode-view__result-card button').attributes('disabled')).toBeDefined()
+      expect(wrapper.find('.decode-view__result-card button').attributes('disabled')).toBeUndefined()
     })
   })
 

--- a/frontend/src/views/DecodeView.vue
+++ b/frontend/src/views/DecodeView.vue
@@ -105,7 +105,6 @@ onUnmounted(() => {
             <button
               type="button"
               class="btn-primary"
-              :disabled="store.resultStale"
               @click="copyResult"
             >
               {{ copyState === 'copied' ? t('decode.result.copied') : copyState === 'error' ? t('decode.result.copyError') : t('decode.result.copy') }}


### PR DESCRIPTION
## Summary
- All four stale result surfaces disabled Copy/Download the moment any field changed, on top of copy saying "Neither is stored anywhere - copy or download them now." Critique #7, P1.
- Copy, Download PNG, and Download SVG now stay enabled while stale - staleness means "may not reflect current form state," not "invalid"

## Test plan
- [x] 216 Vitest tests passing
- [x] Build and lint clean
- [x] Live-verified: stale notice shown, Copy/Download stay enabled, download filename still correctly pinned to the snapshotted size (hexarot-medium.png)
