### PR TITLE
docs: homogenize contributing guide and code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.fr.md
+++ b/CODE_OF_CONDUCT.fr.md
@@ -4,16 +4,41 @@
 
 # Code de conduite
 
-HexaRot est un projet personnel open source. Toute personne interagissant avec ce
-dépôt (issues, pull requests, discussions) est invitée à :
+## Notre engagement
 
-- Rester respectueuse et constructive dans ses échanges
-- Rester sur le sujet et centrée sur le projet
-- S'abstenir de tout harcèlement, attaque personnelle ou propos discriminatoire
+En tant que contributeurs et mainteneurs, nous nous engageons à faire de la participation au projet HexaRot une expérience exempte de harcèlement pour tout le monde, quel que soit le niveau d'expérience, le parcours ou l'identité.
 
-Les signalements de comportement inacceptable peuvent être envoyés au mainteneur
-via une issue GitHub, ou directement par email (voir le profil GitHub pour les
-coordonnées). Les signalements seront traités avec discrétion.
+## Nos standards
 
-Les manquements peuvent entraîner la suppression de commentaires ou le refus de
-contributions, à la discrétion du mainteneur.
+Exemples de comportements qui contribuent à un environnement positif :
+
+- Utiliser un langage accueillant et respectueux
+- Donner et accepter avec bienveillance des retours constructifs
+- Se concentrer sur ce qui est le mieux pour le projet et ses utilisateurs
+
+Exemples de comportements inacceptables :
+
+- Insultes, attaques personnelles ou langage agressif
+- Harcèlement, public ou privé
+- Publication d'informations privées d'autrui sans autorisation explicite
+
+## Périmètre
+
+Ce code de conduite s'applique dans tous les espaces du projet (issues, pull requests, commits, discussions) ainsi que dans tout canal de communication utilisé par les contributeurs du projet, dès lors qu'une personne participe au projet ou le représente.
+
+## Signalement
+
+Tout comportement inacceptable peut être signalé en contactant directement le mainteneur du projet, via une issue GitHub ou par email (voir le profil GitHub pour les coordonnées). Les signalements seront examinés et traités avec discrétion.
+
+## Barème des sanctions
+
+Les mainteneurs suivront ce barème pour déterminer les conséquences de toute violation :
+
+1. **Correction** : notice privée et informelle expliquant le problème et demandant un changement de comportement.
+2. **Avertissement** : avertissement formel, avec la mention qu'une récidive pourra entraîner une action supplémentaire.
+3. **Restriction temporaire** : restriction temporaire d'un ou plusieurs canaux de communication utilisés par le projet (issues, pull requests, chat, etc.) pour une durée définie.
+4. **Exclusion définitive** : exclusion définitive du projet et de l'ensemble de ses canaux de communication.
+
+## Attribution
+
+Ce code de conduite est adapté du [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -4,16 +4,41 @@
 
 # Code of Conduct
 
-HexaRot is a personal, open-source project. Everyone interacting with this
-repository (issues, pull requests, discussions) is expected to:
+## Our Pledge
 
-- Be respectful and constructive in all communication
-- Stay on topic and focused on the project
-- Refrain from harassment, personal attacks, or discriminatory language
+We as contributors and maintainers pledge to make participation in the HexaRot project a harassment-free experience for everyone, regardless of experience level, background, or identity.
 
-Reports of unacceptable behaviour can be sent to the maintainer via a GitHub issue
-or directly by email (see the GitHub profile for contact details). Reports will be
-handled with discretion.
+## Our Standards
 
-Violations may result in comments being removed, or contributions being declined,
-at the maintainer's discretion.
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and respectful language
+- Giving and gracefully accepting constructive feedback
+- Focusing on what is best for the project and its users
+
+Examples of unacceptable behavior:
+
+- Insults, personal attacks, or aggressive language
+- Harassment, public or private
+- Publishing others' private information without explicit permission
+
+## Scope
+
+This Code of Conduct applies within all project spaces (issues, pull requests, commits, discussions) and in any communication channel used by contributors of the project, whenever an individual is participating in or representing the project.
+
+## Enforcement
+
+Instances of unacceptable behavior may be reported by contacting the project maintainer directly, via a GitHub issue or by email (see the GitHub profile for contact details). Reports will be reviewed and handled with discretion.
+
+## Enforcement Guidelines
+
+Maintainers will follow these guidelines in determining the consequences for any violation:
+
+1. **Correction**: private, informal notice explaining the issue and requesting a change in behavior.
+2. **Warning**: a formal warning, with a note that repeated behavior may lead to further action.
+3. **Temporary restriction**: temporary restriction from one or more communication channels used by the project (issues, pull requests, chat, etc.) for a defined period.
+4. **Permanent exclusion**: permanent exclusion from the project and all its communication channels.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/CONTRIBUTING.fr.md
+++ b/CONTRIBUTING.fr.md
@@ -4,45 +4,126 @@
 
 # Contribuer à HexaRot
 
-## Environnement de développement local
+Il s'agit avant tout d'un projet personnel. Les contributions externes (rapports de bugs, correctifs, petites améliorations) sont bienvenues mais dans une portée limitée.
 
-Le développement local passe par un reverse proxy Traefik local, sur le même principe
-qu'en production, plutôt que de publier les ports des conteneurs directement.
+## Prérequis
 
-### Prérequis
+- **Docker & Docker Compose** : pour lancer la stack complète (backend, frontend, PostgreSQL)
+- **Node.js 20+** : pour développer le backend ou le frontend sans Docker
+- **Une instance Traefik locale** : nécessaire pour accéder à l'application via son domaine local, voir [Reverse proxy local](#reverse-proxy-local) ci-dessous
+- **Git**
 
-- Une instance Traefik déjà lancée localement, rattachée à un réseau Docker externe
-  nommé `traefik-public`, avec un entrypoint `web` sur le port 80.
-- Une entrée dans `/etc/hosts` faisant pointer `hexarot.marvinlerouge.local` vers
-  `127.0.0.1` :
-  ```
-  127.0.0.1 hexarot.marvinlerouge.local
-  ```
-
-### Lancer la stack
+## Installation locale
 
 ```bash
+git clone https://github.com/MarvinLeRouge/HexaRot.git
+cd HexaRot
 docker compose up
 ```
 
 - Frontend : `http://hexarot.marvinlerouge.local`
 - API backend : `http://hexarot.marvinlerouge.local/api/...`
-- PostgreSQL reste accessible directement sur `127.0.0.1:5433` pour l'outillage local
-  (Prisma Studio, `psql`) - non routé via Traefik.
+- PostgreSQL reste accessible directement sur `127.0.0.1:5433` pour l'outillage local (Prisma Studio, `psql`) - non routé via Traefik.
+
+### Backend seul
+
+```bash
+cd backend
+npm install
+npx prisma migrate dev
+npx prisma db seed
+npm run start:dev
+```
+
+### Frontend seul
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+## Lancer les tests
+
+```bash
+cd backend && npm run test       # tests unitaires (Jest)
+cd backend && npm run test:e2e   # tests end-to-end
+cd frontend && npm run test      # tests unitaires (Vitest)
+```
+
+## Workflow
+
+1. Forker le dépôt et créer une branche à partir de `main`.
+2. Faire la modification, avec des tests qui la couvrent.
+3. Commiter en suivant la convention ci-dessous.
+4. Pousser et ouvrir une pull request vers `main`.
+5. La CI doit passer avant la revue.
+
+## Nommage des branches
+
+| Type | Préfixe |
+|---|---|
+| Fonctionnalité | `feat/description-courte` |
+| Correction | `fix/description-courte` |
+| Maintenance | `chore/description-courte` |
+| Documentation | `docs/description-courte` |
+| Refactoring | `refactor/description-courte` |
+| Tests | `test/description-courte` |
+
+Minuscules, kebab-case, sans caractères spéciaux.
+
+## Convention de commit
+
+Suivre [Conventional Commits](https://www.conventionalcommits.org/), impératif, minuscules, sans point final, avec une section `Modified files:` obligatoire :
+
+```
+<type>(<scope optionnel>): <résumé court>
+
+Modified files:
+- chemin/vers/fichier-a.ext - ce qui a été modifié
+- chemin/vers/fichier-b.ext - ce qui a été modifié
+```
+
+Types : `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `style`, `perf`, `ci`.
+
+## Style de code
+
+- **Backend :** vérifié par ESLint et Prettier. Lancer `npm run lint && npm run format` dans `backend/` avant de pousser
+- **Frontend :** vérifié par ESLint et TypeScript. Lancer `npm run lint` dans `frontend/` avant de pousser
+
+La CI rejettera toute pull request qui ne passe pas ces vérifications.
+
+## Code de conduite
+
+Ce projet suit un [Code de conduite](CODE_OF_CONDUCT.fr.md). En participant, vous vous engagez à le respecter.
+
+## Licence
+
+En contribuant, vous acceptez que vos contributions soient distribuées sous la [licence MIT](LICENSE) du projet.
+
+---
+
+## Reverse proxy local
+
+Le développement local passe par un reverse proxy Traefik local, sur le même principe qu'en production, plutôt que de publier les ports des conteneurs directement.
+
+### Mise en place
+
+- Une instance Traefik déjà lancée localement, rattachée à un réseau Docker externe nommé `traefik-public`, avec un entrypoint `web` sur le port 80.
+- Une entrée dans `/etc/hosts` faisant pointer `hexarot.marvinlerouge.local` vers `127.0.0.1` :
+  ```
+  127.0.0.1 hexarot.marvinlerouge.local
+  ```
 
 ## Configuration de GitHub Actions
 
-Le pipeline CI/CD nécessite un Personal Access Token (classic) stocké comme secret de
-repository.
+Le pipeline CI/CD nécessite un Personal Access Token (classic) stocké comme secret de repository.
 
-**Pourquoi un classic token ?** L'API GraphQL GitHub Projects v2 ne supporte pas les
-fine-grained tokens à ce jour. Un classic token est donc requis pour les opérations sur
-le Kanban.
+**Pourquoi un classic token ?** L'API GraphQL GitHub Projects v2 ne supporte pas les fine-grained tokens à ce jour. Un classic token est donc requis pour les opérations sur le Kanban.
 
 ### 1. Créer le token
 
-Aller dans **GitHub → Settings → Developer settings → Personal access tokens → Tokens (classic)**
-et générer un nouveau token avec les scopes suivants :
+Aller dans **GitHub → Settings → Developer settings → Personal access tokens → Tokens (classic)** et générer un nouveau token avec les scopes suivants :
 
 - `repo` (scope entier)
 - `project`
@@ -51,10 +132,8 @@ Nommer le token `HEXAROT_PROJECT_TOKEN`.
 
 ### 2. Stocker le token
 
-Aller dans **repo GitHub → Settings → Secrets and variables → Actions → Repository secrets**
-et créer un secret nommé `HEXAROT_PROJECT_TOKEN` avec la valeur du token.
+Aller dans **repo GitHub → Settings → Secrets and variables → Actions → Repository secrets** et créer un secret nommé `HEXAROT_PROJECT_TOKEN` avec la valeur du token.
 
 ### Sécurité
 
-Le token est lié au compte propriétaire du repo. Ne jamais le committer dans le code.
-Le renouveler immédiatement s'il est compromis.
+Le token est lié au compte propriétaire du repo. Ne jamais le committer dans le code. Le renouveler immédiatement s'il est compromis.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,42 +4,126 @@
 
 # Contributing to HexaRot
 
-## Local development environment
+This is primarily a personal project. External contributions (bug reports, fixes, small improvements) are welcome but limited in scope.
 
-Local development is routed through a local Traefik reverse proxy, mirroring the
-topology used in production, instead of publishing container ports directly.
+## Prerequisites
 
-### Prerequisites
+- **Docker & Docker Compose**: to run the full stack (backend, frontend, PostgreSQL)
+- **Node.js 20+**: for backend or frontend development without Docker
+- **A local Traefik instance**: required to reach the app through its local domain, see [Local reverse proxy](#local-reverse-proxy) below
+- **Git**
 
-- A Traefik instance already running locally, attached to an external Docker network
-  named `traefik-public`, with a `web` entrypoint on port 80.
-- An entry in `/etc/hosts` pointing `hexarot.marvinlerouge.local` to `127.0.0.1`:
-  ```
-  127.0.0.1 hexarot.marvinlerouge.local
-  ```
-
-### Running the stack
+## Local setup
 
 ```bash
+git clone https://github.com/MarvinLeRouge/HexaRot.git
+cd HexaRot
 docker compose up
 ```
 
 - Frontend: `http://hexarot.marvinlerouge.local`
 - Backend API: `http://hexarot.marvinlerouge.local/api/...`
-- PostgreSQL remains reachable directly at `127.0.0.1:5433` for local tooling
-  (Prisma Studio, `psql`) - it is not routed through Traefik.
+- PostgreSQL remains reachable directly at `127.0.0.1:5433` for local tooling (Prisma Studio, `psql`) - it is not routed through Traefik.
+
+### Backend only
+
+```bash
+cd backend
+npm install
+npx prisma migrate dev
+npx prisma db seed
+npm run start:dev
+```
+
+### Frontend only
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+## Running tests
+
+```bash
+cd backend && npm run test       # unit tests (Jest)
+cd backend && npm run test:e2e   # end-to-end tests
+cd frontend && npm run test      # unit tests (Vitest)
+```
+
+## Workflow
+
+1. Fork the repository and create a branch off `main`.
+2. Make your change, with tests covering it.
+3. Commit following the convention below.
+4. Push and open a pull request against `main`.
+5. CI must pass before review.
+
+## Branch naming
+
+| Type | Prefix |
+|---|---|
+| Feature | `feat/short-description` |
+| Bug fix | `fix/short-description` |
+| Chore | `chore/short-description` |
+| Documentation | `docs/short-description` |
+| Refactor | `refactor/short-description` |
+| Tests | `test/short-description` |
+
+Use lowercase kebab-case. No special characters.
+
+## Commit convention
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/), imperative mood, lowercase summary, no trailing period, with a mandatory `Modified files:` section:
+
+```
+<type>(<optional scope>): <short summary>
+
+Modified files:
+- path/to/file-a.ext - what was changed
+- path/to/file-b.ext - what was changed
+```
+
+Types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `style`, `perf`, `ci`.
+
+## Code style
+
+- **Backend:** enforced by ESLint and Prettier. Run `npm run lint && npm run format` in `backend/` before pushing
+- **Frontend:** enforced by ESLint and TypeScript. Run `npm run lint` in `frontend/` before pushing
+
+CI will reject any pull request that fails these checks.
+
+## Code of Conduct
+
+This project follows a [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold it.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the project's [MIT License](LICENSE).
+
+---
+
+## Local reverse proxy
+
+Local development is routed through a local Traefik reverse proxy, mirroring the topology used in production, instead of publishing container ports directly.
+
+### Setup
+
+- A Traefik instance already running locally, attached to an external Docker network named `traefik-public`, with a `web` entrypoint on port 80.
+- An entry in `/etc/hosts` pointing `hexarot.marvinlerouge.local` to `127.0.0.1`:
+  ```
+  127.0.0.1 hexarot.marvinlerouge.local
+  ```
 
 ## GitHub Actions setup
 
 The CI/CD pipeline requires a Personal Access Token (classic) stored as a repository secret.
 
-**Why a classic token?** The GitHub Projects v2 GraphQL API does not support fine-grained
-tokens at this time. A classic token is therefore required for Kanban board operations.
+**Why a classic token?** The GitHub Projects v2 GraphQL API does not support fine-grained tokens at this time. A classic token is therefore required for Kanban board operations.
 
 ### 1. Create the token
 
-Go to **GitHub → Settings → Developer settings → Personal access tokens → Tokens (classic)**
-and generate a new token with the following scopes:
+Go to **GitHub → Settings → Developer settings → Personal access tokens → Tokens (classic)** and generate a new token with the following scopes:
 
 - `repo` (entire scope)
 - `project`
@@ -48,10 +132,8 @@ Name it `HEXAROT_PROJECT_TOKEN`.
 
 ### 2. Store the token
 
-Go to **repo GitHub → Settings → Secrets and variables → Actions → Repository secrets**
-and create a secret named `HEXAROT_PROJECT_TOKEN` with the token value.
+Go to **repo GitHub → Settings → Secrets and variables → Actions → Repository secrets** and create a secret named `HEXAROT_PROJECT_TOKEN` with the token value.
 
 ### Security
 
-The token is tied to the account that owns the repository. Never commit it to the codebase.
-Rotate it immediately if compromised.
+The token is tied to the account that owns the repository. Never commit it to the codebase. Rotate it immediately if compromised.


### PR DESCRIPTION
## Summary
- Restructure CONTRIBUTING.md/.fr.md around the shared cross-project template (Prerequisites, Local setup, Running tests, Workflow, Branch naming, Commit convention, Code style), keeping the Traefik reverse proxy and GitHub Actions PAT setup in a dedicated section instead of removing it
- Replace CODE_OF_CONDUCT.md/.fr.md with the Contributor Covenant-based template shared across projects

## Test plan
- [ ] Review rendered Markdown on GitHub for both languages
- [ ] Verify internal links (CODE_OF_CONDUCT.md, LICENSE) resolve correctly
