### PR TITLE
ci: fix duplicate --config flag in changelog workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -26,7 +26,7 @@ jobs:
         uses: orhun/git-cliff-action@v4
         with:
           config: cliff.toml
-          args: --config cliff.toml -o CHANGELOG.md
+          args: -o CHANGELOG.md
 
       - name: Open pull request
         uses: peter-evans/create-pull-request@v6


### PR DESCRIPTION
## Summary
- The git-cliff-action's `config` input already passes `--config cliff.toml` internally; the workflow's `args` also repeated it, causing git-cliff to fail with "the argument '--config <PATH>' cannot be used multiple times"
- Drop the redundant flag from `args`, keeping only `-o CHANGELOG.md`

## Test plan
- [ ] Merge and confirm the changelog workflow succeeds and opens its PR on the next push to main
