### PR TITLE
feat(backend): pack the cryptogram size into the key (FEAT-022)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1980,7 +1980,7 @@ has `overflow-y: auto` (needed for long messages) but no `tabindex`, `role`, or
 - **type:** feat
 - **id:** FEAT-022
 - **milestone:** v2
-- **status:** ready
+- **status:** done
 - **priority:** medium
 - **domain:** backend
 - **complexity:** M
@@ -2040,4 +2040,21 @@ that UX improvement is still wanted.
 - `POST /encode` embeds the actual requested `size` into any key it generates
 - Unit tests for the bit-packing (mirroring the existing `rotationSequenceIndex`/
   `readingOrderIndex` test coverage) plus e2e coverage for the two updated endpoints
+
+#### Resolution (2026-08-22)
+
+Open design question resolved: **the key is authoritative**. When `POST /encode`
+is called in "existing key" mode, the key's own embedded `size` is always used for
+rendering, and a differing `dto.size` in the same request body is silently ignored -
+consistent with how `pivotBlockSize`/`rotationSequence`/`rotationDirection`/
+`readingOrder` already behave in that mode. This keeps a key fully self-sufficient:
+it never describes a cryptogram rendered at a different size than what it says.
+The cost is that Encode's frontend size selector becomes silently ineffective in
+key-mode until a frontend follow-up surfaces this (not part of this item's scope).
+
+Implemented in `backend/src/key/key-codec.ts` (`sizeIndex` at bits 17-18, no
+version bump needed), `backend/src/api/key.service.ts`,
+`backend/src/api/dto/key-generate-request.dto.ts`, and
+`backend/src/api/encode.service.ts`. `DecodeService`/`DecodeRequestDto` needed no
+changes (out of scope, doesn't construct `KeyParams` literals).
 <!-- ITEM:END -->

--- a/backend/src/api/decode.service.spec.ts
+++ b/backend/src/api/decode.service.spec.ts
@@ -132,6 +132,7 @@ describe('DecodeService', () => {
         rotationSequence: [0, 1, 2, 3],
         rotationDirection: 'cw',
         readingOrder: 'LR-TB',
+        size: 'medium',
       });
       const dto = {
         cryptogram: Buffer.from('not a png', 'utf-8').toString('base64'),
@@ -152,6 +153,7 @@ describe('DecodeService', () => {
         rotationSequence: [0, 1, 2, 3],
         rotationDirection: 'cw',
         readingOrder: 'LR-TB',
+        size: 'medium',
       });
       const dto = {
         cryptogram: 'not svg at all',
@@ -173,6 +175,7 @@ describe('DecodeService', () => {
         rotationSequence: [0, 1, 2, 3],
         rotationDirection: 'cw',
         readingOrder: 'LR-TB',
+        size: 'medium',
       });
       const dto = {
         cryptogram: encoded.png,

--- a/backend/src/api/dto/encode-request.dto.ts
+++ b/backend/src/api/dto/encode-request.dto.ts
@@ -18,7 +18,10 @@ import { READING_ORDERS } from '../../key/key-codec';
  * Request body for POST /encode. Either `key` is provided (individual
  * params below are ignored), or all four individual params are provided
  * (there is no "sensible defaults" fallback for this endpoint - that is
- * POST /key/generate's job).
+ * POST /key/generate's job). `size` is also ignored when `key` is provided:
+ * the key embeds its own size (FEAT-022), and honouring a request-supplied
+ * size that differs from it would let the rendered cryptogram silently
+ * stop matching what the key says it is.
  */
 export class EncodeRequestDto {
   @IsString()

--- a/backend/src/api/dto/key-generate-request.dto.ts
+++ b/backend/src/api/dto/key-generate-request.dto.ts
@@ -44,4 +44,8 @@ export class KeyGenerateRequestDto {
   @IsOptional()
   @IsIn(READING_ORDERS)
   readingOrder?: string;
+
+  @IsOptional()
+  @IsIn(['small', 'medium', 'large'])
+  size?: 'small' | 'medium' | 'large';
 }

--- a/backend/src/api/encode.service.spec.ts
+++ b/backend/src/api/encode.service.spec.ts
@@ -58,6 +58,23 @@ describe('EncodeService', () => {
       expect(decoded.readingOrder).toBe('LR-TB');
     });
 
+    it('embeds the actual requested size into a newly generated key', async () => {
+      const service = makeService();
+      const result = await service.encode({
+        ...VALID_PARAMS_DTO,
+        size: 'large',
+      });
+      const decoded = KeyCodec.decode(result.key);
+      expect(decoded.size).toBe('large');
+    });
+
+    it('defaults a newly generated key to size "medium" when size is omitted', async () => {
+      const service = makeService();
+      const result = await service.encode(VALID_PARAMS_DTO);
+      const decoded = KeyCodec.decode(result.key);
+      expect(decoded.size).toBe('medium');
+    });
+
     it('uses the provided key and ignores individual params when key is present', async () => {
       const service = makeService();
       const key = KeyCodec.encode({
@@ -66,11 +83,34 @@ describe('EncodeService', () => {
         rotationSequence: [3, 2, 1, 0],
         rotationDirection: 'ccw',
         readingOrder: 'RL-TB',
+        size: 'large',
       });
       const dto = { message: 'ABC', key } as EncodeRequestDto;
 
       const result = await service.encode(dto);
       expect(result.key).toBe(key);
+    });
+
+    it("renders at the key's own embedded size in key mode, ignoring a differing dto.size", async () => {
+      const service = makeService();
+      const key = KeyCodec.encode({
+        version: 1,
+        pivotBlockSize: 5,
+        rotationSequence: [0, 1, 2, 3],
+        rotationDirection: 'cw',
+        readingOrder: 'LR-TB',
+        size: 'large',
+      });
+      const renderSpy = jest.spyOn(PngRenderer.prototype, 'render');
+
+      await service.encode({
+        message: 'ABC',
+        key,
+        size: 'small',
+      } as EncodeRequestDto);
+
+      expect(renderSpy).toHaveBeenCalledWith(expect.anything(), 'large');
+      renderSpy.mockRestore();
     });
 
     it.each(['small', 'medium', 'large'] as const)(

--- a/backend/src/api/encode.service.ts
+++ b/backend/src/api/encode.service.ts
@@ -45,6 +45,7 @@ export class EncodeService {
         rotationSequence: dto.rotationSequence as RotationSequence,
         rotationDirection: dto.rotationDirection as 'cw' | 'ccw',
         readingOrder: dto.readingOrder as KeyParams['readingOrder'],
+        size: dto.size ?? 'medium',
       };
       try {
         key = KeyCodec.encode(keyParams);
@@ -70,9 +71,16 @@ export class EncodeService {
       keyParams.readingOrder,
     );
 
-    const size = dto.size ?? 'medium';
-    const pngBuffer = await this.pngRenderer.render(rotatedGrid, size);
-    const svgString = this.svgRenderer.render(rotatedGrid, size);
+    // Always render at the key's own size - keyParams.size is either the
+    // caller's requested size (params mode, embedded into the new key) or
+    // whatever the provided key already encodes (key mode). This keeps the
+    // key authoritative: it never describes a cryptogram rendered at a
+    // different size than what it says.
+    const pngBuffer = await this.pngRenderer.render(
+      rotatedGrid,
+      keyParams.size,
+    );
+    const svgString = this.svgRenderer.render(rotatedGrid, keyParams.size);
 
     return {
       png: pngBuffer.toString('base64'),

--- a/backend/src/api/key.service.spec.ts
+++ b/backend/src/api/key.service.spec.ts
@@ -65,6 +65,21 @@ describe('KeyService', () => {
       const dto = { rotationSequence: [0, 0, 1, 2] } as KeyGenerateRequestDto;
       expect(() => service.generate(dto)).toThrow(BadRequestException);
     });
+
+    it('defaults to size "medium" when no body is provided', () => {
+      const result = service.generate({} as KeyGenerateRequestDto);
+      const decoded = KeyCodec.decode(result.key);
+      expect(decoded.size).toBe('medium');
+    });
+
+    it.each(['small', 'medium', 'large'] as const)(
+      'embeds the requested size %s into the generated key',
+      (size) => {
+        const result = service.generate({ size } as KeyGenerateRequestDto);
+        const decoded = KeyCodec.decode(result.key);
+        expect(decoded.size).toBe(size);
+      },
+    );
   });
 
   describe('parse', () => {
@@ -75,12 +90,14 @@ describe('KeyService', () => {
         rotationSequence: [0, 1, 2, 3],
         rotationDirection: 'cw',
         readingOrder: 'LR-TB',
+        size: 'large',
       });
       const result = service.parse(key);
       expect(result.pivotBlockSize).toBe(5);
       expect(result.rotationSequence).toEqual([0, 90, 180, 270]);
       expect(result.rotationDirection).toBe('cw');
       expect(result.readingOrder).toBe('LR-TB');
+      expect(result.size).toBe('large');
     });
 
     it('returns the correct rotationSequence as an array of angles for a non-identity sequence', () => {
@@ -90,6 +107,7 @@ describe('KeyService', () => {
         rotationSequence: [3, 1, 0, 2],
         rotationDirection: 'cw',
         readingOrder: 'LR-TB',
+        size: 'medium',
       });
       const result = service.parse(key);
       expect(result.rotationSequence).toEqual([270, 90, 0, 180]);

--- a/backend/src/api/key.service.ts
+++ b/backend/src/api/key.service.ts
@@ -8,6 +8,7 @@ const DEFAULT_ROTATION_SEQUENCE: RotationSequence = Object.freeze([
 ]) as unknown as RotationSequence;
 const DEFAULT_ROTATION_DIRECTION: 'cw' | 'ccw' = 'cw';
 const DEFAULT_READING_ORDER: KeyParams['readingOrder'] = 'LR-TB';
+const DEFAULT_SIZE: KeyParams['size'] = 'medium';
 
 /** Response shape for POST /key/parse. */
 export interface KeyParseResult {
@@ -20,6 +21,7 @@ export interface KeyParseResult {
   rotationSequence: number[];
   rotationDirection: 'cw' | 'ccw';
   readingOrder: KeyParams['readingOrder'];
+  size: KeyParams['size'];
 }
 
 @Injectable()
@@ -34,6 +36,7 @@ export class KeyService {
       readingOrder:
         (dto.readingOrder as KeyParams['readingOrder']) ??
         DEFAULT_READING_ORDER,
+      size: dto.size ?? DEFAULT_SIZE,
     };
 
     try {
@@ -56,6 +59,7 @@ export class KeyService {
       rotationSequence: keyParams.rotationSequence.map((index) => index * 90),
       rotationDirection: keyParams.rotationDirection,
       readingOrder: keyParams.readingOrder,
+      size: keyParams.size,
     };
   }
 }

--- a/backend/src/key/key-codec.spec.ts
+++ b/backend/src/key/key-codec.spec.ts
@@ -13,6 +13,7 @@ const BASE_PARAMS: KeyParams = {
   rotationSequence: [0, 1, 2, 3],
   rotationDirection: 'cw',
   readingOrder: 'LR-TB',
+  size: 'medium',
 };
 
 const ALL_READING_ORDERS: ReadingOrder[] = [
@@ -153,6 +154,14 @@ describe('KeyCodec round-trip', () => {
     }
   });
 
+  it('round-trips all three case sizes', () => {
+    for (const size of ['small', 'medium', 'large'] as const) {
+      const params = { ...BASE_PARAMS, size };
+      const decoded = KeyCodec.decode(KeyCodec.encode(params));
+      expect(decoded.size).toBe(size);
+    }
+  });
+
   it('produces different keys for different params', () => {
     const key1 = KeyCodec.encode({ ...BASE_PARAMS, pivotBlockSize: 5 });
     const key2 = KeyCodec.encode({ ...BASE_PARAMS, pivotBlockSize: 7 });
@@ -171,5 +180,25 @@ describe('KeyCodec.decode - out-of-range payload values', () => {
 
   it('throws for a structurally valid key that unpacks to pivotBlockSize=0', () => {
     expect(() => KeyCodec.decode('HR1·0000')).toThrow(Error);
+  });
+
+  it('throws for a structurally valid key that unpacks to the reserved size index (3)', () => {
+    // Payload = pivotBlockSize=1 | orderIndex=0 | dirBit=0 | seqIndex=0 | sizeIndex=3<<17
+    expect(() => KeyCodec.decode('HR1·8FEP')).toThrow(Error);
+  });
+});
+
+describe('KeyCodec backward compatibility', () => {
+  it('decodes a pre-FEAT-022 key (no size bits ever set) as size "small", without throwing', () => {
+    // A key encoded before the size field existed never set bits 17-18, so
+    // they read back as 0 ("small") rather than the reserved value 3 - this
+    // must keep decoding cleanly, not throw.
+    const legacyPayload =
+      BASE_PARAMS.pivotBlockSize | (0 << 8) | (0 << 11) | (0 << 12);
+    const legacyKey = `HR1·${legacyPayload.toString(36).toUpperCase().padStart(4, '0')}`;
+
+    const decoded = KeyCodec.decode(legacyKey);
+
+    expect(decoded.size).toBe('small');
   });
 });

--- a/backend/src/key/key-codec.ts
+++ b/backend/src/key/key-codec.ts
@@ -1,4 +1,5 @@
 import type { ReadingOrder } from '../reading-order/reading-order-strategy.interface';
+import type { CaseSize } from '../shared/types/case-size.type';
 
 export type { ReadingOrder };
 
@@ -24,6 +25,8 @@ export interface KeyParams {
   rotationDirection: 'cw' | 'ccw';
   /** Block traversal order. */
   readingOrder: ReadingOrder;
+  /** Rendered case size used to produce (and required to decode) the cryptogram. */
+  size: CaseSize;
 }
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -46,6 +49,9 @@ export const READING_ORDERS: ReadingOrder[] = [
   'BT-LR-ALT',
 ];
 
+/** All 3 case sizes, indexed 0-2. Index 3 is reserved (unused). */
+export const CASE_SIZES: CaseSize[] = ['small', 'medium', 'large'];
+
 /**
  * All 24 permutations of [0, 1, 2, 3] in lexicographic order.
  * Index 0 = [0,1,2,3], index 23 = [3,2,1,0].
@@ -66,11 +72,13 @@ function buildPermutations(arr: number[]): RotationSequence[] {
 
 // ─── Bit layout ───────────────────────────────────────────────────────────────
 //
-// The payload is a 17-bit integer encoded as a 4-digit base36 string:
+// The payload is a 19-bit integer encoded as a 4-digit base36 string (which has
+// room for up to 21 bits, `36^4 - 1 = 1,679,615`; bits 19-20 remain free):
 //   bits  0–7  → pivotBlockSize  (uint8, 1–255)
 //   bits  8–10 → readingOrderIndex (0–7)
 //   bit  11    → rotationDirection (0 = cw, 1 = ccw)
 //   bits 12–16 → rotationSequenceIndex (0–23)
+//   bits 17–18 → sizeIndex (0–2; 3 is reserved)
 
 function pack(params: KeyParams): number {
   const seqIndex = ROTATION_SEQUENCES.findIndex((s) =>
@@ -78,12 +86,14 @@ function pack(params: KeyParams): number {
   );
   const orderIndex = READING_ORDERS.indexOf(params.readingOrder);
   const dirBit = params.rotationDirection === 'ccw' ? 1 : 0;
+  const sizeIndex = CASE_SIZES.indexOf(params.size);
 
   return (
     params.pivotBlockSize |
     (orderIndex << 8) |
     (dirBit << 11) |
-    (seqIndex << 12)
+    (seqIndex << 12) |
+    (sizeIndex << 17)
   );
 }
 
@@ -92,12 +102,14 @@ function unpack(payload: number): Omit<KeyParams, 'version'> {
   const orderIndex = (payload >> 8) & 0x07;
   const dirBit = (payload >> 11) & 0x01;
   const seqIndex = (payload >> 12) & 0x1f;
+  const sizeIndex = (payload >> 17) & 0x03;
 
   return {
     pivotBlockSize,
     readingOrder: READING_ORDERS[orderIndex],
     rotationDirection: dirBit === 1 ? 'ccw' : 'cw',
     rotationSequence: ROTATION_SEQUENCES[seqIndex],
+    size: CASE_SIZES[sizeIndex],
   };
 }
 
@@ -151,7 +163,7 @@ export class KeyCodec {
    * Deserialises a key string to its parameters.
    *
    * @throws {Error} If the key string is malformed or has an unknown version.
-   * @throws {Error} If the key unpacks to a semantically invalid pivotBlockSize or rotation sequence index.
+   * @throws {Error} If the key unpacks to a semantically invalid pivotBlockSize, rotation sequence index, or size index.
    */
   static decode(key: string): KeyParams {
     if (!KeyCodec.validate(key)) {
@@ -171,6 +183,11 @@ export class KeyCodec {
     if (!unpacked.rotationSequence) {
       throw new Error(
         `Invalid key format: "${key}" (unpacks to an out-of-range rotation sequence index)`,
+      );
+    }
+    if (!unpacked.size) {
+      throw new Error(
+        `Invalid key format: "${key}" (unpacks to a reserved size index)`,
       );
     }
 

--- a/backend/test/encode.e2e-spec.ts
+++ b/backend/test/encode.e2e-spec.ts
@@ -11,6 +11,15 @@ import {
   MALFORMED_KEY_STRINGS,
 } from './fixtures/api.fixtures';
 
+/** Reads width/height from a base64 PNG's IHDR chunk (bytes 16-23). */
+function pngDimensions(base64Png: string): { width: number; height: number } {
+  const buffer = Buffer.from(base64Png, 'base64');
+  return {
+    width: buffer.readUInt32BE(16),
+    height: buffer.readUInt32BE(20),
+  };
+}
+
 describe('POST /api/encode (e2e)', () => {
   let app: INestApplication;
 
@@ -118,6 +127,51 @@ describe('POST /api/encode (e2e)', () => {
         expect(res.status).toBe(200);
       },
     );
+
+    it('embeds the requested size into a newly generated key', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/encode')
+        .send({ ...VALID_ENCODE_BODY, size: 'large' });
+
+      expect(res.status).toBe(200);
+      const body = res.body as EncodeResult;
+
+      const parseRes = await request(app.getHttpServer())
+        .post('/api/key/parse')
+        .send({ key: body.key });
+      expect(parseRes.status).toBe(200);
+      expect((parseRes.body as { size: string }).size).toBe('large');
+    });
+
+    it('renders at the key\'s own embedded size, ignoring a differing request size', async () => {
+      // VALID_KEY_STRING embeds size 'medium' - so requesting 'large'
+      // alongside it must still render at 'medium', matching a direct
+      // 'medium' params-mode request. Grid padding is randomised per call,
+      // so compare PNG pixel dimensions (IHDR), not raw byte length.
+      const withKeyRes = await request(app.getHttpServer())
+        .post('/api/encode')
+        .send({ ...VALID_ENCODE_BODY_WITH_KEY, size: 'large' });
+      const withMediumParamsRes = await request(app.getHttpServer())
+        .post('/api/encode')
+        .send({ ...VALID_ENCODE_BODY, size: 'medium' });
+      const withLargeParamsRes = await request(app.getHttpServer())
+        .post('/api/encode')
+        .send({ ...VALID_ENCODE_BODY, size: 'large' });
+
+      expect(withKeyRes.status).toBe(200);
+      expect(withMediumParamsRes.status).toBe(200);
+      expect(withLargeParamsRes.status).toBe(200);
+      const withKeyBody = withKeyRes.body as EncodeResult;
+      const withMediumParamsBody = withMediumParamsRes.body as EncodeResult;
+      const withLargeParamsBody = withLargeParamsRes.body as EncodeResult;
+
+      expect(pngDimensions(withKeyBody.png)).toEqual(
+        pngDimensions(withMediumParamsBody.png),
+      );
+      expect(pngDimensions(withKeyBody.png)).not.toEqual(
+        pngDimensions(withLargeParamsBody.png),
+      );
+    });
   });
 
   describe('weakness warning', () => {

--- a/backend/test/fixtures/api.fixtures.ts
+++ b/backend/test/fixtures/api.fixtures.ts
@@ -14,6 +14,7 @@ export const VALID_KEY_STRING = KeyCodec.encode({
   rotationSequence: [0, 1, 2, 3],
   rotationDirection: 'cw',
   readingOrder: 'LR-TB',
+  size: 'medium',
 });
 
 export const VALID_ENCODE_BODY_WITH_KEY = {

--- a/backend/test/key.e2e-spec.ts
+++ b/backend/test/key.e2e-spec.ts
@@ -110,6 +110,13 @@ describe('Key endpoints (e2e)', () => {
         .send({ pivotBlockSize: 0 });
       expect(res.status).toBe(400);
     });
+
+    it('returns 400 when size is not small, medium, or large', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/key/generate')
+        .send({ size: 'huge' });
+      expect(res.status).toBe(400);
+    });
   });
 
   describe('POST /api/key/parse', () => {
@@ -194,6 +201,39 @@ describe('Key endpoints (e2e)', () => {
       );
       expect(parseBody.rotationDirection).toBe(requestBody.rotationDirection);
       expect(parseBody.readingOrder).toBe(requestBody.readingOrder);
+    });
+
+    it.each(['small', 'medium', 'large'])(
+      'round-trips size %s through generate and parse',
+      async (size) => {
+        const generateRes = await request(app.getHttpServer())
+          .post('/api/key/generate')
+          .send({ size });
+        const { key } = generateRes.body as KeyGenerateResult;
+
+        const parseRes = await request(app.getHttpServer())
+          .post('/api/key/parse')
+          .send({ key });
+
+        expect(parseRes.status).toBe(200);
+        const parseBody = parseRes.body as KeyParseResult;
+        expect(parseBody.size).toBe(size);
+      },
+    );
+
+    it('defaults to size "medium" when generate is called without a size', async () => {
+      const generateRes = await request(app.getHttpServer())
+        .post('/api/key/generate')
+        .send({});
+      const { key } = generateRes.body as KeyGenerateResult;
+
+      const parseRes = await request(app.getHttpServer())
+        .post('/api/key/parse')
+        .send({ key });
+
+      expect(parseRes.status).toBe(200);
+      const parseBody = parseRes.body as KeyParseResult;
+      expect(parseBody.size).toBe('medium');
     });
   });
 });


### PR DESCRIPTION
## Summary

- Extends KeyCodec's existing 4-character base36 payload with a 2-bit sizeIndex field (bits 17-18), packing pivotBlockSize, readingOrderIndex, rotationDirection, rotationSequenceIndex, and now size — no version bump or length change needed (per CHORE-009's bit-budget finding).
- Pre-FEAT-022 keys (bits never set) decode cleanly as small, without throwing — backward compatible by construction.
- decode() rejects the reserved sizeIndex value 3.
- POST /key/generate and POST /key/parse both round-trip size.
- POST /encode in key mode now treats the key as authoritative for size: the request's size field is ignored if it differs from what the key embeds, matching the existing precedent for pivotBlockSize/rotationSequence/etc. In params mode, the requested size (or medium default) gets embedded into the newly generated key.

## Test plan

- [x] Backend unit suite: 380/380 passing
- [x] Backend e2e suite: 79/79 passing (against a throwaway Postgres container, migrated + seeded)
- [x] npm run build clean
- [x] npm run lint: 0 errors (49 pre-existing warnings in unrelated e2e supertest typings)
- [x] BACKLOG.md: FEAT-022 marked done, with the size-precedence design resolution recorded
