### PR TITLE
fix(frontend): Copy button includes the cryptogram size alongside the key (REFACTOR-008)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1810,7 +1810,7 @@ critique rounds.
 - **type:** refactor
 - **id:** REFACTOR-008
 - **milestone:** v2
-- **status:** ready
+- **status:** done
 - **priority:** medium
 - **domain:** frontend
 - **complexity:** S

--- a/frontend/src/components/EncodeResultPanel.spec.ts
+++ b/frontend/src/components/EncodeResultPanel.spec.ts
@@ -50,15 +50,28 @@ describe('EncodeResultPanel', () => {
   })
 
   describe('copy to clipboard', () => {
-    it('copies the key and shows "Copied!" on success', async () => {
+    it('copies the key and size together, and shows "Copied!" on success', async () => {
       Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } })
       const wrapper = mountPanel()
 
       await wrapper.find('.encode-result-panel__key button').trigger('click')
       await flushPromises()
 
-      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(MOCK_ENCODE_RESPONSE.key)
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(`${MOCK_ENCODE_RESPONSE.key} · ${en.encode.form.size.medium}`)
       expect(wrapper.find('.encode-result-panel__key button').text()).toBe(en.encode.result.copied)
+    })
+
+    it('copies the snapshotted result size, not the live form field', async () => {
+      Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } })
+      const wrapper = mountPanel({ result: { ...MOCK_ENCODE_RESPONSE, size: 'large' } })
+      const store = useEncodeStore()
+      store.size = 'small'
+      await flushPromises()
+
+      await wrapper.find('.encode-result-panel__key button').trigger('click')
+      await flushPromises()
+
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(`${MOCK_ENCODE_RESPONSE.key} · ${en.encode.form.size.large}`)
     })
 
     it('shows "Copy failed" when the clipboard write rejects', async () => {

--- a/frontend/src/components/EncodeResultPanel.vue
+++ b/frontend/src/components/EncodeResultPanel.vue
@@ -21,9 +21,10 @@ function reencode(): void {
 
 const copyState = ref<'idle' | 'copied' | 'error'>('idle')
 
-async function copyKey(): Promise<void> {
+async function copyKeyAndSize(): Promise<void> {
+  const sizeLabel = t(`encode.form.size.${props.result.size}`)
   try {
-    await navigator.clipboard.writeText(props.result.key)
+    await navigator.clipboard.writeText(`${props.result.key} · ${sizeLabel}`)
     copyState.value = 'copied'
   } catch {
     copyState.value = 'error'
@@ -115,7 +116,7 @@ function downloadSvg(): void {
         <button
           type="button"
           class="btn-primary"
-          @click="copyKey"
+          @click="copyKeyAndSize"
         >
           {{ copyState === 'copied' ? t('encode.result.copied') : copyState === 'error' ? t('encode.result.copyError') : t('encode.result.copy') }}
         </button>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -64,7 +64,7 @@
       "keyLabel": "Key",
       "sizeLabel": "Cryptogram size",
       "keyHint": "You'll need both this key and the cryptogram size to decode your message. Neither is stored anywhere - copy or download them now.",
-      "copy": "Copy",
+      "copy": "Copy key and size",
       "copied": "Copied!",
       "staleNotice": "These parameters changed. Re-encode to update this cryptogram.",
       "staleBadge": "Out of date",


### PR DESCRIPTION
## Summary
- Copy only wrote the key to the clipboard, while the adjacent hint says the user needs both the key and the size. Critique #7, P1.
- Copy now writes "<key> · <size>" together, using the snapshotted result size (REFACTOR-007), not the live form field
- Button relabeled "Copy key and size"

## Test plan
- [x] 217 Vitest tests passing (was 216 before this branch)
- [x] Build and lint clean
