### PR TITLE
fix(frontend): fix Encode form horizontal overflow on mobile (REFACTOR-009)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1843,7 +1843,7 @@ snapshotted, trustworthy size value to copy.
 - **type:** refactor
 - **id:** REFACTOR-009
 - **milestone:** v2
-- **status:** ready
+- **status:** done
 - **priority:** medium
 - **domain:** frontend
 - **complexity:** S

--- a/frontend/src/components/EncodeParamsForm.vue
+++ b/frontend/src/components/EncodeParamsForm.vue
@@ -212,6 +212,15 @@ function handleSubmit(): void {
   border-radius: 8px;
   padding: 16px;
   margin: 0;
+  /*
+   * A <fieldset> defaults to min-inline-size: min-content (a UA default
+   * that ordinary width rules can't override) with box-sizing: content-box,
+   * so it refuses to shrink below its widest child - here, the reading
+   * order <select>'s longest option text. Without this, the fieldset (and
+   * the whole page) overflows horizontally on narrow viewports.
+   */
+  min-inline-size: 0;
+  box-sizing: border-box;
 }
 
 .encode-params-form__group legend {


### PR DESCRIPTION
## Summary
- At 360px, Encode overflowed the page by 112px because its fieldset (UA default min-inline-size: min-content + box-sizing: content-box) refused to shrink below the reading-order select's widest option. Critique #7, P2.
- Fix: min-inline-size: 0 + box-sizing: border-box on the fieldset

## Test plan
- [x] 217 Vitest tests passing
- [x] Build and lint clean
- [x] Live-verified via a same-origin 360px iframe (faithful media-query evaluation): overflow went from 112px to 0px, select shrank from 407px to 279px; also verified no regression at 1200px (fieldset still 480px, 0 overflow)
