### PR TITLE
fix(frontend): stop the "Out of date" badge from overlapping cryptogram cells (REFACTOR-010)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1879,7 +1879,7 @@ the overflow from 112px to 0px in live testing.
 - **type:** refactor
 - **id:** REFACTOR-010
 - **milestone:** v2
-- **status:** ready
+- **status:** done
 - **priority:** medium
 - **domain:** frontend
 - **complexity:** S

--- a/frontend/src/components/EncodeResultPanel.vue
+++ b/frontend/src/components/EncodeResultPanel.vue
@@ -94,14 +94,14 @@ function downloadSvg(): void {
       :class="{ 'encode-result-panel__content--stale': stale }"
     >
       <div class="encode-result-panel__preview">
-        <!-- eslint-disable-next-line vue/no-v-html, vue/max-attributes-per-line -- result.svg is generated exclusively by this project's own backend renderer, never from user input, so it is a trusted string. -->
-        <div class="encode-result-panel__svg" v-html="result.svg" />
         <span
           v-if="stale"
           class="encode-result-panel__stale-badge"
         >
           {{ t('encode.result.staleBadge') }}
         </span>
+        <!-- eslint-disable-next-line vue/no-v-html, vue/max-attributes-per-line -- result.svg is generated exclusively by this project's own backend renderer, never from user input, so it is a trusted string. -->
+        <div class="encode-result-panel__svg" v-html="result.svg" />
       </div>
 
       <div class="encode-result-panel__key">
@@ -220,19 +220,25 @@ function downloadSvg(): void {
 }
 
 .encode-result-panel__preview {
-  position: relative;
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
   padding: 20px;
   border: 1px solid var(--border);
   border-radius: 8px;
   box-shadow: var(--shadow);
 }
 
+/*
+ * Stacked above the cryptogram rather than overlaid on it: an absolutely
+ * positioned badge in the corner overlapped the actual cells at narrow
+ * preview widths, tinting and occluding the cipher's own color data - the
+ * exact thing this badge exists to avoid doing (see the opacity comment
+ * below).
+ */
 .encode-result-panel__stale-badge {
-  position: absolute;
-  top: 8px;
-  right: 8px;
+  align-self: flex-end;
   padding: 2px 8px;
   border: 1px solid var(--warning-border);
   border-radius: 4px;


### PR DESCRIPTION
## Summary
- The stale badge was absolutely positioned over the SVG preview, clear of it only when there was spare padding around a capped 280px image. At narrower widths it landed on the cells - measured 2/36 cells overlapped at 360px in critique #7, plus visible color tinting. Critique #7, P2.
- Badge now stacks above the SVG instead of overlapping it - structurally impossible to overlap at any width

## Test plan
- [x] 217 Vitest tests passing
- [x] Build and lint clean
- [x] Live-verified via a 360px iframe: badge bottom edge at y=515.7, SVG top edge at y=523.7 - zero overlap area
