### PR TITLE
fix(frontend): make the decoded message keyboard-scrollable (REFACTOR-011)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1914,7 +1914,7 @@ allowed to sit on top of them.
 - **type:** refactor
 - **id:** REFACTOR-011
 - **milestone:** v2
-- **status:** ready
+- **status:** done
 - **priority:** low
 - **domain:** frontend
 - **complexity:** S

--- a/frontend/src/views/DecodeView.spec.ts
+++ b/frontend/src/views/DecodeView.spec.ts
@@ -180,6 +180,20 @@ describe('DecodeView', () => {
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith(MOCK_DECODE_RESPONSE.message)
       expect(wrapper.find('.decode-view__result-card button').text()).toBe(en.decode.result.copied)
     })
+
+    it('makes the decoded message keyboard-focusable and labelled, so long messages remain reachable', async () => {
+      vi.mocked(postJson).mockResolvedValue(MOCK_DECODE_RESPONSE)
+      const wrapper = mountView()
+      await selectFile(wrapper, MOCK_PNG_FILE)
+      await wrapper.find('input[type="text"]').setValue('HR1·a1b2')
+      await wrapper.find('form').trigger('submit')
+      await vi.waitFor(() => expect(wrapper.find('.decode-view__result').exists()).toBe(true))
+      await flushPromises()
+
+      const result = wrapper.find('.decode-view__result')
+      expect(result.attributes('tabindex')).toBe('0')
+      expect(result.attributes('aria-label')).toBe(en.decode.result.label)
+    })
   })
 
   describe('stale result', () => {

--- a/frontend/src/views/DecodeView.vue
+++ b/frontend/src/views/DecodeView.vue
@@ -99,7 +99,11 @@ onUnmounted(() => {
             :class="{ 'decode-view__result-card--stale': store.resultStale }"
           >
             <span class="decode-view__result-label">{{ t('decode.result.label') }}</span>
-            <p class="decode-view__result">
+            <p
+              class="decode-view__result"
+              tabindex="0"
+              :aria-label="t('decode.result.label')"
+            >
               {{ store.result }}
             </p>
             <button


### PR DESCRIPTION
## Summary
- .decode-view__result has overflow-y: auto but no tabindex/role/aria-label - a keyboard-only user could only reach the first ~240px of a long message.
Critique #7, P3.
- Added tabindex="0" and an aria-label="Decoded message"

## Test plan
- [x] 218 Vitest tests passing (was 217 before this branch)
- [x] Build and lint clean
- [x] Live-verified: element receives keyboard focus (tabindex="0"), aria-label correct, scrollHeight 1717px vs clientHeight 240px confirms real scrollability
