### PR TITLE
docs: homogenize documentation structure across the project

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Report something that doesn't work as expected
+title: ""
+labels: bug
+---
+
+## Description
+
+A clear description of the problem.
+
+## Steps to reproduce
+
+1. ...
+2. ...
+
+## Expected behaviour
+
+What you expected to happen.
+
+## Actual behaviour
+
+What actually happened. Include error messages, screenshots, or a sample
+cryptogram/key if relevant.
+
+## Environment
+
+- HexaRot version/commit:
+- Browser (if frontend issue):
+- How you ran it (Docker Compose, local backend/frontend, etc.):

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Suggest an idea or improvement
+title: ""
+labels: enhancement
+---
+
+## Problem or motivation
+
+What gap or friction does this address?
+
+## Proposed solution
+
+What you'd like to see happen.
+
+## Alternatives considered
+
+Any alternative approaches, if relevant.

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,38 @@
+name: Changelog
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - CHANGELOG.md
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-changelog:
+    name: Regenerate CHANGELOG.md
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate changelog
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          args: --config cliff.toml -o CHANGELOG.md
+
+      - name: Open pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "docs: update changelog"
+          title: "docs: update changelog"
+          body: Automated changelog update, generated from Conventional Commits history on main.
+          branch: chore/update-changelog
+          delete-branch: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,242 @@
+# Changelog
+
+All notable changes to this project are documented in this file, generated
+automatically from Conventional Commits history.
+## [Unreleased]
+
+### Bug Fixes
+
+- Corrected BACKLOG.md statut of item TEST-004
+- Bad backlog item status
+- Fix Kanban column name casing in sync-backlog script
+- Guard invalid pivotBlockSize, add missing T=6 coverage
+- Widen the grid adaptively instead of always using the minimum width
+- Guard invalid pivotBlockSize and rotation sequence entries
+- Replace em dashes with plain punctuation in renderer.md design note
+- Guard colorNameToRgb against Object.prototype lookup
+- Address final review findings for FEAT-009
+- Address final review findings for FEAT-010
+- Address final review findings for FEAT-011
+- Harden KeyCodec.decode against out-of-range payload values
+- Address final review findings for FEAT-013
+- Detect misaligned casePixels in PNG parser
+- Bound decoded pixel count in PNG parser
+- Force CommonJS output for the generated Prisma client
+- Correct inverted key format error condition
+- Declare globals as an explicit devDependency
+- Disambiguate select controls in the initial-render test
+- Route the Vite dev-server proxy through an env var for Docker Compose
+- Route error messages through i18n and add ApiError.code
+- Handle clipboard failures, tidy eslint-disable placement, guard pivotBlockSize
+- Resolve FileReader failures inside decode submit()
+- Add a size-selector hint on the decode form
+- Reset decode store on unmount and mark result aria-live
+- Accept uppercase key payloads in client-side format check
+- Close DB connections in e2e teardown, tighten test timing
+- Correct e2e coverage scoping and a backlog ID collision
+- Wire the design token stylesheet into the app entrypoint
+- Stop destroying the encode key on navigation
+- Move actual keyboard focus on rotation-picker arrow navigation
+- Stop the success-path focus call from cancelling the scroll
+- Raise disabled-button and form-border contrast
+- Always focus and instant-scroll to result errors
+- Extend stale-result protection to decode and key parser
+- Restore readable disabled-button contrast, stop dimming cryptogram colors when stale
+- Keep output column height stable during encode/decode requests
+- Translate reading order to a human-readable label
+- Surface the cryptogram size alongside the encode key
+- Drop the decryption key from downloaded filenames
+- Make decoded messages readable, fix stale-state contrast on Key views
+- Move key parsing off a GET query string (REFACTOR-004)
+- Snapshot the encode result size instead of reading it live (REFACTOR-007)
+- Stop destroying the previous result on a failed submit (REFACTOR-006)
+- Keep Copy and Download enabled while a result is stale (REFACTOR-005)
+- Copy button includes the cryptogram size alongside the key (REFACTOR-008)
+- Fix Encode form horizontal overflow on mobile (REFACTOR-009)
+- Stop the "Out of date" badge from overlapping cryptogram cells (REFACTOR-010)
+- Make the decoded message keyboard-scrollable (REFACTOR-011)
+
+### CI/CD
+
+- Set up GitHub Actions CI pipeline
+- Fix vitest exit code when no test files found
+- Add backlog sync pipeline, branch and PR trackers, PR template
+- Extract sync script to separate file, fix YAML syntax error
+- Fix working-directory and BACKLOG.md path in sync script
+- Add debug logging to backlog parser
+- Log full debug block in parser
+- Fix parser split to ignore ITEM:BEGIN references in item descriptions
+- Add status coherence validation and auto-promotion to ready
+- Pass token to checkout to allow BACKLOG.md auto-commit
+- Add PostgreSQL service to backend CI job for integration tests
+- Add real backend e2e coverage collection and Codecov reporting
+
+### Documentation
+
+- Add README.md and README.fr.md, fix BACKLOG.md case in .gitignore
+- Added Github Action token management to documentation
+- Add TEST-004 MockAlphabet implementation plan
+- Remove em dashes and exotic punctuation from TEST-004 plan
+- Add FEAT-005 reading order strategies implementation plan
+- Add Tasks 4-5 to FEAT-005 plan for docs/tests/reading-order.md compliance
+- Add FEAT-006 grid construction implementation plan
+- Add Task 3 to FEAT-006 plan for adaptive grid width
+- Sync test contract with shipped suite, add narrow-alphabet coverage
+- List the narrow-alphabet test in the adaptive width bullets
+- Add FEAT-007 rotation engine implementation plan
+- Add FEAT-008 metadata header implementation plan
+- Clarify header messageLength semantics and sync test contract
+- Add FEAT-011 encode API endpoint plan
+- Add FEAT-013 key endpoints plan
+- Add FEAT-012 decode API endpoint plan and design spec
+- Document decodeGrid trailing-truncation behavior
+- Sync FEAT-012 description with resolved decisions
+- Note the spaces bullet is skipped in the shipped suite
+- Update V1 roadmap to reflect completed backend API
+- Add design spec and implementation plan for the encode view
+- Add design spec and implementation plan for the decode view
+- Add design spec and implementation plan for the key view
+- Complete README API examples and fix stale content
+- Persist the post-REFACTOR-001 re-critique snapshot
+- Close REFACTOR-001, log deferred structural findings as REFACTOR-002
+- Decompose REFACTOR-002 into layout, staleness and key-format investigation
+- Persist critique #4 and #5 snapshots
+- Persist critique #6 snapshot
+- Persist critique #7 snapshot
+- Add REFACTOR-004..011 from critique #7 findings
+- Mark REFACTOR-004 done
+- CHORE-009 recommendation, open FEAT-022
+- Rewrite backend README with HexaRot-specific content
+- Rewrite frontend README with HexaRot-specific content
+- Add code of conduct
+- Add security policy
+
+### Features
+
+- Implement text pre-processing pipeline
+- Implement GCD-based parameter validator
+- Implement KeyCodec with base36 encoding and round-trip decode
+- Add ReadingOrderStrategy interface, LR-TB and RL-TB strategies
+- Add TB-LR and BT-LR strategies
+- Add ReadingOrderRegistry and wire it into the module
+- Implement buildGrid for symbol layout and random padding
+- Implement rotateBlock for single-block rotation
+- Implement RotationEngine and wire it into the module
+- Implement encodeHeader/decodeHeader for cryptogram metadata
+- Add Renderer<T> interface and CaseSize type
+- Add Hexahue palette constants and colour-to-RGB lookup
+- Implement PngRenderer with Sharp raw pixel painting
+- Implement SvgRenderer with native string templating
+- Add global ValidationPipe, API prefix, and EncodeRequestDto
+- Implement EncodeService orchestrating the full cipher pipeline
+- Wire POST /encode end to end with a full HTTP-level test suite
+- Implement KeyController and KeyService for key generate/parse
+- Add PNG and SVG parsers, inverse of PngRenderer/SvgRenderer
+- Add decodeGrid, the inverse of buildGrid
+- Implement DecodeService and DecodeController for POST /decode
+- Add router, layout, and shared build config for FEAT-014
+- Add fetch-based API client wrapper
+- Add encode Pinia store, reading-order constants, and shared test fixtures
+- Add client-side HexaRot key format validation
+- Add drag-and-drop rotation sequence picker
+- Add encode parameters form
+- Add encode result panel with previews, copy, and downloads
+- Assemble the encode view and wire it into the router
+- Add decode Pinia store and decode-related test fixtures
+- Add file upload area with drag-and-drop for the decode view
+- Add decode parameters form
+- Assemble the decode view and wire it into the router
+- Add the key store for generate and parse actions
+- Add the key generator form
+- Add the key parser form
+- Assemble the key view and wire it into the router
+- Apply the layout fix pass across encode, decode and key views
+- Make the rotation sequence picker keyboard accessible
+- Clarify error copy and explain weakness warnings
+- Add submit feedback across encode, decode and key views
+- Amplify the encode key result to its own visual weight
+- Final polish pass across encode, decode and key views
+- Introduce a primary/secondary button system and fix contrast tokens
+- Tolerate near-miss HexaRot key input and diagnose format errors
+- Two-column result layout for encode and decode views
+- Invalidate a stale encode result on parameter change
+- Mark a stale encode result instead of deleting it
+- Give the output column an empty state and align the title
+- Bring Key view to parity with Encode and Decode
+- Pack the cryptogram size into the key (FEAT-022)
+
+### Miscellaneous
+
+- Initialize NestJS backend project
+- Initialize Vue.js 3 frontend project
+- Configure pre-commit hooks with Husky and lint-staged
+- Untrack gitignored files
+- Configure Docker Compose for local development
+- Configure Prisma and PostgreSQL schema with Hexahue seed
+- Mark CI-002 as done
+- Auto-promote ready items [skip ci]
+- Mark CI-003 as done and clarify acceptance criteria
+- Updated BACKLOG
+- Mark FEAT-001 as done
+- Auto-promote ready items [skip ci]
+- Mark FEAT-002 as done
+- Auto-promote ready items [skip ci]
+- Auto-promote ready items [skip ci]
+- Plan reactivation roadmap - traefik infra, Brevo registration, design and security passes
+- Mark TEST-004 as done
+- Mark FEAT-005 as done
+- Auto-promote ready items [skip ci]
+- Relocate MockAlphabet to test/utils per docs/tests/cipher.md
+- Mark FEAT-006 as done
+- Auto-promote ready items [skip ci]
+- Mark FEAT-007 as done
+- Auto-promote ready items [skip ci]
+- Mark FEAT-008 as done
+- Auto-promote ready items [skip ci]
+- Mark FEAT-010 as done, fix doc comment, commit plan
+- Auto-promote ready items [skip ci]
+- Mark FEAT-011 as done
+- Auto-promote ready items [skip ci]
+- Mark FEAT-013 as done
+- Auto-promote ready items [skip ci]
+- Mark FEAT-012 as done
+- Auto-promote ready items [skip ci]
+- Flip FEAT-014 to status done
+- Mark FEAT-016 as done
+- Route local dev through Traefik instead of published ports
+- Auto-promote ready items [skip ci]
+- Auto-promote ready items [skip ci]
+- Enforce the Codecov project status now that a real number exists
+- Auto-promote ready items [skip ci]
+- Mark FEAT-015 done - already implemented
+- Auto-promote ready items [skip ci]
+
+### Refactoring
+
+- Consolidate colour and size guards into shared palette helpers
+
+### Styling
+
+- Apply linter fixes to CLI-generated files
+
+### Testing
+
+- Add MockAlphabet test double with non-Hexahue dimensions
+- Add dimension-agnostic VisualAlphabet contract suite
+- Give MockAlphabet a real consumer and address review findings
+- Align tests with docs/tests/reading-order.md contract
+- Add module-wiring test, fix stale JSDoc, update TEST-001 deps
+- Add sections 2-6 behavioral tests from docs/tests/reading-order.md
+- Add shared fixtures for grid construction tests
+- Assert padding region differs from message symbol rendering
+- Add shared fixtures for rotation engine tests
+- Add missing messageLength=0 case to header round-trip tests
+- Add PngRenderer integration tests for the full pipeline
+- Add SvgRenderer integration tests for the full pipeline
+- Add full HTTP-level test suite for key generate/parse endpoints
+- Add full HTTP-level test suite for POST /decode
+- Enforce coverage thresholds on the algorithmic core
+- Make the e2e suite hit a real seeded database
+- Enforce coverage thresholds, close two real test gaps
+
+

--- a/CODE_OF_CONDUCT.fr.md
+++ b/CODE_OF_CONDUCT.fr.md
@@ -1,0 +1,19 @@
+🇫🇷 Version française | [🇬🇧 English version](CODE_OF_CONDUCT.md)
+
+---
+
+# Code de conduite
+
+HexaRot est un projet personnel open source. Toute personne interagissant avec ce
+dépôt (issues, pull requests, discussions) est invitée à :
+
+- Rester respectueuse et constructive dans ses échanges
+- Rester sur le sujet et centrée sur le projet
+- S'abstenir de tout harcèlement, attaque personnelle ou propos discriminatoire
+
+Les signalements de comportement inacceptable peuvent être envoyés au mainteneur
+via une issue GitHub, ou directement par email (voir le profil GitHub pour les
+coordonnées). Les signalements seront traités avec discrétion.
+
+Les manquements peuvent entraîner la suppression de commentaires ou le refus de
+contributions, à la discrétion du mainteneur.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,19 @@
+[🇫🇷 Version française](CODE_OF_CONDUCT.fr.md) | 🇬🇧 English version
+
+---
+
+# Code of Conduct
+
+HexaRot is a personal, open-source project. Everyone interacting with this
+repository (issues, pull requests, discussions) is expected to:
+
+- Be respectful and constructive in all communication
+- Stay on topic and focused on the project
+- Refrain from harassment, personal attacks, or discriminatory language
+
+Reports of unacceptable behaviour can be sent to the maintainer via a GitHub issue
+or directly by email (see the GitHub profile for contact details). Reports will be
+handled with discretion.
+
+Violations may result in comments being removed, or contributions being declined,
+at the maintainer's discretion.

--- a/README.fr.md
+++ b/README.fr.md
@@ -64,92 +64,10 @@ L'API est disponible sur `http://hexarot.marvinlerouge.local/api`.
 
 ## API
 
-Tous les endpoints sont préfixés par `/api`.
-
-| Méthode | Route | Description |
-|---|---|---|
-| `POST` | `/encode` | Encoder un message → cryptogramme PNG + SVG |
-| `POST` | `/decode` | Décoder un cryptogramme → texte en clair |
-| `POST` | `/key/generate` | Générer une clé HR depuis des paramètres |
-| `POST` | `/key/parse` | Analyser une clé HR → paramètres structurés |
-
-**Exemple — `POST /encode`**
-
-```json
-POST /api/encode
-{
-  "message": "HELLO WORLD",
-  "pivotBlockSize": 5,
-  "rotationSequence": [0, 1, 2, 3],
-  "rotationDirection": "cw",
-  "readingOrder": "LR-TB",
-  "size": "medium"
-}
-```
-
-```json
-{
-  "png": "<PNG encodé en base64>",
-  "svg": "<chaîne SVG>",
-  "key": "HR1·57C3",
-  "warnings": [],
-  "unknownChars": []
-}
-```
-
-**Exemple — `POST /decode`**
-
-```json
-POST /api/decode
-{
-  "cryptogram": "<PNG encodé en base64 ou chaîne SVG brute>",
-  "format": "png",
-  "key": "HR1·57C3",
-  "size": "medium"
-}
-```
-
-```json
-{
-  "message": "HELLO WORLD"
-}
-```
-
-**Exemple — `POST /key/generate`**
-
-```json
-POST /api/key/generate
-{
-  "pivotBlockSize": 5,
-  "rotationSequence": [0, 1, 2, 3],
-  "rotationDirection": "cw",
-  "readingOrder": "LR-TB"
-}
-```
-
-```json
-{
-  "key": "HR1·57C3"
-}
-```
-
-**Exemple — `POST /key/parse`**
-
-```json
-POST /api/key/parse
-{
-  "key": "HR1·57C3"
-}
-```
-
-```json
-{
-  "pivotBlockSize": 5,
-  "rotationSequence": [0, 90, 180, 270],
-  "rotationDirection": "cw",
-  "readingOrder": "LR-TB"
-}
-```
+Tous les endpoints sont préfixés par `/api` : `POST /encode`, `POST /decode`,
+`POST /key/generate`, `POST /key/parse`. Voir
+[docs/api/api_endpoints.fr.md](docs/api/api_endpoints.fr.md) pour la référence
+complète, avec des exemples de requêtes/réponses.
 
 ---
 
@@ -218,27 +136,11 @@ frontend/
 
 ## Roadmap
 
-### V1
-
-- ✅ Infra (NestJS, Vue.js, Docker Compose, Prisma)
-- ✅ CI (GitHub Actions — pipeline de tests, synchronisation du backlog)
-- ✅ Alphabet (interface VisualAlphabet + implémentation Hexahue)
-- ✅ Cipher (pré-traitement, construction de grille, pas d'en-tête de métadonnées, choix délibéré anti-fuite)
-- ✅ Moteur de rotation
-- ✅ Codec de clé (encodage / décodage / validation base36)
-- ✅ Stratégies d'ordre de lecture (4 directions + mode alterné)
-- ✅ Renderers (PNG + SVG)
-- ✅ Endpoints API (encode, decode, key)
-- ✅ Frontend (vues encodage, décodage, clé toutes terminées, passe UI/UX terminée)
-- ✅ Tests & couverture (suites unitaires/e2e backend + frontend, reporting Codecov, seuil global ≥85% confirmé)
-
-### V2
-
-- ⬜ Interface française (i18n)
-- ⬜ Mode de décodage animé
-- ⬜ Ordre de lecture en spirale
-- ⬜ Score de corrélation
-- ⬜ Authentification utilisateur
+La V1 est terminée : infra, pipeline de chiffrement, codec de clé, API, frontend
+et couverture de tests sont tous faits. La V2 vise une interface française, un
+mode de décodage animé, un ordre de lecture en spirale, un score de corrélation
+et l'authentification utilisateur. Voir [docs/roadmap.fr.md](docs/roadmap.fr.md)
+pour le détail complet.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -64,92 +64,10 @@ The API is available at `http://hexarot.marvinlerouge.local/api`.
 
 ## API
 
-All endpoints are prefixed with `/api`.
-
-| Method | Route | Description |
-|---|---|---|
-| `POST` | `/encode` | Encode a message → PNG + SVG cryptogram |
-| `POST` | `/decode` | Decode a cryptogram → plaintext |
-| `POST` | `/key/generate` | Generate an HR key from parameters |
-| `POST` | `/key/parse` | Parse an HR key → structured parameters |
-
-**Example — `POST /encode`**
-
-```json
-POST /api/encode
-{
-  "message": "HELLO WORLD",
-  "pivotBlockSize": 5,
-  "rotationSequence": [0, 1, 2, 3],
-  "rotationDirection": "cw",
-  "readingOrder": "LR-TB",
-  "size": "medium"
-}
-```
-
-```json
-{
-  "png": "<base64-encoded PNG>",
-  "svg": "<SVG string>",
-  "key": "HR1·57C3",
-  "warnings": [],
-  "unknownChars": []
-}
-```
-
-**Example — `POST /decode`**
-
-```json
-POST /api/decode
-{
-  "cryptogram": "<base64-encoded PNG or raw SVG string>",
-  "format": "png",
-  "key": "HR1·57C3",
-  "size": "medium"
-}
-```
-
-```json
-{
-  "message": "HELLO WORLD"
-}
-```
-
-**Example — `POST /key/generate`**
-
-```json
-POST /api/key/generate
-{
-  "pivotBlockSize": 5,
-  "rotationSequence": [0, 1, 2, 3],
-  "rotationDirection": "cw",
-  "readingOrder": "LR-TB"
-}
-```
-
-```json
-{
-  "key": "HR1·57C3"
-}
-```
-
-**Example — `POST /key/parse`**
-
-```json
-POST /api/key/parse
-{
-  "key": "HR1·57C3"
-}
-```
-
-```json
-{
-  "pivotBlockSize": 5,
-  "rotationSequence": [0, 90, 180, 270],
-  "rotationDirection": "cw",
-  "readingOrder": "LR-TB"
-}
-```
+All endpoints are prefixed with `/api`: `POST /encode`, `POST /decode`,
+`POST /key/generate`, `POST /key/parse`. See
+[docs/api/api_endpoints.md](docs/api/api_endpoints.md) for the full reference,
+including request/response examples.
 
 ---
 
@@ -217,27 +135,10 @@ frontend/
 
 ## Roadmap
 
-### V1
-
-- ✅ Infra (NestJS, Vue.js, Docker Compose, Prisma)
-- ✅ CI (GitHub Actions — tests pipeline, backlog sync)
-- ✅ Alphabet (VisualAlphabet interface + Hexahue implementation)
-- ✅ Cipher (pre-processing, grid construction, no metadata header by design, a deliberate anti-leakage choice)
-- ✅ Rotation engine
-- ✅ Key codec (base36 encode / decode / validate)
-- ✅ Reading order strategies (4 directions + alternate)
-- ✅ Renderers (PNG + SVG)
-- ✅ API endpoints (encode, decode, key)
-- ✅ Frontend (encode, decode, key views all done, UI/UX polish pass done)
-- ✅ Tests & coverage (backend + frontend unit/e2e suites, Codecov reporting, ≥85% global bar confirmed)
-
-### V2
-
-- ⬜ French interface (i18n)
-- ⬜ Animated decoding mode
-- ⬜ Spiral reading order
-- ⬜ Correlation score
-- ⬜ User authentication
+V1 is complete: infra, cipher pipeline, key codec, API, frontend, and test
+coverage are all done. V2 targets a French interface, an animated decoding mode,
+a spiral reading order, a correlation score, and user authentication. See
+[docs/roadmap.md](docs/roadmap.md) for the full breakdown.
 
 ---
 

--- a/SECURITY.fr.md
+++ b/SECURITY.fr.md
@@ -1,0 +1,34 @@
+🇫🇷 Version française | [🇬🇧 English version](SECURITY.md)
+
+---
+
+# Politique de sécurité
+
+## Versions supportées
+
+HexaRot est en développement actif, pré-1.0. Seul l'état courant de la branche
+`main` est supporté ; il n'y a pas de rétroportage de correctifs vers d'anciens
+tags.
+
+## Signaler une vulnérabilité
+
+Si vous découvrez un problème de sécurité (par exemple, un moyen de faire fuiter
+le contenu ou la longueur d'un message chiffré via le cryptogramme, ou une
+vulnérabilité dans l'API ou les dépendances), merci de le signaler en privé plutôt
+que d'ouvrir une issue publique :
+
+- Utilisez le [signalement privé de vulnérabilités](https://github.com/MarvinLeRouge/HexaRot/security/advisories/new)
+  de GitHub pour ce dépôt, ou
+- Contactez le mainteneur directement par email (voir le profil GitHub pour les
+  coordonnées).
+
+Merci d'inclure les étapes de reproduction et, si possible, le composant concerné
+(module backend, vue frontend, ou dépendance).
+
+## Périmètre
+
+HexaRot est un chiffre visuel à visée d'obfuscation et d'apprentissage, et non un
+schéma de chiffrement validé cryptographiquement. Il évite délibérément de laisser
+fuiter la longueur du message dans le cryptogramme (voir l'[ADR 0001](docs/adr/0001-no-message-length-exposure.md)),
+mais ne doit pas être utilisé pour protéger des données sensibles face à un
+attaquant déterminé.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+[🇫🇷 Version française](SECURITY.fr.md) | 🇬🇧 English version
+
+---
+
+# Security Policy
+
+## Supported versions
+
+HexaRot is under active development, pre-1.0. Only the latest state of the `main`
+branch is supported; there is no back-porting of fixes to older tags.
+
+## Reporting a vulnerability
+
+If you find a security issue (for example, a way to leak encrypted message content
+or length through the cryptogram, or a vulnerability in the API or dependencies),
+please report it privately rather than opening a public issue:
+
+- Use GitHub's [private vulnerability reporting](https://github.com/MarvinLeRouge/HexaRot/security/advisories/new)
+  for this repository, or
+- Contact the maintainer directly by email (see the GitHub profile for contact
+  details).
+
+Please include steps to reproduce and, if applicable, the affected component
+(backend module, frontend view, or dependency).
+
+## Scope notes
+
+HexaRot is a visual cipher for obfuscation and learning purposes, not a
+cryptographically vetted encryption scheme. It intentionally avoids leaking
+message-length metadata in the cryptogram (see [ADR 0001](docs/adr/0001-no-message-length-exposure.md)),
+but should not be relied upon for protecting sensitive data against a motivated
+attacker.

--- a/backend/README.fr.md
+++ b/backend/README.fr.md
@@ -1,0 +1,94 @@
+🇫🇷 Version française | [🇬🇧 English version](README.md)
+
+---
+
+# Backend HexaRot
+
+API NestJS 11 implémentant le chiffre visuel HexaRot : pré-traitement du message,
+construction de la grille, rotation des blocs, encodage/décodage de la clé, et rendu
+PNG/SVG.
+
+Voir le [README racine](../README.fr.md) pour la vue d'ensemble du projet et le
+[guide d'architecture backend](../docs/architecture/backend_architecture.fr.md) pour
+le détail des modules.
+
+---
+
+## Prérequis
+
+- Node.js et npm
+- PostgreSQL 16 (via le `docker-compose.yml` racine, ou une instance locale)
+
+Le lancement via Docker Compose depuis la racine du dépôt est la configuration
+recommandée ; voir la section Démarrage rapide du README racine.
+
+---
+
+## Installation
+
+```bash
+npm install
+npx prisma migrate dev     # applique les migrations et régénère le client Prisma
+npx prisma db seed         # peuple les données de l'alphabet Hexahue
+```
+
+Le client Prisma est généré dans `generated/prisma` (pas l'emplacement par défaut
+dans `node_modules`), au format CommonJS.
+
+---
+
+## Développement
+
+```bash
+npm run start:dev          # serveur de dev avec watch
+npm run build               # build de production
+npm run lint                 # ESLint avec correction automatique
+npm run format              # Prettier
+```
+
+## Tests
+
+```bash
+npm run test                # tests unitaires Jest
+npm run test:watch          # mode watch Jest
+npm run test:cov            # rapport de couverture
+npm run test:e2e            # tests de bout en bout (nécessite une instance PostgreSQL accessible)
+```
+
+Lancer un seul fichier de test :
+
+```bash
+npx jest path/to/file.spec.ts
+```
+
+---
+
+## Organisation des modules
+
+```
+src/
+├── alphabet/        # Interface VisualAlphabet + implémentation HexahueAlphabet
+├── cipher/          # Pré-traitement (majuscules, translittération), construction de grille
+├── rotation/        # Moteur de rotation de blocs (encodage + inverse)
+├── key/             # KeyCodec, encode/décode/validation base36
+├── reading-order/   # Implémentations de ReadingOrderStrategy
+├── renderer/        # PngRenderer (Sharp), SvgRenderer
+├── validation/       # Validateur de paramètres par PGCD
+├── shared/           # Types et utilitaires de test partagés
+└── api/             # Contrôleurs NestJS + DTOs
+```
+
+Chaque domaine est un module NestJS autonome enregistré dans `app.module.ts`. Toutes
+les routes API sont préfixées par `/api` ; voir la
+[référence API](../docs/api/api_endpoints.fr.md) pour le détail des endpoints.
+
+---
+
+## Base de données
+
+Trois modèles Prisma : `Alphabet` → `Symbol` → `ColorCase`. Les données de seed pour
+l'alphabet Hexahue se trouvent dans `prisma/seed.ts`.
+
+```bash
+npx prisma studio           # parcourir la base de données
+```

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,98 +1,93 @@
-<p align="center">
-  <a href="http://nestjs.com/" target="blank"><img src="https://nestjs.com/img/logo-small.svg" width="120" alt="Nest Logo" /></a>
-</p>
+[🇫🇷 Version française](README.fr.md) | 🇬🇧 English version
 
-[circleci-image]: https://img.shields.io/circleci/build/github/nestjs/nest/master?token=abc123def456
-[circleci-url]: https://circleci.com/gh/nestjs/nest
+---
 
-  <p align="center">A progressive <a href="http://nodejs.org" target="_blank">Node.js</a> framework for building efficient and scalable server-side applications.</p>
-    <p align="center">
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/v/@nestjs/core.svg" alt="NPM Version" /></a>
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/l/@nestjs/core.svg" alt="Package License" /></a>
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/dm/@nestjs/common.svg" alt="NPM Downloads" /></a>
-<a href="https://circleci.com/gh/nestjs/nest" target="_blank"><img src="https://img.shields.io/circleci/build/github/nestjs/nest/master" alt="CircleCI" /></a>
-<a href="https://discord.gg/G7Qnnhy" target="_blank"><img src="https://img.shields.io/badge/discord-online-brightgreen.svg" alt="Discord"/></a>
-<a href="https://opencollective.com/nest#backer" target="_blank"><img src="https://opencollective.com/nest/backers/badge.svg" alt="Backers on Open Collective" /></a>
-<a href="https://opencollective.com/nest#sponsor" target="_blank"><img src="https://opencollective.com/nest/sponsors/badge.svg" alt="Sponsors on Open Collective" /></a>
-  <a href="https://paypal.me/kamilmysliwiec" target="_blank"><img src="https://img.shields.io/badge/Donate-PayPal-ff3f59.svg" alt="Donate us"/></a>
-    <a href="https://opencollective.com/nest#sponsor"  target="_blank"><img src="https://img.shields.io/badge/Support%20us-Open%20Collective-41B883.svg" alt="Support us"></a>
-  <a href="https://twitter.com/nestframework" target="_blank"><img src="https://img.shields.io/twitter/follow/nestframework.svg?style=social&label=Follow" alt="Follow us on Twitter"></a>
-</p>
-  <!--[![Backers on Open Collective](https://opencollective.com/nest/backers/badge.svg)](https://opencollective.com/nest#backer)
-  [![Sponsors on Open Collective](https://opencollective.com/nest/sponsors/badge.svg)](https://opencollective.com/nest#sponsor)-->
+# HexaRot backend
 
-## Description
+NestJS 11 API implementing the HexaRot visual cipher: message pre-processing, grid
+construction, block rotation, key encode/decode, and PNG/SVG rendering.
 
-[Nest](https://github.com/nestjs/nest) framework TypeScript starter repository.
+See the root [README](../README.md) for the project overview and the
+[backend architecture guide](../docs/architecture/backend_architecture.md) for a
+detailed module breakdown.
 
-## Project setup
+---
+
+## Requirements
+
+- Node.js and npm
+- PostgreSQL 16 (via the root `docker-compose.yml`, or a local instance)
+
+Running through Docker Compose from the repository root is the recommended setup; see
+the root README's Quick start section.
+
+---
+
+## Setup
 
 ```bash
-$ npm install
+npm install
+npx prisma migrate dev     # apply migrations and regenerate the Prisma client
+npx prisma db seed         # seed the Hexahue alphabet data
 ```
 
-## Compile and run the project
+The Prisma client is generated to `generated/prisma` (not the default `node_modules`
+location), in CommonJS format.
+
+---
+
+## Development
 
 ```bash
-# development
-$ npm run start
-
-# watch mode
-$ npm run start:dev
-
-# production mode
-$ npm run start:prod
+npm run start:dev          # dev server with watch
+npm run build               # production build
+npm run lint                 # ESLint with auto-fix
+npm run format              # Prettier
 ```
 
-## Run tests
+## Testing
 
 ```bash
-# unit tests
-$ npm run test
-
-# e2e tests
-$ npm run test:e2e
-
-# test coverage
-$ npm run test:cov
+npm run test                # Jest unit tests
+npm run test:watch          # Jest watch mode
+npm run test:cov            # coverage report
+npm run test:e2e            # end-to-end tests (requires a reachable PostgreSQL instance)
 ```
 
-## Deployment
-
-When you're ready to deploy your NestJS application to production, there are some key steps you can take to ensure it runs as efficiently as possible. Check out the [deployment documentation](https://docs.nestjs.com/deployment) for more information.
-
-If you are looking for a cloud-based platform to deploy your NestJS application, check out [Mau](https://mau.nestjs.com), our official platform for deploying NestJS applications on AWS. Mau makes deployment straightforward and fast, requiring just a few simple steps:
+Run a single test file:
 
 ```bash
-$ npm install -g @nestjs/mau
-$ mau deploy
+npx jest path/to/file.spec.ts
 ```
 
-With Mau, you can deploy your application in just a few clicks, allowing you to focus on building features rather than managing infrastructure.
+---
 
-## Resources
+## Module layout
 
-Check out a few resources that may come in handy when working with NestJS:
+```
+src/
+├── alphabet/        # VisualAlphabet interface + HexahueAlphabet implementation
+├── cipher/          # Pre-processing (uppercase, transliteration), grid construction
+├── rotation/        # Block rotation engine (encode + inverse)
+├── key/             # KeyCodec, base36 encode/decode/validate
+├── reading-order/   # ReadingOrderStrategy implementations
+├── renderer/        # PngRenderer (Sharp), SvgRenderer
+├── validation/       # GCD-based parameter validator
+├── shared/           # Shared types and testing utilities
+└── api/             # NestJS controllers + DTOs
+```
 
-- Visit the [NestJS Documentation](https://docs.nestjs.com) to learn more about the framework.
-- For questions and support, please visit our [Discord channel](https://discord.gg/G7Qnnhy).
-- To dive deeper and get more hands-on experience, check out our official video [courses](https://courses.nestjs.com/).
-- Deploy your application to AWS with the help of [NestJS Mau](https://mau.nestjs.com) in just a few clicks.
-- Visualize your application graph and interact with the NestJS application in real-time using [NestJS Devtools](https://devtools.nestjs.com).
-- Need help with your project (part-time to full-time)? Check out our official [enterprise support](https://enterprise.nestjs.com).
-- To stay in the loop and get updates, follow us on [X](https://x.com/nestframework) and [LinkedIn](https://linkedin.com/company/nestjs).
-- Looking for a job, or have a job to offer? Check out our official [Jobs board](https://jobs.nestjs.com).
+Each domain is a standalone NestJS module registered in `app.module.ts`. All API
+routes are prefixed with `/api`; see the [API reference](../docs/api/api_endpoints.md)
+for endpoint details.
 
-## Support
+---
 
-Nest is an MIT-licensed open source project. It can grow thanks to the sponsors and support by the amazing backers. If you'd like to join them, please [read more here](https://docs.nestjs.com/support).
+## Database
 
-## Stay in touch
+Three Prisma models: `Alphabet` → `Symbol` → `ColorCase`. Seed data for the Hexahue
+alphabet lives in `prisma/seed.ts`.
 
-- Author - [Kamil Myśliwiec](https://twitter.com/kammysliwiec)
-- Website - [https://nestjs.com](https://nestjs.com/)
-- Twitter - [@nestframework](https://twitter.com/nestframework)
-
-## License
-
-Nest is [MIT licensed](https://github.com/nestjs/nest/blob/master/LICENSE).
+```bash
+npx prisma studio           # browse the database
+```

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,45 @@
+[changelog]
+header = """
+# Changelog
+
+All notable changes to this project are documented in this file, generated
+automatically from Conventional Commits history.
+"""
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [Unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | striptags | trim | upper_first }}
+    {% for commit in commits %}
+        - {{ commit.message | upper_first }}\
+    {% endfor %}
+{% endfor %}\n
+"""
+trim = true
+footer = ""
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+commit_preprocessors = []
+commit_parsers = [
+  { message = "^feat", group = "Features" },
+  { message = "^fix", group = "Bug Fixes" },
+  { message = "^perf", group = "Performance" },
+  { message = "^refactor", group = "Refactoring" },
+  { message = "^doc", group = "Documentation" },
+  { message = "^test", group = "Testing" },
+  { message = "^chore\\(release\\)", skip = true },
+  { message = "^chore", group = "Miscellaneous" },
+  { message = "^style", group = "Styling" },
+  { message = "^ci", group = "CI/CD" },
+  { message = ".*", group = "Other" },
+]
+filter_commits = true
+tag_pattern = "v[0-9]*"
+topo_order = false
+sort_commits = "oldest"

--- a/docs/adr/0001-no-message-length-exposure.md
+++ b/docs/adr/0001-no-message-length-exposure.md
@@ -1,0 +1,67 @@
+# 1. No message-length exposure in the cryptogram
+
+## Status
+
+Accepted
+
+## Context
+
+An early design (FEAT-008) built a fixed-size binary header (`encodeHeader` /
+`decodeHeader` in `backend/src/cipher/header.ts`, a 2-byte `Uint16BE` storing the
+message's character count) that was originally planned to be rendered as a
+visual row above the grid by the PNG/SVG renderers (FEAT-009/FEAT-010), so a
+decoder could know exactly where the real message ends and random padding
+begins.
+
+That plan was reversed before the renderers shipped: both `PngRenderer` and
+`SvgRenderer` explicitly draw the grid "with no header of any kind." Exposing
+the message length, even indirectly through a visually distinct row, leaks
+information about the plaintext an attacker does not otherwise have, undermining
+the cipher's own anti-leakage goal. `header.ts` remains in the codebase but is
+never called by the encode or decode pipeline.
+
+This left an open question on the decode side: without a length header, how
+does decoding know where the real message ends and padding begins? FEAT-012's
+design spec considered two options:
+
+1. Stop decoding at the first symbol block that doesn't match any known
+   character (padding blocks are usually, but not always, unrecognizable).
+2. Decode every block unconditionally, real message and padding alike, marking
+   unrecognized blocks with a placeholder character, with no attempt to guess
+   where the real content ends.
+
+## Decision
+
+No message-length metadata is ever stored in the key or rendered into the
+cryptogram. Decoding always processes the full grid (option 2 above): the real
+message decodes to its exact original characters (always recognizable, by
+construction), followed by the padding region, most of which decodes to the
+`?` placeholder (`UNRECOGNIZED_PLACEHOLDER` in `decode-grid.ts`), occasionally to
+a real character by coincidence.
+
+No heuristic judgment call is made about where the message "really" ends; that
+determination is left entirely to whoever reads the response. This is a more
+honest design given that no signal is reliable enough to make that call
+correctly 100% of the time: guessing wrong would either silently truncate real
+content or silently append garbage, in a way the caller cannot detect or
+correct.
+
+## Consequences
+
+- The key remains genuinely message-independent and reusable across messages of
+  different lengths, since no length-specific data is embedded anywhere.
+- Decoded output routinely contains trailing `?` characters (or, rarely, other
+  characters by coincidence) that are not part of the original message; API
+  consumers and the frontend must treat this as expected behaviour, not an
+  error.
+- The round-trip acceptance criterion for encode/decode is not strict equality
+  on the full decoded string; it accounts for this trailing padding region.
+- Message-boundary detection (distinguishing real content from padding-derived
+  noise in decoded output) remains genuinely unsolved by design, not by
+  oversight. A future evolution could revisit this with a key-dependent
+  encoding or a different heuristic; the current design deliberately does not
+  attempt one.
+- `header.ts`'s `encodeHeader`/`decodeHeader` are dead code relative to the
+  actual pipeline. They are kept for now rather than removed, since no backlog
+  item has revisited whether to delete them or repurpose them outside the
+  visual cryptogram.

--- a/docs/adr/0002-key-off-query-string.md
+++ b/docs/adr/0002-key-off-query-string.md
@@ -1,0 +1,32 @@
+# 2. Move key parsing off a GET query string
+
+## Status
+
+Accepted
+
+## Context
+
+`GET /api/key/parse?key=...` sent the decryption key as a URL query string
+parameter. Query strings are written by default into server access logs,
+reverse-proxy logs (Traefik in local development), and browser history/cache: a
+durable, shared leak channel that a secret like a decryption key must not
+travel through. This was flagged as a P0 finding in a design/UX critique round
+(critique #7).
+
+## Decision
+
+`POST /api/key/parse` now takes the key in a JSON request body, matching the
+shape already used by `POST /api/key/generate`. The corresponding DTO was
+renamed from a query DTO to a request-body DTO
+(`key-parse-query.dto.ts` → `key-parse-request.dto.ts`) with the same
+validation rules.
+
+## Consequences
+
+- Both key endpoints (`generate` and `parse`) now share a consistent
+  POST-with-JSON-body shape, simplifying the frontend API client.
+- The frontend's `getJson()` helper, used only for the old GET-with-query-string
+  call, had no other caller and was removed rather than left dead.
+- Any external integration built against the old `GET /api/key/parse?key=...`
+  route needs updating; this is a breaking API change, not something addressed
+  with a v1/v2 endpoint split, given the project is pre-1.0.

--- a/docs/adr/0003-prisma-client-commonjs-output.md
+++ b/docs/adr/0003-prisma-client-commonjs-output.md
@@ -1,0 +1,38 @@
+# 3. Force CommonJS output for the generated Prisma client
+
+## Status
+
+Accepted
+
+## Context
+
+The `prisma-client` generator defaults to emitting `import.meta.url` in its
+generated client source. TypeScript compiles that source to CommonJS (there is
+no `"type": "module"` in `backend/package.json`), producing a file that mixes
+CommonJS `exports.foo =` assignments with an ESM-only construct. Node's module
+loader cannot resolve the resulting hybrid module, so any real process that
+imports `PrismaService` (`nest start`, `nest start --watch`, or the built
+`dist/src/main.js`) crashed on startup with `ReferenceError: exports is not
+defined`.
+
+This was invisible to the test suite, since `PrismaService` is mocked in every
+spec: no test actually booted the application against a real database. The
+issue was reproduced identically on two different Node versions, ruling out a
+Node-version-specific cause.
+
+## Decision
+
+Set `moduleFormat = "cjs"` on the Prisma client generator block in
+`backend/prisma/schema.prisma`, so the generator emits `require()`-based output
+with no `import.meta` usage, matching the module system used by the rest of the
+codebase.
+
+## Consequences
+
+- The application boots correctly against a real PostgreSQL instance in every
+  execution mode (dev watch, production build).
+- Since the failure mode was invisible to a mocked test suite, this is a
+  standing reminder that mocking `PrismaService` in unit tests does not
+  substitute for occasionally verifying the full boot path against a real
+  database (see [docs/operations.md](../operations.md) for how to run one
+  locally).

--- a/docs/adr/0004-traefik-reverse-proxy-local-dev.md
+++ b/docs/adr/0004-traefik-reverse-proxy-local-dev.md
@@ -1,0 +1,43 @@
+# 4. Route local development through Traefik instead of published ports
+
+## Status
+
+Accepted
+
+## Context
+
+Local development originally published the `backend` and `frontend` container
+ports directly on the host. Production, however, is expected to sit behind a
+reverse proxy. Developing against directly published ports meant the local
+topology didn't match production, and routing/host-header behaviour couldn't be
+exercised locally.
+
+## Decision
+
+Route local development through a local Traefik reverse proxy instead of
+publishing container ports:
+
+- `backend` and `frontend` join an external `traefik-public` Docker network (in
+  addition to the project's internal network) and carry Traefik routing labels
+  keyed on the host `hexarot.marvinlerouge.local`, with the backend routed under
+  the `/api` path prefix.
+- Container ports are no longer published directly; `postgres` binds to
+  `127.0.0.1` only, for local tooling access, and stays off the public network.
+- Vite's dev server is configured to allow the `hexarot.marvinlerouge.local`
+  host header, since Vite's default host-header check otherwise returns 403 for
+  any host other than `localhost`.
+
+Developers need a Traefik instance already running locally, attached to the
+`traefik-public` network, plus a `/etc/hosts` entry pointing
+`hexarot.marvinlerouge.local` to `127.0.0.1`; see
+[docs/operations.md](../operations.md) for the full setup.
+
+## Consequences
+
+- Local development now exercises the same host-based routing topology as
+  production, catching routing/proxy issues earlier.
+- Onboarding requires a one-time Traefik setup step; this is documented in
+  [CONTRIBUTING.md](../../CONTRIBUTING.md) and [docs/operations.md](../operations.md).
+- The backend's own `/api` prefix must not be stripped by Traefik's routing
+  rule, and Vite's `allowedHosts` configuration must stay in sync with the
+  chosen local hostname.

--- a/docs/adr/0005-stale-result-marked-not-destroyed.md
+++ b/docs/adr/0005-stale-result-marked-not-destroyed.md
@@ -1,0 +1,55 @@
+# 5. Mark stale results, don't destroy them
+
+## Status
+
+Accepted
+
+## Context
+
+Editing the message or any transform parameter after a successful encode
+originally left the old cryptogram and key fully visible, downloadable, and
+copyable on screen, with no indication that they no longer matched the current
+form state: a user could produce a key/image pair that would never decode
+together.
+
+An initial fix (REFACTOR-003) introduced result invalidation on parameter
+change, clearing the result back to an idle state. A follow-up design/UX
+critique round (critique #7) found this went too far in the other direction:
+all four stale-result surfaces (Encode, Decode, both Key views) disabled their
+Copy and Download actions the moment any form field changed, on top of copy
+that explicitly told the user "Neither is stored anywhere, copy or download
+them now." A user who edited a small typo after encoding lost the only way to
+save the artifact still on screen, even though the underlying result blob was
+still perfectly valid, just possibly out of sync with the current form.
+
+The same round also found that a failed follow-up request (e.g. a validation
+error after changing parameters) was destroying the previous successful result
+entirely, compounding the problem: a transient error left the user with
+nothing to fall back on.
+
+## Decision
+
+Staleness means "this result may not reflect your current form state," not
+"this result is invalid." Concretely:
+
+- A result becomes stale when a relevant form field changes after that result
+  was produced, but it is not cleared or destroyed.
+- Recovery actions (Copy, Download) remain enabled on a stale result; only
+  actions that would be misleading if taken on stale data are affected.
+- A failed request does not destroy the previous successful result; the UI
+  keeps showing it, flagged as no longer necessarily current, alongside the new
+  error.
+
+## Consequences
+
+- Every store tracking a submittable result (`stores/encode.ts`,
+  `stores/decode.ts`, `stores/key.ts`) needs to expose a derived staleness flag
+  and preserve the last successful result across both parameter changes and
+  failed requests, rather than clearing it eagerly.
+- The design system's visual language for a stale versus fresh result had to be
+  revisited more than once to keep contrast and legibility acceptable in the
+  stale state; see [docs/design-system.md](../design-system.md)'s "In flux"
+  section.
+- New views or stores following this pattern should preserve the last
+  successful result by default and add opt-in destruction only where a case
+  genuinely warrants it, rather than the reverse.

--- a/docs/api/api_endpoints.fr.md
+++ b/docs/api/api_endpoints.fr.md
@@ -1,0 +1,121 @@
+🇫🇷 Version française | [🇬🇧 English version](api_endpoints.md)
+
+---
+
+# Référence API
+
+Tous les endpoints sont préfixés par `/api`. Voir le
+[guide d'architecture backend](../architecture/backend_architecture.fr.md) pour
+la correspondance entre chaque endpoint et le pipeline sous-jacent.
+
+| Méthode | Route | Description |
+|---|---|---|
+| `POST` | `/encode` | Encoder un message → cryptogramme PNG + SVG |
+| `POST` | `/decode` | Décoder un cryptogramme → texte en clair |
+| `POST` | `/key/generate` | Générer une clé HR depuis des paramètres |
+| `POST` | `/key/parse` | Analyser une clé HR → paramètres structurés |
+
+## `POST /encode`
+
+```json
+POST /api/encode
+{
+  "message": "HELLO WORLD",
+  "pivotBlockSize": 5,
+  "rotationSequence": [0, 1, 2, 3],
+  "rotationDirection": "cw",
+  "readingOrder": "LR-TB",
+  "size": "medium"
+}
+```
+
+```json
+{
+  "png": "<PNG encodé en base64>",
+  "svg": "<chaîne SVG>",
+  "key": "HR1·57C3",
+  "warnings": [],
+  "unknownChars": []
+}
+```
+
+## `POST /decode`
+
+```json
+POST /api/decode
+{
+  "cryptogram": "<PNG encodé en base64 ou chaîne SVG brute>",
+  "format": "png",
+  "key": "HR1·57C3",
+  "size": "medium"
+}
+```
+
+```json
+{
+  "message": "HELLO WORLD"
+}
+```
+
+## `POST /key/generate`
+
+```json
+POST /api/key/generate
+{
+  "pivotBlockSize": 5,
+  "rotationSequence": [0, 1, 2, 3],
+  "rotationDirection": "cw",
+  "readingOrder": "LR-TB"
+}
+```
+
+```json
+{
+  "key": "HR1·57C3"
+}
+```
+
+## `POST /key/parse`
+
+```json
+POST /api/key/parse
+{
+  "key": "HR1·57C3"
+}
+```
+
+```json
+{
+  "pivotBlockSize": 5,
+  "rotationSequence": [0, 90, 180, 270],
+  "rotationDirection": "cw",
+  "readingOrder": "LR-TB"
+}
+```
+
+## Format de la clé
+
+Une clé HexaRot condense tous les paramètres de chiffrement dans une courte
+chaîne base36 :
+
+```
+HR1·57C3
+│  │ └─── paramètres encodés (base36)
+│  └───── séparateur
+└──────── préfixe de version
+```
+
+| Paramètre | Valeur exemple | Signification |
+|---|---|---|
+| Version | `1` | Version du système |
+| Taille de bloc pivot | `5` | Blocs de 5×5 cases |
+| Séquence de rotations | `[0°, 90°, 180°, 270°]` | Une des 24 permutations possibles |
+| Direction de rotation | `cw` | Sens horaire |
+| Ordre de lecture | `LR-TB` | Gauche-droite, haut-bas |
+
+La clé est indépendante du message : la même clé chiffre et déchiffre autant de
+messages que souhaité. Le cryptogramme ne contient aucune métadonnée de longueur
+par conception (voir l'[ADR 0001](../adr/0001-no-message-length-exposure.md)) :
+le décodage traite toujours la grille entière, en remplissant le padding
+éventuel par un caractère `?` plutôt que de stocker ou de laisser fuiter la
+longueur d'origine.

--- a/docs/api/api_endpoints.md
+++ b/docs/api/api_endpoints.md
@@ -1,0 +1,119 @@
+[🇫🇷 Version française](api_endpoints.fr.md) | 🇬🇧 English version
+
+---
+
+# API reference
+
+All endpoints are prefixed with `/api`. See the
+[backend architecture guide](../architecture/backend_architecture.md) for how
+each endpoint maps onto the underlying pipeline.
+
+| Method | Route | Description |
+|---|---|---|
+| `POST` | `/encode` | Encode a message → PNG + SVG cryptogram |
+| `POST` | `/decode` | Decode a cryptogram → plaintext |
+| `POST` | `/key/generate` | Generate an HR key from parameters |
+| `POST` | `/key/parse` | Parse an HR key → structured parameters |
+
+## `POST /encode`
+
+```json
+POST /api/encode
+{
+  "message": "HELLO WORLD",
+  "pivotBlockSize": 5,
+  "rotationSequence": [0, 1, 2, 3],
+  "rotationDirection": "cw",
+  "readingOrder": "LR-TB",
+  "size": "medium"
+}
+```
+
+```json
+{
+  "png": "<base64-encoded PNG>",
+  "svg": "<SVG string>",
+  "key": "HR1·57C3",
+  "warnings": [],
+  "unknownChars": []
+}
+```
+
+## `POST /decode`
+
+```json
+POST /api/decode
+{
+  "cryptogram": "<base64-encoded PNG or raw SVG string>",
+  "format": "png",
+  "key": "HR1·57C3",
+  "size": "medium"
+}
+```
+
+```json
+{
+  "message": "HELLO WORLD"
+}
+```
+
+## `POST /key/generate`
+
+```json
+POST /api/key/generate
+{
+  "pivotBlockSize": 5,
+  "rotationSequence": [0, 1, 2, 3],
+  "rotationDirection": "cw",
+  "readingOrder": "LR-TB"
+}
+```
+
+```json
+{
+  "key": "HR1·57C3"
+}
+```
+
+## `POST /key/parse`
+
+```json
+POST /api/key/parse
+{
+  "key": "HR1·57C3"
+}
+```
+
+```json
+{
+  "pivotBlockSize": 5,
+  "rotationSequence": [0, 90, 180, 270],
+  "rotationDirection": "cw",
+  "readingOrder": "LR-TB"
+}
+```
+
+## The key format
+
+A HexaRot key encodes all encryption parameters into a short base36 string:
+
+```
+HR1·57C3
+│  │ └─── encoded parameters (base36)
+│  └───── separator
+└──────── version prefix
+```
+
+| Parameter | Example value | Meaning |
+|---|---|---|
+| Version | `1` | System version |
+| Pivot block size | `5` | 5×5 cases per rotation block |
+| Rotation sequence | `[0°, 90°, 180°, 270°]` | One of 24 possible permutations |
+| Rotation direction | `cw` | Clockwise |
+| Reading order | `LR-TB` | Left-right, top-bottom |
+
+The key is message-independent: the same key encrypts and decrypts any number of
+messages. The cryptogram carries no message-length metadata by design (see
+[ADR 0001](../adr/0001-no-message-length-exposure.md)); decoding always processes
+the full grid, filling any padding with a `?` placeholder rather than storing or
+leaking the original length anywhere.

--- a/docs/architecture/backend_architecture.fr.md
+++ b/docs/architecture/backend_architecture.fr.md
@@ -1,0 +1,99 @@
+🇫🇷 Version française | [🇬🇧 English version](backend_architecture.md)
+
+---
+
+# Architecture backend
+
+Le backend est une application NestJS 11. Chaque domaine est un module autonome
+enregistré dans `app.module.ts`, communiquant via des interfaces typées plutôt
+qu'un état mutable partagé.
+
+## Carte des modules
+
+```
+backend/src/
+├── alphabet/         # Interface VisualAlphabet + implémentation HexahueAlphabet
+├── cipher/           # Pré-traitement, construction de grille, décodage
+├── rotation/         # Moteur de rotation de blocs (encodage + inverse)
+├── key/               # KeyCodec, encode/décode/validation base36
+├── reading-order/     # Implémentations de ReadingOrderStrategy + registre
+├── renderer/          # PngRenderer, SvgRenderer, palette, parseurs
+├── validation/         # Validateur de paramètres par PGCD
+├── shared/             # Types transverses et utilitaires de test
+└── api/               # Contrôleurs NestJS + DTOs
+```
+
+## Responsabilités des modules
+
+### `alphabet/`
+
+Définit l'abstraction `VisualAlphabet` permettant de brancher un autre alphabet
+visuel basé sur une grille, substitution caractère par caractère, à l'avenir.
+`HexahueAlphabetService` est la seule implémentation en V1, associant chaque
+caractère à un symbole de 2×3 cases de couleur.
+
+### `cipher/`
+
+La colle du pipeline central : `preprocess.ts` met le message en majuscules et le
+translittère (en signalant les caractères non gérés), `build-grid.ts` dispose le
+message dans une grille dimensionnée pour le bloc pivot, en la complétant par des
+cases de couleur aléatoires, et `decode-grid.ts` inverse ce processus. Le
+cryptogramme ne contient aucune métadonnée de longueur par conception ; voir
+l'[ADR 0001](../adr/0001-no-message-length-exposure.md).
+
+### `rotation/`
+
+`RotationEngine` et `rotate-block.ts` implémentent la rotation de blocs
+elle-même : parcours des blocs pivots selon l'ordre de lecture donné, et rotation
+des cases de couleur à l'intérieur de chacun. Le même moteur pilote à la fois
+l'encodage et son inverse (décodage).
+
+### `key/`
+
+`KeyCodec` encode et décode le format de clé base36 (préfixe `HR`) : version du
+système, taille de bloc pivot, séquence et direction de rotation, et ordre de
+lecture. Les clés sont indépendantes du message et réutilisables.
+
+### `reading-order/`
+
+`ReadingOrderStrategy` est l'interface implémentée par chacune des quatre
+directions (LR-TB, RL-TB, TB-LR, BT-LR, chacune avec un mode alterné optionnel).
+Le `reading-order.registry.ts` résout une stratégie à partir de son identifiant
+encodé dans la clé.
+
+### `renderer/`
+
+`PngRenderer` (basé sur Sharp) et `SvgRenderer` transforment une grille colorée
+en image de sortie ; `palette.ts` associe les couleurs logiques à des valeurs de
+pixel concrètes, et les parseurs PNG/SVG font l'inverse pour le décodage.
+
+### `validation/`
+
+Calcule le PGCD de la taille de bloc pivot et des dimensions du symbole de
+l'alphabet. Un résultat différent de 1 indique une combinaison de paramètres qui
+affaiblit le cryptogramme ; l'API le remonte comme un avertissement plutôt qu'un
+échec bloquant, un override explicite restant possible.
+
+### `api/`
+
+Contrôleurs et DTOs NestJS exposant le pipeline via HTTP. Voir
+[docs/api/api_endpoints.fr.md](../api/api_endpoints.fr.md) pour la référence des
+endpoints.
+
+## Flux de données
+
+**Encodage :** `preprocess` → `build-grid` → `RotationEngine` (sens direct) →
+`PngRenderer`/`SvgRenderer`, `KeyCodec` produisant la clé à partir des paramètres
+choisis.
+
+**Décodage :** `KeyCodec` analyse la clé pour retrouver les paramètres → le
+parseur PNG/SVG lit le cryptogramme en une grille → `RotationEngine` (sens
+inverse) → `decode-grid` reconstruit le message, en remplissant tout padding par
+un caractère `?`.
+
+## Base de données
+
+Trois modèles Prisma : `Alphabet` → `Symbol` → `ColorCase`. Le client Prisma est
+généré dans `backend/generated/prisma` au format CommonJS (voir
+l'[ADR 0003](../adr/0003-prisma-client-commonjs-output.md)). Les données de seed
+pour l'alphabet Hexahue se trouvent dans `backend/prisma/seed.ts`.

--- a/docs/architecture/backend_architecture.md
+++ b/docs/architecture/backend_architecture.md
@@ -1,0 +1,93 @@
+[🇫🇷 Version française](backend_architecture.fr.md) | 🇬🇧 English version
+
+---
+
+# Backend architecture
+
+The backend is a NestJS 11 application. Each domain is a standalone module
+registered in `app.module.ts`, communicating through typed interfaces rather than
+shared mutable state.
+
+## Module map
+
+```
+backend/src/
+├── alphabet/         # VisualAlphabet interface + HexahueAlphabet implementation
+├── cipher/           # Pre-processing, grid construction, decoding
+├── rotation/         # Block rotation engine (encode + inverse)
+├── key/               # KeyCodec, base36 encode/decode/validate
+├── reading-order/     # ReadingOrderStrategy implementations + registry
+├── renderer/          # PngRenderer, SvgRenderer, palette, parsers
+├── validation/         # GCD-based parameter validator
+├── shared/             # Cross-module types and testing utilities
+└── api/               # NestJS controllers + DTOs
+```
+
+## Module responsibilities
+
+### `alphabet/`
+
+Defines the `VisualAlphabet` abstraction so a different grid-based,
+character-by-character alphabet could be plugged in later. `HexahueAlphabetService`
+is the only implementation in V1, mapping characters to 2×3 colour-case symbols.
+
+### `cipher/`
+
+The core pipeline glue: `preprocess.ts` uppercases and transliterates the input
+message (reporting unhandled characters), `build-grid.ts` lays the message out
+into a grid sized to the pivot block, padding it with random colour cases, and
+`decode-grid.ts` reverses that process. The cryptogram carries no message-length
+metadata by design; see [ADR 0001](../adr/0001-no-message-length-exposure.md).
+
+### `rotation/`
+
+`RotationEngine` and `rotate-block.ts` implement the block rotation itself:
+traversing pivot blocks in the given reading order and rotating the colour cases
+inside each one. The same engine drives both encoding and its inverse (decoding).
+
+### `key/`
+
+`KeyCodec` encodes and decodes the base36 key format (`HR` prefix): system
+version, pivot block size, rotation sequence and direction, and reading order.
+Keys are message-independent and reusable.
+
+### `reading-order/`
+
+`ReadingOrderStrategy` is the interface each of the four directions (LR-TB,
+RL-TB, TB-LR, BT-LR, each with an optional alternate mode) implements. The
+`reading-order.registry.ts` resolves a strategy from its key-encoded identifier.
+
+### `renderer/`
+
+`PngRenderer` (built on Sharp) and `SvgRenderer` turn a coloured grid into an
+output image; `palette.ts` maps logical colours to concrete pixel values, and the
+PNG/SVG parsers do the reverse for decoding.
+
+### `validation/`
+
+Computes the GCD of the pivot block size and the alphabet's symbol dimensions.
+A non-1 result indicates a parameter combination that weakens the cryptogram;
+the API surfaces this as a warning rather than a hard failure, and an explicit
+override remains possible.
+
+### `api/`
+
+NestJS controllers and DTOs exposing the pipeline over HTTP. See
+[docs/api/api_endpoints.md](../api/api_endpoints.md) for the endpoint reference.
+
+## Data flow
+
+**Encode:** `preprocess` → `build-grid` → `RotationEngine` (forward) →
+`PngRenderer`/`SvgRenderer`, with `KeyCodec` producing the key from the chosen
+parameters.
+
+**Decode:** `KeyCodec` parses the key back into parameters → the PNG/SVG parser
+reads the cryptogram into a grid → `RotationEngine` (inverse) → `decode-grid`
+reconstructs the message, filling any padding with a `?` placeholder.
+
+## Database
+
+Three Prisma models: `Alphabet` → `Symbol` → `ColorCase`. The Prisma client is
+generated to `backend/generated/prisma` in CommonJS format (see
+[ADR 0003](../adr/0003-prisma-client-commonjs-output.md)). Seed data for the
+Hexahue alphabet lives in `backend/prisma/seed.ts`.

--- a/docs/architecture/frontend_architecture.fr.md
+++ b/docs/architecture/frontend_architecture.fr.md
@@ -1,0 +1,80 @@
+🇫🇷 Version française | [🇬🇧 English version](frontend_architecture.md)
+
+---
+
+# Architecture frontend
+
+Le frontend est une application monopage Vue 3 utilisant la Composition API,
+Pinia pour l'état, Vue Router pour la navigation, et vue-i18n pour les
+traductions.
+
+## Structure
+
+```
+frontend/src/
+├── views/            # EncodeView, DecodeView, KeyView
+├── components/        # Composants UI partagés, spécifiques aux vues
+├── layouts/            # AppLayout (structure de page)
+├── stores/             # Stores Pinia : encode, decode, key
+├── api/                # Client de l'API backend
+├── constants/           # Constantes partagées (ex. reading-orders.ts)
+├── locales/             # Fichiers de traduction vue-i18n (en.json)
+├── router/               # Configuration de Vue Router
+└── utils/                # Fonctions utilitaires partagées
+```
+
+## Routage
+
+Trois routes de premier niveau, définies dans `router/`, chacune associée à une
+vue :
+
+| Chemin | Vue | Rôle |
+|---|---|---|
+| `/` | redirige vers `/encode` | |
+| `/encode` | `EncodeView` | Texte → cryptogramme |
+| `/decode` | `DecodeView` | Cryptogramme → texte |
+| `/key` | `KeyView` | Générer ou analyser une clé |
+
+## Vues et composants
+
+Chaque vue compose un formulaire de paramètres, une action de soumission vers son
+store, et un panneau de résultat :
+
+- `EncodeView` utilise `EncodeParamsForm`, `RotationSequencePicker`, et
+  `EncodeResultPanel`.
+- `DecodeView` utilise `DecodeUploadArea` et `DecodeParamsForm`.
+- `KeyView` utilise `KeyGeneratorForm` et `KeyParserForm`.
+
+`LoadingSpinner` est partagé entre les trois pour les requêtes en cours.
+`AppLayout` fournit la structure de page commune (navigation, largeur du
+conteneur).
+
+## Gestion de l'état
+
+Chaque vue a un store Pinia dédié (`stores/encode.ts`, `stores/decode.ts`,
+`stores/key.ts`) qui conserve les paramètres du formulaire, le dernier résultat
+réussi, l'état de chargement, et l'état d'erreur. Les stores ont la
+responsabilité de suivre si un résultat affiché est périmé par rapport aux
+paramètres courants du formulaire, plutôt que de purement supprimer le résultat
+précédent ; voir l'[ADR 0005](../adr/0005-stale-result-marked-not-destroyed.md).
+
+## Client API
+
+`api/client.ts` centralise les appels vers les endpoints `/api` du backend (voir
+[docs/api/api_endpoints.fr.md](../api/api_endpoints.fr.md)). Les requêtes passent
+par le proxy du serveur de dev Vite vers le conteneur backend en développement
+local (voir [docs/operations.fr.md](../operations.fr.md)).
+
+## Internationalisation
+
+`vue-i18n` est en place, avec `locales/en.json` comme seule locale implémentée en
+V1. Une locale française est prévue pour la V2 ; voir [docs/roadmap.fr.md](../roadmap.fr.md).
+
+## Ajouter une vue
+
+1. Créer le composant de vue sous `views/`, et un store Pinia correspondant sous
+   `stores/` s'il nécessite son propre état.
+2. Enregistrer la route dans `router/`.
+3. Ajouter tout nouveau texte d'interface à `locales/en.json`.
+4. Ajouter un fichier de test `.spec.ts` à côté de la vue, en suivant la
+   structure de test des vues existantes.

--- a/docs/architecture/frontend_architecture.md
+++ b/docs/architecture/frontend_architecture.md
@@ -1,0 +1,76 @@
+[🇫🇷 Version française](frontend_architecture.fr.md) | 🇬🇧 English version
+
+---
+
+# Frontend architecture
+
+The frontend is a Vue 3 single-page application using the Composition API, Pinia
+for state, Vue Router for navigation, and vue-i18n for translations.
+
+## Structure
+
+```
+frontend/src/
+├── views/            # EncodeView, DecodeView, KeyView
+├── components/        # Shared, view-specific UI components
+├── layouts/            # AppLayout (page shell)
+├── stores/             # Pinia stores: encode, decode, key
+├── api/                # Backend API client
+├── constants/           # Shared constants (e.g. reading-orders.ts)
+├── locales/             # vue-i18n translation files (en.json)
+├── router/               # Vue Router configuration
+└── utils/                # Shared utility functions
+```
+
+## Routing
+
+Three top-level routes, defined in `router/`, each mapped to a view:
+
+| Path | View | Purpose |
+|---|---|---|
+| `/` | redirects to `/encode` | |
+| `/encode` | `EncodeView` | Text → cryptogram |
+| `/decode` | `DecodeView` | Cryptogram → text |
+| `/key` | `KeyView` | Generate or parse a key |
+
+## Views and components
+
+Each view composes a params form, a submit action against its store, and a
+result panel:
+
+- `EncodeView` uses `EncodeParamsForm`, `RotationSequencePicker`, and
+  `EncodeResultPanel`.
+- `DecodeView` uses `DecodeUploadArea` and `DecodeParamsForm`.
+- `KeyView` uses `KeyGeneratorForm` and `KeyParserForm`.
+
+`LoadingSpinner` is shared across all three for in-flight requests.
+`AppLayout` provides the common page shell (navigation, container width).
+
+## State management
+
+Each view has a dedicated Pinia store (`stores/encode.ts`, `stores/decode.ts`,
+`stores/key.ts`) holding form parameters, the last successful result, loading
+state, and error state. Stores are responsible for tracking whether a displayed
+result is stale relative to the current form parameters, rather than discarding
+the previous result outright; see [ADR 0005](../adr/0005-stale-result-marked-not-destroyed.md).
+
+## API client
+
+`api/client.ts` centralises calls to the backend's `/api` endpoints (see
+[docs/api/api_endpoints.md](../api/api_endpoints.md)). Requests are proxied
+through Vite's dev server to the backend container in local development (see
+[docs/operations.md](../operations.md)).
+
+## Internationalization
+
+`vue-i18n` is wired in, with `locales/en.json` as the only implemented locale in
+V1. A French locale is planned for V2; see [docs/roadmap.md](../roadmap.md).
+
+## Adding a view
+
+1. Create the view component under `views/`, and a matching Pinia store under
+   `stores/` if it needs its own state.
+2. Register the route in `router/`.
+3. Add any new UI text to `locales/en.json`.
+4. Add a `.spec.ts` test file alongside the view, following the existing views'
+   test structure.

--- a/docs/design-system.fr.md
+++ b/docs/design-system.fr.md
@@ -1,0 +1,85 @@
+🇫🇷 Version française | [🇬🇧 English version](design-system.md)
+
+---
+
+# Système de design
+
+Ce document décrit le langage visuel actuel du frontend HexaRot, tel qu'il existe
+dans `frontend/src/style.css`. C'est un instantané des tokens et motifs en usage,
+pas une spécification figée : plusieurs points sont encore en évolution (voir
+[En cours](#en-cours) ci-dessous).
+
+## Tokens de design
+
+Les tokens sont définis comme des custom properties CSS sur `:root`, avec un bloc
+de surcharge `prefers-color-scheme: dark` pour le mode sombre.
+
+### Couleur
+
+| Token | Clair | Sombre | Usage |
+|---|---|---|---|
+| `--text` | `#6b6375` | `#9ca3af` | Texte courant |
+| `--text-h` | `#08060d` | `#f3f4f6` | Titres, texte à fort contraste |
+| `--text-muted` | `#756d80` | `#8890a0` | Texte secondaire |
+| `--bg` | `#fff` | `#16171d` | Arrière-plan de page |
+| `--border` | `#8d8a92` | `#6f6d78` | Bordures par défaut |
+| `--code-bg` | `#f4f3ec` | `#1f2028` | Blocs de code, surfaces désactivées |
+| `--accent` | `#aa3bff` | `#c084fc` | Couleur d'action principale |
+| `--accent-bg` | `rgba(170, 59, 255, 0.1)` | `rgba(192, 132, 252, 0.15)` | Arrière-plans teintés accent |
+| `--accent-border` | `rgba(170, 59, 255, 0.5)` | `rgba(192, 132, 252, 0.5)` | Bordures teintées accent |
+| `--accent-contrast` | `#08060d` | `#08060d` | Texte sur fond `--accent` |
+| `--danger` | `#c0392b` | `#f87171` | Erreurs |
+| `--warning-border` | `#b45309` | `#fbbf24` | Bordures d'avertissement |
+| `--warning-bg` | `rgba(180, 83, 9, 0.08)` | `rgba(251, 191, 36, 0.12)` | Arrière-plans d'avertissement |
+| `--shadow` | ombre portée douce à deux couches | équivalent plus sombre | Surfaces surélevées |
+
+### Typographie
+
+- `--sans` / `--heading` : `system-ui, 'Segoe UI', Roboto, sans-serif`
+- `--mono` : `ui-monospace, Consolas, monospace` (utilisé pour `code`)
+- Taille de base : `18px` (`16px` sous `max-width: 1024px`), interligne `145%`,
+  espacement des lettres `0.18px`
+- Titres (`h1`, `h2`) : `font-weight: 500`, colorés avec `--text-h`
+
+### Mise en page
+
+- `#app` est plafonné à `max-width: 1126px`, centré, `min-height: 100svh`
+- `color-scheme: light dark` laisse le navigateur adapter les contrôles de
+  formulaire natifs
+
+### Éléments interactifs
+
+- Focus : `:focus-visible` reçoit un contour plein 2px `--accent` avec un
+  décalage de 2px
+- Boutons : `min-height: 44px` (dimensionné pour le tactile), `border-radius: 4px`
+- `.btn-primary` : fond plein `--accent`, texte `--accent-contrast`, s'assombrit
+  au survol/clic via `filter: brightness()`
+- `.btn-secondary` : contour `--border`, fond transparent, bascule vers
+  `--accent-border` / `--accent-bg` au survol
+- Boutons désactivés : fond `--code-bg`, couleur `--text`, contour `--border`,
+  `cursor: not-allowed`
+- Champs texte, `select`, `textarea` : contour 1px `--border`, rayon `4px`,
+  padding `8px 10px`
+
+## En cours
+
+Les points ci-dessous sont connus comme incomplets ou en évolution active ; ce
+document décrit l'état actuel, pas un contrat figé.
+
+- **Pas de fichier de tokens centralisé pour des consommateurs externes.** Les
+  tokens vivent uniquement dans `frontend/src/style.css` ; il n'y a pas de
+  `tokens.css` séparé ni d'export depuis un outil de design à synchroniser.
+- **Le langage visuel de l'état "périmé" est encore en cours de stabilisation.**
+  Les vues Encode/Decode/Key doivent distinguer visuellement un résultat
+  "périmé" (paramètres modifiés depuis la génération du cryptogramme) d'un
+  résultat frais, sans détruire le résultat précédent ni désactiver les actions
+  de récupération comme Copier/Télécharger. Les niveaux de contraste des
+  contrôles désactivés dans cet état ont été révisés plusieurs fois (voir les
+  rapports `.impeccable/critique/`).
+- **La gestion des thèmes clair/sombre repose uniquement sur
+  `prefers-color-scheme`.** Il n'y a pas de bascule manuelle de thème ; c'est une
+  simplification délibérée pour l'instant, pas une décision définitive.
+- **Le dimensionnement du panneau de résultat a des questions ouvertes.** La
+  sortie du cryptogramme a été signalée comme visuellement petite par rapport à
+  la mise en page environnante sur grand écran ; aucun ratio ou taille minimale
+  cible n'a encore été fixé.

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,0 +1,81 @@
+[🇫🇷 Version française](design-system.fr.md) | 🇬🇧 English version
+
+---
+
+# Design system
+
+This document describes the current visual language of the HexaRot frontend, as
+it exists in `frontend/src/style.css`. It is a snapshot of the design tokens and
+patterns in use, not a finalized spec: several items are still in flux (see
+[In flux](#in-flux) below).
+
+## Design tokens
+
+Tokens are defined as CSS custom properties on `:root`, with a
+`prefers-color-scheme: dark` override block for dark mode.
+
+### Colour
+
+| Token | Light | Dark | Usage |
+|---|---|---|---|
+| `--text` | `#6b6375` | `#9ca3af` | Body text |
+| `--text-h` | `#08060d` | `#f3f4f6` | Headings, high-contrast text |
+| `--text-muted` | `#756d80` | `#8890a0` | Secondary text |
+| `--bg` | `#fff` | `#16171d` | Page background |
+| `--border` | `#8d8a92` | `#6f6d78` | Default borders |
+| `--code-bg` | `#f4f3ec` | `#1f2028` | Code blocks, disabled surfaces |
+| `--accent` | `#aa3bff` | `#c084fc` | Primary action colour |
+| `--accent-bg` | `rgba(170, 59, 255, 0.1)` | `rgba(192, 132, 252, 0.15)` | Accent-tinted backgrounds |
+| `--accent-border` | `rgba(170, 59, 255, 0.5)` | `rgba(192, 132, 252, 0.5)` | Accent-tinted borders |
+| `--accent-contrast` | `#08060d` | `#08060d` | Text on top of `--accent` |
+| `--danger` | `#c0392b` | `#f87171` | Errors |
+| `--warning-border` | `#b45309` | `#fbbf24` | Warning borders |
+| `--warning-bg` | `rgba(180, 83, 9, 0.08)` | `rgba(251, 191, 36, 0.12)` | Warning backgrounds |
+| `--shadow` | soft dual-layer drop shadow | darker equivalent | Elevated surfaces |
+
+### Typography
+
+- `--sans` / `--heading`: `system-ui, 'Segoe UI', Roboto, sans-serif`
+- `--mono`: `ui-monospace, Consolas, monospace` (used for `code`)
+- Base size: `18px` (`16px` under `max-width: 1024px`), `145%` line height,
+  `0.18px` letter-spacing
+- Headings (`h1`, `h2`): `font-weight: 500`, coloured with `--text-h`
+
+### Layout
+
+- `#app` is capped at `max-width: 1126px`, centred, `min-height: 100svh`
+- `color-scheme: light dark` lets the browser adapt native form controls
+
+### Interactive elements
+
+- Focus: `:focus-visible` gets a 2px solid `--accent` outline with a 2px offset
+- Buttons: `min-height: 44px` (touch-target sized), `border-radius: 4px`
+- `.btn-primary`: solid `--accent` background, `--accent-contrast` text, darkens
+  on hover/active via `filter: brightness()`
+- `.btn-secondary`: outlined with `--border`, transparent background, switches to
+  `--accent-border` / `--accent-bg` on hover
+- Disabled buttons: `--code-bg` background, `--text` colour, `--border` outline,
+  `cursor: not-allowed`
+- Text inputs, `select`, `textarea`: 1px `--border` outline, `4px` radius,
+  `8px 10px` padding
+
+## In flux
+
+The items below are known to be incomplete or actively evolving; treat this
+document as descriptive of the current state, not as a fixed contract.
+
+- **No centralized design-token file for consumers.** Tokens live only in
+  `frontend/src/style.css`; there is no separate `tokens.css` or design-tool
+  export to keep in sync.
+- **Stale-result visual language is still settling.** Encode/Decode/Key views
+  need to visually distinguish a "stale" result (parameters changed since the
+  cryptogram was generated) from a fresh one, without destroying the previous
+  result or disabling recovery actions like Copy/Download. Contrast levels for
+  disabled controls in that state have been revised more than once (see
+  `.impeccable/critique/` reports).
+- **Dark/light theme handling relies solely on `prefers-color-scheme`.** There is
+  no manual theme toggle; this is a deliberate simplification for now, not a
+  final decision.
+- **Result panel sizing has open questions.** The cryptogram output has been
+  flagged as visually small relative to the surrounding layout on wide screens;
+  no target aspect ratio or minimum size has been fixed yet.

--- a/docs/guides/backend_developer_guide.fr.md
+++ b/docs/guides/backend_developer_guide.fr.md
@@ -1,0 +1,71 @@
+🇫🇷 Version française | [🇬🇧 English version](backend_developer_guide.md)
+
+---
+
+# Guide développeur backend
+
+Ce guide couvre les conventions de développement backend au quotidien. Voir le
+[guide d'architecture backend](../architecture/backend_architecture.fr.md) pour
+la carte des modules et le flux de données, et [docs/tests/](../tests/index.md)
+pour le contrat de test par module à respecter pour toute modification.
+
+## Démarrage
+
+```bash
+cd backend
+npm install
+npx prisma migrate dev
+npx prisma db seed
+npm run start:dev
+```
+
+Voir [docs/operations.fr.md](../operations.fr.md) pour l'alternative Docker
+Compose.
+
+## Ajouter une stratégie d'ordre de lecture
+
+1. Implémenter `ReadingOrderStrategy` (voir `reading-order/reading-order-strategy.interface.ts`)
+   pour le nouvel ordre de parcours.
+2. L'enregistrer dans `reading-order.registry.ts` sous un identifiant stable,
+   puisque cet identifiant est ce qui est encodé dans la clé.
+3. Ajouter des tests unitaires couvrant le parcours lui-même et son interaction
+   avec le placement du padding, en suivant [docs/tests/reading-order.md](../tests/reading-order.md).
+4. Mettre à jour `KeyCodec` si la nouvelle stratégie nécessite une nouvelle plage
+   d'identifiants dans la charge utile de la clé.
+
+## Ajouter un renderer
+
+1. Implémenter un nouveau renderer aux côtés de `PngRenderer`/`SvgRenderer` dans
+   `renderer/`, consommant la même entrée de grille colorée.
+2. Ajouter le parseur correspondant (grille ← format de sortie) si le nouveau
+   format doit être décodable.
+3. Ajouter des tests d'intégration exerçant l'aller-retour complet
+   encodage-puis-décodage via le nouveau format, en suivant le modèle des suites
+   de tests PNG/SVG existantes.
+
+## Conventions de test
+
+```bash
+npm run test              # tests unitaires Jest
+npm run test:cov          # rapport de couverture
+npm run test:e2e          # tests de bout en bout (nécessite une instance PostgreSQL accessible)
+npx jest path/to/file.spec.ts   # un seul fichier de test
+```
+
+- `docs/tests/<module>.md` est un contrat de test spec-first par module : le lire
+  avant d'écrire ou de relire des tests pour ce module, il peut décrire un
+  comportement non documenté ailleurs.
+- `PrismaService` se connecte de façon eager à l'initialisation du module, donc
+  les tests e2e nécessitent une vraie instance PostgreSQL authentifiée, même pour
+  des endpoints qui ne touchent pas la base de données.
+- Des seuils de couverture sont appliqués, avec une barre plus haute sur le
+  cœur algorithmique (cipher, rotation, key) qu'au niveau global.
+
+## Conventions
+
+- Les fonctions sont nommées avec un verbe en premier : `rotateBlock`,
+  `generateKey`, `parseKey`.
+- Chaque tâche d'implémentation devrait correspondre à une entrée dans
+  `BACKLOG.md` (gitignored, local au mainteneur).
+- Les messages de commit suivent Conventional Commits avec une liste de
+  fichiers obligatoire ; voir le `CLAUDE.md` du dépôt.

--- a/docs/guides/backend_developer_guide.md
+++ b/docs/guides/backend_developer_guide.md
@@ -1,0 +1,68 @@
+[🇫🇷 Version française](backend_developer_guide.fr.md) | 🇬🇧 English version
+
+---
+
+# Backend developer guide
+
+This guide covers day-to-day backend development conventions. See the
+[backend architecture guide](../architecture/backend_architecture.md) for the
+module map and data flow, and [docs/tests/](../tests/index.md) for the per-module
+test contract that must be honoured for any change.
+
+## Getting started
+
+```bash
+cd backend
+npm install
+npx prisma migrate dev
+npx prisma db seed
+npm run start:dev
+```
+
+See [docs/operations.md](../operations.md) for the Docker Compose alternative.
+
+## Adding a reading-order strategy
+
+1. Implement `ReadingOrderStrategy` (see `reading-order/reading-order-strategy.interface.ts`)
+   for the new traversal order.
+2. Register it in `reading-order.registry.ts` under a stable identifier, since
+   that identifier is what gets encoded into the key.
+3. Add unit tests covering the traversal itself and its interaction with padding
+   placement, following [docs/tests/reading-order.md](../tests/reading-order.md).
+4. Update `KeyCodec` if the new strategy needs a new identifier range in the key
+   payload.
+
+## Adding a renderer
+
+1. Implement a new renderer alongside `PngRenderer`/`SvgRenderer` in `renderer/`,
+   consuming the same coloured-grid input.
+2. Add the matching parser (grid ← output format) if the new format needs to be
+   decodable.
+3. Add integration tests exercising the full encode-then-decode round trip
+   through the new format, mirroring the existing PNG/SVG test suites.
+
+## Testing conventions
+
+```bash
+npm run test              # Jest unit tests
+npm run test:cov          # coverage report
+npm run test:e2e          # end-to-end tests (needs a reachable PostgreSQL instance)
+npx jest path/to/file.spec.ts   # single test file
+```
+
+- `docs/tests/<module>.md` is a spec-first test contract per module: read it
+  before writing or reviewing tests for that module, it can describe behaviour
+  not otherwise documented.
+- `PrismaService` connects eagerly on module init, so e2e tests need a real,
+  authenticated PostgreSQL instance even for endpoints that don't touch the
+  database.
+- Coverage thresholds are enforced, with a higher bar on the algorithmic core
+  (cipher, rotation, key) than globally.
+
+## Conventions
+
+- Functions are named verb-first: `rotateBlock`, `generateKey`, `parseKey`.
+- Every implementation task should map to a `BACKLOG.md` entry (gitignored,
+  local to the maintainer).
+- Commit messages follow Conventional Commits with a mandatory file list; see
+  the repository's `CLAUDE.md`.

--- a/docs/guides/frontend_developer_guide.fr.md
+++ b/docs/guides/frontend_developer_guide.fr.md
@@ -1,0 +1,69 @@
+🇫🇷 Version française | [🇬🇧 English version](frontend_developer_guide.md)
+
+---
+
+# Guide développeur frontend
+
+Ce guide couvre les conventions de développement frontend au quotidien. Voir le
+[guide d'architecture frontend](../architecture/frontend_architecture.fr.md)
+pour la vue d'ensemble de la structure et [docs/design-system.fr.md](../design-system.fr.md)
+pour le langage visuel actuel.
+
+## Démarrage
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+Voir [docs/operations.fr.md](../operations.fr.md) pour l'alternative Docker
+Compose, qui passe par Traefik plutôt que directement par le serveur de dev
+Vite.
+
+## Ajouter une vue
+
+1. Créer le composant de vue sous `views/`.
+2. Ajouter un store Pinia sous `stores/` si la vue nécessite son propre état
+   (paramètres du formulaire, résultat, chargement, erreur, péremption).
+3. Enregistrer la route dans `router/`.
+4. Ajouter tout nouveau texte d'interface à `locales/en.json` ; ne pas coder en
+   dur de chaînes destinées à l'utilisateur.
+5. Ajouter un fichier de test `.spec.ts` à côté de la vue.
+
+## Stores et péremption
+
+Le store de chaque vue suit si le résultat actuellement affiché est périmé par
+rapport aux paramètres courants du formulaire, plutôt que de vider le résultat
+dès qu'un paramètre change. Voir l'[ADR 0005](../adr/0005-stale-result-marked-not-destroyed.md)
+pour la justification. Lors de l'ajout d'un nouveau store, suivre le même
+principe : conserver le dernier résultat réussi à travers les changements de
+paramètres et les requêtes échouées, et exposer un indicateur "périmé" dérivé
+que la vue peut utiliser pour ajuster son UI (par exemple désactiver des
+raccourcis de re-soumission, sans désactiver les actions de récupération comme
+copier/télécharger).
+
+## Conventions de style
+
+- Utiliser les custom properties CSS définies dans `style.css` (voir
+  [docs/design-system.fr.md](../design-system.fr.md)) plutôt que de coder en dur
+  des couleurs ou des espacements.
+- Respecter le contour `:focus-visible` et la taille minimale de 44px pour les
+  cibles tactiles des éléments interactifs.
+
+## Conventions de test
+
+```bash
+npm run test              # Vitest
+npm run test:cov          # rapport de couverture
+```
+
+Faire correspondre la structure des tests à celle du code source ; le fichier
+de spec d'une vue se trouve à côté de la vue.
+
+## Internationalisation
+
+Toutes les chaînes destinées à l'utilisateur passent par `vue-i18n` et
+`locales/en.json`, même si seul l'anglais est implémenté en V1, afin que la
+locale française prévue (voir [docs/roadmap.fr.md](../roadmap.fr.md)) puisse
+être ajoutée sans passe de reprise.

--- a/docs/guides/frontend_developer_guide.md
+++ b/docs/guides/frontend_developer_guide.md
@@ -1,0 +1,65 @@
+[🇫🇷 Version française](frontend_developer_guide.fr.md) | 🇬🇧 English version
+
+---
+
+# Frontend developer guide
+
+This guide covers day-to-day frontend development conventions. See the
+[frontend architecture guide](../architecture/frontend_architecture.md) for the
+structure overview and [docs/design-system.md](../design-system.md) for the
+current visual language.
+
+## Getting started
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+See [docs/operations.md](../operations.md) for the Docker Compose alternative,
+which routes through Traefik instead of Vite's own dev server directly.
+
+## Adding a view
+
+1. Create the view component under `views/`.
+2. Add a Pinia store under `stores/` if the view needs its own state (form
+   parameters, result, loading, error, staleness).
+3. Register the route in `router/`.
+4. Add any new UI text to `locales/en.json`; do not hardcode user-facing strings.
+5. Add a `.spec.ts` test file alongside the view.
+
+## Stores and staleness
+
+Each view's store tracks whether the currently displayed result is stale
+relative to the form's current parameters, rather than clearing the result
+outright when a parameter changes. See
+[ADR 0005](../adr/0005-stale-result-marked-not-destroyed.md) for the rationale.
+When adding a new store, follow the same pattern: preserve the last successful
+result across parameter changes and failed requests, and expose a derived
+"stale" flag the view can use to adjust its UI (e.g. disabling re-submission
+shortcuts, not disabling recovery actions like copy/download).
+
+## Styling conventions
+
+- Use the CSS custom properties defined in `style.css` (see
+  [docs/design-system.md](../design-system.md)) rather than hardcoding colours
+  or spacing.
+- Respect the `:focus-visible` outline and the 44px minimum touch target for
+  interactive elements.
+
+## Testing conventions
+
+```bash
+npm run test              # Vitest
+npm run test:cov          # coverage report
+```
+
+Mirror the test structure to the source structure; a view's spec file sits
+alongside the view.
+
+## Internationalization
+
+All user-facing strings go through `vue-i18n` and `locales/en.json`, even though
+only English is implemented in V1, so the planned French locale (see
+[docs/roadmap.md](../roadmap.md)) can be added without a retrofit pass.

--- a/docs/guides/user_guide.fr.md
+++ b/docs/guides/user_guide.fr.md
@@ -1,0 +1,60 @@
+🇫🇷 Version française | [🇬🇧 English version](user_guide.md)
+
+---
+
+# Guide utilisateur
+
+Ce guide couvre l'usage de l'interface web HexaRot : Encode, Decode et Key.
+
+## Encode : texte → cryptogramme
+
+1. Aller sur la vue **Encode**.
+2. Saisir ou coller le message à encoder. Il sera mis en majuscules, et les
+   caractères accentués translittérés (é→E, à→A, ç→C…) automatiquement. Tout
+   caractère que HexaRot ne peut pas représenter est signalé afin d'ajuster le
+   message.
+3. Choisir les paramètres de chiffrement :
+   - **Taille de bloc pivot** : la taille (en cases) des blocs carrés selon
+     lesquels la grille est tournée.
+   - **Séquence et direction de rotation** : quelle rotation s'applique à chaque
+     bloc, dans quel ordre, sens horaire ou antihoraire.
+   - **Ordre de lecture** : la direction de parcours des blocs (gauche-droite/
+     haut-bas, et variantes), avec un mode alterné optionnel.
+   - **Taille de sortie** : small, medium ou large.
+4. Si une combinaison de paramètres affaiblit le cryptogramme (détecté via une
+   vérification par PGCD par rapport aux dimensions du symbole de l'alphabet),
+   un avertissement s'affiche ; il est possible d'ajuster les paramètres ou de
+   continuer malgré tout.
+5. Soumettre pour obtenir le cryptogramme (PNG et SVG) et la clé générée.
+   **Sauvegarder la clé** : elle n'est stockée nulle part par HexaRot, et c'est
+   le seul moyen de décoder le message par la suite.
+6. Copier ou télécharger le cryptogramme et la clé.
+
+## Decode : cryptogramme + clé → texte
+
+1. Aller sur la vue **Decode**.
+2. Charger le fichier cryptogramme (PNG ou SVG) à décoder.
+3. Saisir la clé utilisée pour l'encoder, ainsi que la taille de sortie utilisée
+   lors de l'encodage.
+4. Soumettre pour révéler le message décodé.
+
+Le décodage traite toujours la grille entière ; si le message original était
+plus court que la capacité de la grille, les caractères de padding se décodent
+en `?` et peuvent être ignorés sans risque, ils ne portent aucune information
+sur la longueur du message original.
+
+## Key : générer ou analyser
+
+- **Générer** : choisir des paramètres de chiffrement sans encoder de message,
+  pour obtenir une clé réutilisable à l'avance (utile pour partager une clé
+  avant l'envoi d'un message encodé).
+- **Analyser** : coller une clé existante pour voir les paramètres qu'elle
+  encode (taille de bloc pivot, séquence et direction de rotation, ordre de
+  lecture).
+
+## Résultats périmés
+
+Si un paramètre est modifié après l'obtention d'un résultat, le résultat
+précédent est marqué comme périmé plutôt que supprimé, ce qui permet de le
+copier ou le télécharger malgré tout avant de décider de soumettre à nouveau
+avec les nouveaux paramètres.

--- a/docs/guides/user_guide.md
+++ b/docs/guides/user_guide.md
@@ -1,0 +1,55 @@
+[🇫🇷 Version française](user_guide.fr.md) | 🇬🇧 English version
+
+---
+
+# User guide
+
+This guide covers using the HexaRot web interface: Encode, Decode, and Key.
+
+## Encode: text → cryptogram
+
+1. Go to the **Encode** view.
+2. Type or paste the message to encode. It will be uppercased, and accented
+   characters transliterated (é→E, à→A, ç→C…) automatically. Any character
+   HexaRot cannot represent is reported so you can adjust the message.
+3. Choose the encryption parameters:
+   - **Pivot block size**: the size (in cases) of the square blocks the grid is
+     rotated by.
+   - **Rotation sequence and direction**: which rotation applies to each block,
+     in which order, clockwise or counter-clockwise.
+   - **Reading order**: the direction blocks are traversed (left-right/top-bottom,
+     and variants), with an optional alternating mode.
+   - **Output size**: small, medium, or large.
+4. If a parameter combination weakens the cryptogram (detected via a GCD check
+   against the alphabet's symbol dimensions), a warning is shown; you can adjust
+   the parameters or proceed anyway.
+5. Submit to get the cryptogram (PNG and SVG) and the generated key. **Save the
+   key**: it is not stored anywhere by HexaRot, and it is the only way to decode
+   the message later.
+6. Copy or download the cryptogram and the key.
+
+## Decode: cryptogram + key → text
+
+1. Go to the **Decode** view.
+2. Upload the cryptogram file (PNG or SVG) you want to decode.
+3. Enter the key that was used to encode it, and the output size used at encode
+   time.
+4. Submit to reveal the decoded message.
+
+Decoding always processes the full grid; if the original message was shorter
+than the grid capacity, the padding characters decode as `?` and can be safely
+ignored, they carry no information about the original message length.
+
+## Key: generate or parse
+
+- **Generate**: pick encryption parameters without encoding a message, to get a
+  reusable key upfront (useful for sharing a key ahead of sending an encoded
+  message).
+- **Parse**: paste an existing key to see the parameters it encodes (pivot block
+  size, rotation sequence and direction, reading order).
+
+## Stale results
+
+If you change a parameter after getting a result, the previous result is marked
+as stale rather than discarded, so you can still copy or download it while you
+decide whether to re-submit with the new parameters.

--- a/docs/operations.fr.md
+++ b/docs/operations.fr.md
@@ -1,0 +1,68 @@
+🇫🇷 Version française | [🇬🇧 English version](operations.md)
+
+---
+
+# Opérations
+
+## Développement local
+
+Le développement local est entièrement conteneurisé avec Docker Compose, et passe
+par un reverse proxy Traefik local pour refléter la production plutôt que de
+publier les ports des conteneurs directement. Voir [CONTRIBUTING.fr.md](../CONTRIBUTING.fr.md)
+pour la configuration initiale de Traefik et de `/etc/hosts`.
+
+```bash
+cp .env.example .env
+docker compose up
+```
+
+- Frontend : `http://hexarot.marvinlerouge.local`
+- API backend : `http://hexarot.marvinlerouge.local/api/...`
+- PostgreSQL : accessible directement sur `127.0.0.1:5433` pour l'outillage local
+  (Prisma Studio, `psql`) ; ce port n'est pas routé via Traefik.
+
+## Services
+
+| Service | Image / build | Notes |
+|---|---|---|
+| `postgres` | `postgres:16-alpine` | Conditionné par healthcheck ; `backend` attend qu'il soit sain avant de démarrer |
+| `backend` | `backend/Dockerfile.dev` | Serveur de dev NestJS avec le code source monté en bind ; routé via Traefik sous `/api` |
+| `frontend` | `frontend/Dockerfile.dev` | Serveur de dev Vite avec le code source monté en bind ; routé via Traefik à la racine de l'hôte |
+
+`backend` et `frontend` rejoignent tous deux le réseau Docker externe
+`traefik-public` (créé par l'instance Traefik locale), en plus du réseau interne
+du projet.
+
+## Variables d'environnement
+
+Définies dans `.env` (à copier depuis `.env.example`, non commité) :
+
+| Variable | Utilisée par | Rôle |
+|---|---|---|
+| `POSTGRES_USER` | `postgres`, `backend` | Utilisateur de la base de données |
+| `POSTGRES_PASSWORD` | `postgres`, `backend` | Mot de passe de la base de données |
+| `POSTGRES_DB` | `postgres`, `backend` | Nom de la base de données |
+| `PORT` | `backend` | Port sur lequel le serveur NestJS écoute dans le conteneur (`3000`) |
+
+`DATABASE_URL` pour le backend et `VITE_PROXY_TARGET` pour le frontend sont
+dérivées automatiquement dans `docker-compose.yml` ; elles n'ont pas besoin
+d'être définies manuellement.
+
+## CI/CD
+
+GitHub Actions s'exécute sur les pull requests vers `main` (`.github/workflows/ci.yml`) :
+
+- **Job backend :** installation des dépendances, `prisma migrate deploy`, seed de
+  la base, lint, exécution de la suite Jest (contre un service PostgreSQL 16).
+- **Job frontend :** installation des dépendances, lint, exécution de la suite
+  Vitest (en parallèle du job backend).
+
+`sync-backlog.yml` synchronise `BACKLOG.md` vers les Issues GitHub et un tableau
+Kanban à chaque push sur `main`. Il nécessite un secret de repository
+`HEXAROT_PROJECT_TOKEN` (Personal Access Token classic avec les scopes `repo` et
+`project`) ; voir [CONTRIBUTING.fr.md](../CONTRIBUTING.fr.md) pour la configuration.
+
+`changelog.yml` régénère `CHANGELOG.md` à chaque push sur `main` et ouvre une pull
+request plutôt que de pousser directement. Il nécessite l'activation de « Allow
+GitHub Actions to create and approve pull requests » dans les paramètres Actions
+du repository.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,68 @@
+[🇫🇷 Version française](operations.fr.md) | 🇬🇧 English version
+
+---
+
+# Operations
+
+## Local development
+
+Local development is fully containerised with Docker Compose, and routed through
+a local Traefik reverse proxy to mirror production instead of publishing
+container ports directly. See [CONTRIBUTING.md](../CONTRIBUTING.md) for the
+one-time Traefik and `/etc/hosts` setup.
+
+```bash
+cp .env.example .env
+docker compose up
+```
+
+- Frontend: `http://hexarot.marvinlerouge.local`
+- Backend API: `http://hexarot.marvinlerouge.local/api/...`
+- PostgreSQL: reachable directly at `127.0.0.1:5433` for local tooling (Prisma
+  Studio, `psql`); this port is not routed through Traefik.
+
+## Services
+
+| Service | Image / build | Notes |
+|---|---|---|
+| `postgres` | `postgres:16-alpine` | Healthcheck-gated; `backend` waits for it to be healthy before starting |
+| `backend` | `backend/Dockerfile.dev` | NestJS dev server with a bind-mounted source tree; routed through Traefik under `/api` |
+| `frontend` | `frontend/Dockerfile.dev` | Vite dev server with a bind-mounted source tree; routed through Traefik at the host root |
+
+Both `backend` and `frontend` join the external `traefik-public` Docker network
+(created by the local Traefik instance) in addition to the project's internal
+network.
+
+## Environment variables
+
+Defined in `.env` (copy from `.env.example`, not committed):
+
+| Variable | Used by | Purpose |
+|---|---|---|
+| `POSTGRES_USER` | `postgres`, `backend` | Database user |
+| `POSTGRES_PASSWORD` | `postgres`, `backend` | Database password |
+| `POSTGRES_DB` | `postgres`, `backend` | Database name |
+| `PORT` | `backend` | Port the NestJS server listens on inside the container (`3000`) |
+
+`DATABASE_URL` for the backend and `VITE_PROXY_TARGET` for the frontend are
+derived automatically inside `docker-compose.yml`; they don't need to be set
+manually.
+
+## CI/CD
+
+GitHub Actions runs on pull requests to `main` (`.github/workflows/ci.yml`):
+
+- **Backend job:** install dependencies, run `prisma migrate deploy`, seed the
+  database, lint, run the Jest suite (against a PostgreSQL 16 service container).
+- **Frontend job:** install dependencies, lint, run the Vitest suite (in parallel
+  with the backend job).
+
+`sync-backlog.yml` syncs `BACKLOG.md` to GitHub Issues and a Kanban board on push
+to `main`. It requires a `HEXAROT_PROJECT_TOKEN` repository secret (classic
+Personal Access Token with `repo` and `project` scopes); see
+[CONTRIBUTING.md](../CONTRIBUTING.md) for setup.
+
+`changelog.yml` regenerates `CHANGELOG.md` on push to `main` and opens a pull
+request rather than pushing directly. It requires "Allow GitHub Actions to
+create and approve pull requests" to be enabled in the repository's Actions
+settings.

--- a/docs/product-context.fr.md
+++ b/docs/product-context.fr.md
@@ -1,0 +1,60 @@
+🇫🇷 Version française | [🇬🇧 English version](product-context.md)
+
+---
+
+# Contexte produit
+
+## Ce qu'est HexaRot
+
+HexaRot est un chiffre visuel qui combine l'encodage de symboles par couleur avec
+des rotations géométriques de blocs, pour produire des cryptogrammes faciles à
+générer et difficiles à lire. Les paramètres de chiffrement (taille de bloc,
+décalage de rotation, ordre de lecture, et plus) sont condensés dans une clé
+compacte, offrant un contrôle fin sur la complexité de la sortie.
+
+## Nature et public
+
+HexaRot est une application web avec une API intégrée. L'interface web est le
+point d'entrée principal ; l'API permet l'intégration dans des projets tiers mais
+n'est pas l'objectif premier.
+
+Le public visé est toute personne intéressée par la cryptographie visuelle en tant
+que concept. Les usages spécifiques au geocaching (l'alphabet Hexahue est issu de
+cette communauté) ne sont pas mis en avant comme un public cible particulier.
+
+## Le chiffre, en bref
+
+- **Alphabet visuel :** basé sur Hexahue, où chaque caractère est un bloc de 2×3
+  cases de couleur. Le système repose sur une abstraction `VisualAlphabet`
+  permettant d'ajouter d'autres alphabets visuels compatibles (grille, substitution
+  caractère par caractère) à l'avenir ; seul Hexahue est implémenté aujourd'hui.
+- **Pré-traitement :** le texte est mis en majuscules et les caractères accentués
+  sont translittérés (é→E, à→A, ç→C…) ; tout caractère hors de l'alphabet et hors
+  translittération est signalé à l'utilisateur plutôt que silencieusement ignoré.
+- **Construction de la grille :** le message est disposé en lignes dimensionnées
+  pour être un multiple de la taille de bloc pivot, avec un padding aléatoire
+  complétant la grille.
+- **Rotation :** la grille est divisée en blocs pivots, chacun tourné selon la
+  séquence définie dans la clé. La rotation s'applique aux cases de couleur
+  individuelles, pas aux symboles entiers, ce qui disloque le motif visuel et
+  produit le bruit apparent du cryptogramme.
+- **La clé :** une chaîne base36 compacte, réutilisable et indépendante du message
+  (préfixe `HR`) condensant la version du système, la taille de bloc pivot, la
+  séquence et la direction de rotation, et l'ordre de lecture. Voir l'[ADR 0001](adr/0001-no-message-length-exposure.md)
+  pour comprendre pourquoi la clé et le cryptogramme ne contiennent délibérément
+  aucune métadonnée de longueur.
+
+## Objectif du projet
+
+HexaRot est un projet personnel à double vocation :
+
+- **Apprentissage :** TypeScript strict, architecture NestJS (modules, injection
+  de dépendances, pipes), Prisma + PostgreSQL, Vue.js 3 Composition API, rendu
+  d'images avec Sharp, encodage base36, algorithmes de rotation de matrices 2D,
+  CI/CD GitHub Actions.
+- **Portfolio :** démontrer une approche structurée sur un domaine algorithmique
+  non trivial, du design du chiffre jusqu'à la livraison full-stack testée et
+  documentée.
+
+Voir [docs/roadmap.fr.md](roadmap.fr.md) pour ce qui est implémenté et ce qui est
+prévu.

--- a/docs/product-context.md
+++ b/docs/product-context.md
@@ -1,0 +1,57 @@
+[🇫🇷 Version française](product-context.fr.md) | 🇬🇧 English version
+
+---
+
+# Product context
+
+## What HexaRot is
+
+HexaRot is a visual cipher that combines colour-based symbol encoding with
+geometric block rotations to produce cryptograms that are easy to generate and
+hard to read. Encryption parameters (block size, rotation offset, reading order,
+and more) are bundled into a compact key, giving fine-grained control over the
+complexity of the output.
+
+## Nature and audience
+
+HexaRot is a web application with an integrated API. The web interface is the
+primary entry point; the API exists to allow integration into third-party
+projects but is not the primary purpose.
+
+The target audience is anyone interested in visual cryptography as a concept.
+Geocaching-specific use cases (the Hexahue alphabet originates from that
+community) are not highlighted as a specific audience.
+
+## The cipher, at a glance
+
+- **Visual alphabet:** built on Hexahue, where each character is a 2×3 block of
+  colour cases. The system is designed around a `VisualAlphabet` abstraction so
+  other grid-based, character-by-character alphabets could be added later; only
+  Hexahue is implemented today.
+- **Pre-processing:** text is uppercased and accented characters are
+  transliterated (é→E, à→A, ç→C…); any character outside the alphabet and outside
+  transliteration is reported to the user rather than silently dropped.
+- **Grid construction:** the message is laid out in rows sized to be a multiple of
+  the pivot block size, with random padding completing the grid.
+- **Rotation:** the grid is divided into pivot blocks, each rotated according to
+  the sequence defined in the key. Rotation operates on individual colour cases,
+  not whole symbols, which is what dislocates the visual pattern and produces the
+  cryptogram's apparent noise.
+- **The key:** a compact, reusable, message-independent base36 string (`HR`
+  prefix) packing the system version, pivot block size, rotation sequence and
+  direction, and reading order. See [ADR 0001](adr/0001-no-message-length-exposure.md)
+  for why the key and cryptogram deliberately carry no message-length metadata.
+
+## Project purpose
+
+HexaRot is a personal project with a dual purpose:
+
+- **Learning:** TypeScript strict mode, NestJS architecture (modules, dependency
+  injection, pipes), Prisma + PostgreSQL, Vue.js 3 Composition API, image
+  rendering with Sharp, base36 encoding, 2D matrix rotation algorithms, GitHub
+  Actions CI/CD.
+- **Portfolio:** demonstrating a structured approach across a non-trivial
+  algorithmic domain, from cipher design to tested, documented full-stack
+  delivery.
+
+See [docs/roadmap.md](roadmap.md) for what's implemented and what's planned.

--- a/docs/roadmap.fr.md
+++ b/docs/roadmap.fr.md
@@ -1,0 +1,33 @@
+🇫🇷 Version française | [🇬🇧 English version](roadmap.md)
+
+---
+
+# Roadmap
+
+## V1
+
+- ✅ Infra (NestJS, Vue.js, Docker Compose, Prisma)
+- ✅ CI (GitHub Actions, pipeline de tests, synchronisation du backlog)
+- ✅ Alphabet (interface VisualAlphabet + implémentation Hexahue)
+- ✅ Cipher (pré-traitement, construction de grille, pas d'en-tête de métadonnées, choix délibéré anti-fuite)
+- ✅ Moteur de rotation
+- ✅ Codec de clé (encodage / décodage / validation base36)
+- ✅ Stratégies d'ordre de lecture (4 directions + mode alterné)
+- ✅ Renderers (PNG + SVG)
+- ✅ Endpoints API (encode, decode, key)
+- ✅ Frontend (vues encodage, décodage, clé toutes terminées, passe UI/UX terminée)
+- ✅ Tests & couverture (suites unitaires/e2e backend + frontend, reporting Codecov, seuil global ≥85% confirmé)
+
+## V2
+
+- ⬜ Interface française (i18n)
+- ⬜ Mode de décodage animé
+- ⬜ Ordre de lecture en spirale
+- ⬜ Score de corrélation
+- ⬜ Authentification utilisateur
+
+---
+
+`BACKLOG.md` (gitignored, local au mainteneur) est la source de vérité unique pour
+le travail planifié au niveau de chaque item ; cette roadmap suit les phases de
+plus haut niveau.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,32 @@
+[🇫🇷 Version française](roadmap.fr.md) | 🇬🇧 English version
+
+---
+
+# Roadmap
+
+## V1
+
+- ✅ Infra (NestJS, Vue.js, Docker Compose, Prisma)
+- ✅ CI (GitHub Actions, tests pipeline, backlog sync)
+- ✅ Alphabet (VisualAlphabet interface + Hexahue implementation)
+- ✅ Cipher (pre-processing, grid construction, no metadata header by design, a deliberate anti-leakage choice)
+- ✅ Rotation engine
+- ✅ Key codec (base36 encode / decode / validate)
+- ✅ Reading order strategies (4 directions + alternate)
+- ✅ Renderers (PNG + SVG)
+- ✅ API endpoints (encode, decode, key)
+- ✅ Frontend (encode, decode, key views all done, UI/UX polish pass done)
+- ✅ Tests & coverage (backend + frontend unit/e2e suites, Codecov reporting, ≥85% global bar confirmed)
+
+## V2
+
+- ⬜ French interface (i18n)
+- ⬜ Animated decoding mode
+- ⬜ Spiral reading order
+- ⬜ Correlation score
+- ⬜ User authentication
+
+---
+
+`BACKLOG.md` (gitignored, local to the maintainer) is the single source of truth
+for planned work at the item level; this roadmap tracks the higher-level phases.

--- a/frontend/README.fr.md
+++ b/frontend/README.fr.md
@@ -1,0 +1,68 @@
+🇫🇷 Version française | [🇬🇧 English version](README.md)
+
+---
+
+# Frontend HexaRot
+
+Application monopage Vue 3 + TypeScript pour le chiffre visuel HexaRot : vues
+Encode, Decode et Key, adossées à l'[API backend](../backend/README.fr.md).
+
+Voir le [README racine](../README.fr.md) pour la vue d'ensemble du projet et le
+[guide d'architecture frontend](../docs/architecture/frontend_architecture.fr.md)
+pour le détail de la structure.
+
+---
+
+## Prérequis
+
+- Node.js et npm
+
+Le lancement via Docker Compose depuis la racine du dépôt est la configuration
+recommandée ; voir la section Démarrage rapide du README racine.
+
+---
+
+## Installation
+
+```bash
+npm install
+```
+
+## Développement
+
+```bash
+npm run dev                 # serveur de dev Vite
+npm run build                # vérification des types (vue-tsc) + build de production
+npm run preview              # prévisualiser le build de production en local
+npm run lint                 # ESLint
+```
+
+## Tests
+
+```bash
+npm run test                 # Vitest
+npm run test:cov            # rapport de couverture
+```
+
+---
+
+## Structure
+
+```
+src/
+├── views/           # EncodeView, DecodeView, KeyView
+├── stores/           # Stores Pinia (encode, decode, key)
+├── components/       # Composants UI partagés
+├── layouts/          # Structures de mise en page
+├── api/              # Client de l'API backend
+├── constants/        # Constantes partagées (ordres de lecture, tailles, etc.)
+├── locales/           # Fichiers de traduction vue-i18n
+├── router/            # Configuration de Vue Router
+└── utils/             # Fonctions utilitaires partagées
+```
+
+## Internationalisation
+
+Le frontend utilise `vue-i18n`. Seule la locale anglaise (`locales/en.json`) est
+implémentée ; une locale française est prévue pour une version ultérieure (voir
+[docs/roadmap.fr.md](../docs/roadmap.fr.md)).

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,5 +1,68 @@
-# Vue 3 + TypeScript + Vite
+[🇫🇷 Version française](README.fr.md) | 🇬🇧 English version
 
-This template should help get you started developing with Vue 3 and TypeScript in Vite. The template uses Vue 3 `<script setup>` SFCs, check out the [script setup docs](https://v3.vuejs.org/api/sfc-script-setup.html#sfc-script-setup) to learn more.
+---
 
-Learn more about the recommended Project Setup and IDE Support in the [Vue Docs TypeScript Guide](https://vuejs.org/guide/typescript/overview.html#project-setup).
+# HexaRot frontend
+
+Vue 3 + TypeScript single-page application for the HexaRot visual cipher: Encode,
+Decode, and Key views backed by the [backend API](../backend/README.md).
+
+See the root [README](../README.md) for the project overview and the
+[frontend architecture guide](../docs/architecture/frontend_architecture.md) for a
+detailed structure walkthrough.
+
+---
+
+## Requirements
+
+- Node.js and npm
+
+Running through Docker Compose from the repository root is the recommended setup; see
+the root README's Quick start section.
+
+---
+
+## Setup
+
+```bash
+npm install
+```
+
+## Development
+
+```bash
+npm run dev                 # Vite dev server
+npm run build                # type-check (vue-tsc) + production bundle
+npm run preview              # preview the production build locally
+npm run lint                 # ESLint
+```
+
+## Testing
+
+```bash
+npm run test                 # Vitest
+npm run test:cov            # coverage report
+```
+
+---
+
+## Structure
+
+```
+src/
+├── views/           # EncodeView, DecodeView, KeyView
+├── stores/           # Pinia stores (encode, decode, key)
+├── components/       # Shared UI components
+├── layouts/          # Page layout shells
+├── api/              # Backend API client
+├── constants/        # Shared constants (reading orders, sizes, etc.)
+├── locales/           # vue-i18n translation files
+├── router/            # Vue Router configuration
+└── utils/             # Shared utility functions
+```
+
+## Internationalization
+
+The frontend uses `vue-i18n`. Only the English locale (`locales/en.json`) is
+implemented; a French locale is planned for a later release (see
+[docs/roadmap.md](../docs/roadmap.md)).


### PR DESCRIPTION
## Summary
- Rewrite backend/frontend READMEs with real HexaRot content, add CODE_OF_CONDUCT and SECURITY policies
- Add changelog automation (git-cliff config, generated CHANGELOG.md, PR-based GitHub Actions workflow)
- Split reference content out of the root README into docs/: roadmap, product-context, design-system, operations, backend/frontend architecture, API reference, and three developer/user guides (each with an EN/FR pair)
- Add 5 Architecture Decision Records sourced from real commit history and design-spec documents (no-message-length-exposure, key-off-query-string, Prisma CommonJS output, Traefik local dev routing, stale-result handling)
- Add GitHub issue templates for bug reports and feature requests
- Trim the root README's Roadmap and API sections down to short pointers into the new docs/ files

## Test plan
- [ ] Review generated CHANGELOG.md for accuracy
- [ ] After merge, enable "Allow GitHub Actions to create and approve pull requests" in repo Actions settings so the changelog workflow can open PRs
- [ ] Spot-check the bilingual pairs for consistency (EN/FR)
