### PR TITLE
docs/adr-index: docs(adr): add ADR index

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,13 @@
+# Architecture Decision Records
+
+Lightweight ADRs capturing the significant design decisions behind HexaRot.
+English-only, like the changelog: a technical audit trail, not reader-facing
+prose.
+
+| ADR | Title | Date |
+|---|---|---|
+| [0001](0001-no-message-length-exposure.md) | No message-length exposure in the cryptogram | 2026-09-02 |
+| [0002](0002-key-off-query-string.md) | Move key parsing off a GET query string | 2026-09-02 |
+| [0003](0003-prisma-client-commonjs-output.md) | Force CommonJS output for the generated Prisma client | 2026-09-02 |
+| [0004](0004-traefik-reverse-proxy-local-dev.md) | Route local development through Traefik instead of published ports | 2026-09-02 |
+| [0005](0005-stale-result-marked-not-destroyed.md) | Mark stale results, don't destroy them | 2026-09-02 |


### PR DESCRIPTION
## What was done
Added a docs/adr/README.md index table (ADR / title / date), matching the pattern already used on HiveMind.

## How to test
Open docs/adr/README.md and confirm each link resolves to the corresponding ADR file.

## Checklist
- [x] All existing ADRs listed with correct number, title, and date
