### PR TITLE
docs: add architecture summary page

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -115,6 +115,8 @@ longueur d'origine.
 
 ## Architecture
 
+Voir [docs/architecture.fr.md](docs/architecture.fr.md) pour la vue d'ensemble, [docs/architecture/backend_architecture.fr.md](docs/architecture/backend_architecture.fr.md) et [docs/architecture/frontend_architecture.fr.md](docs/architecture/frontend_architecture.fr.md) pour les détails d'implémentation.
+
 ```
 backend/
 ├── alphabet/        # Interface VisualAlphabet + implémentation HexahueAlphabet

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ with a `?` placeholder rather than storing or leaking the original length anywhe
 
 ## Architecture
 
+See [docs/architecture.md](docs/architecture.md) for the overview, [docs/architecture/backend_architecture.md](docs/architecture/backend_architecture.md) and [docs/architecture/frontend_architecture.md](docs/architecture/frontend_architecture.md) for implementation details.
+
 ```
 backend/
 ├── alphabet/        # VisualAlphabet interface + HexahueAlphabet implementation

--- a/docs/architecture.fr.md
+++ b/docs/architecture.fr.md
@@ -1,0 +1,52 @@
+🇫🇷 Version française | [🇬🇧 English version](architecture.md)
+
+---
+
+# Architecture - HexaRot
+
+> Référence technique publique. Voir [architecture backend](architecture/backend_architecture.fr.md) et [architecture frontend](architecture/frontend_architecture.fr.md) pour les détails d'implémentation.
+
+## Vue d'ensemble
+
+HexaRot est une application web à deux composants :
+
+- **Backend** - NestJS 11. Chaque domaine (alphabet, cipher, rotation, key, reading-order, renderer, validation) est un module autonome, assemblés pour encoder un texte en grille de couleurs Hexahue, la brouiller via des rotations de blocs, puis la décoder. PostgreSQL via Prisma stocke les données alphabet/symbole.
+- **Frontend** - SPA Vue 3 (Composition API) avec Pinia, Vue Router et vue-i18n. Trois vues (Encode, Decode, Key) pilotent le pipeline via l'API REST du backend.
+
+## Structure du projet
+
+```
+hexarot/
+├── backend/
+│   └── src/
+│       ├── alphabet/        # Interface VisualAlphabet + HexahueAlphabet
+│       ├── cipher/          # Pré-traitement, construction/décodage de la grille
+│       ├── rotation/        # Moteur de rotation de blocs (encode + inverse)
+│       ├── key/             # KeyCodec, encode/decode/validate base36
+│       ├── reading-order/   # Implémentations ReadingOrderStrategy
+│       ├── renderer/        # PngRenderer, SvgRenderer
+│       ├── validation/      # Validateur de paramètres basé sur le PGCD
+│       └── api/             # Contrôleurs NestJS + DTOs
+├── frontend/
+│   └── src/
+│       ├── views/       # EncodeView, DecodeView, KeyView
+│       ├── stores/      # Stores Pinia (encode, decode, key)
+│       ├── components/  # UI partagée et spécifique aux vues
+│       └── api/         # Client API du backend
+└── docs/
+    ├── architecture/    # architecture backend/frontend
+    ├── adr/             # architecture decision records
+    ├── api/             # référence API
+    └── guides/          # guides développeur/utilisateur
+```
+
+## Pour aller plus loin
+
+- [Architecture backend](architecture/backend_architecture.fr.md)
+- [Architecture frontend](architecture/frontend_architecture.fr.md)
+- [Référence API](api/api_endpoints.fr.md)
+- [Registre des décisions d'architecture](adr/README.md)
+- [Guides développeur](guides/)
+- [Contexte produit](product-context.fr.md)
+- [Opérations](operations.fr.md)
+- [Design system](design-system.fr.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,52 @@
+[🇫🇷 Version française](architecture.fr.md) | 🇬🇧 English version
+
+---
+
+# Architecture - HexaRot
+
+> Public technical reference. See [backend architecture](architecture/backend_architecture.md) and [frontend architecture](architecture/frontend_architecture.md) for implementation details.
+
+## Overview
+
+HexaRot is a two-component web application:
+
+- **Backend** - NestJS 11. Each domain (alphabet, cipher, rotation, key, reading-order, renderer, validation) is a standalone module, wired together to encode text into a Hexahue colour grid, scramble it via block rotations, and decode it back. PostgreSQL via Prisma stores the alphabet/symbol data.
+- **Frontend** - Vue 3 (Composition API) SPA with Pinia, Vue Router, and vue-i18n. Three views (Encode, Decode, Key) drive the pipeline over the backend's REST API.
+
+## Project structure
+
+```
+hexarot/
+├── backend/
+│   └── src/
+│       ├── alphabet/        # VisualAlphabet interface + HexahueAlphabet
+│       ├── cipher/          # Pre-processing, grid construction/decoding
+│       ├── rotation/        # Block rotation engine (encode + inverse)
+│       ├── key/             # KeyCodec, base36 encode/decode/validate
+│       ├── reading-order/   # ReadingOrderStrategy implementations
+│       ├── renderer/        # PngRenderer, SvgRenderer
+│       ├── validation/      # GCD-based parameter validator
+│       └── api/             # NestJS controllers + DTOs
+├── frontend/
+│   └── src/
+│       ├── views/       # EncodeView, DecodeView, KeyView
+│       ├── stores/      # Pinia stores (encode, decode, key)
+│       ├── components/  # Shared and view-specific UI
+│       └── api/         # Backend API client
+└── docs/
+    ├── architecture/    # backend/frontend architecture
+    ├── adr/             # architecture decision records
+    ├── api/             # API reference
+    └── guides/          # developer/user guides
+```
+
+## Further reading
+
+- [Backend architecture](architecture/backend_architecture.md)
+- [Frontend architecture](architecture/frontend_architecture.md)
+- [API reference](api/api_endpoints.md)
+- [Architecture decision records](adr/README.md)
+- [Developer guides](guides/)
+- [Product context](product-context.md)
+- [Operations](operations.md)
+- [Design system](design-system.md)


### PR DESCRIPTION
Adds docs/architecture.md/.fr.md, a short overview page (NestJS backend + Vue 3 frontend, project structure, further reading) that links to the existing per-component architecture files under docs/architecture/. Updates the existing Architecture section in README.md/README.fr.md with a link to the new summary page alongside the existing split docs.
