### PR TITLE
docs: link architecture decision records from README

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -115,7 +115,7 @@ longueur d'origine.
 
 ## Architecture
 
-Voir [docs/architecture.fr.md](docs/architecture.fr.md) pour la vue d'ensemble, [docs/architecture/backend_architecture.fr.md](docs/architecture/backend_architecture.fr.md) et [docs/architecture/frontend_architecture.fr.md](docs/architecture/frontend_architecture.fr.md) pour les détails d'implémentation.
+Voir [docs/architecture.fr.md](docs/architecture.fr.md) pour la vue d'ensemble, [docs/architecture/backend_architecture.fr.md](docs/architecture/backend_architecture.fr.md) et [docs/architecture/frontend_architecture.fr.md](docs/architecture/frontend_architecture.fr.md) pour les détails d'implémentation, et [docs/adr/](docs/adr/) pour le registre des décisions d'architecture.
 
 ```
 backend/

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ with a `?` placeholder rather than storing or leaking the original length anywhe
 
 ## Architecture
 
-See [docs/architecture.md](docs/architecture.md) for the overview, [docs/architecture/backend_architecture.md](docs/architecture/backend_architecture.md) and [docs/architecture/frontend_architecture.md](docs/architecture/frontend_architecture.md) for implementation details.
+See [docs/architecture.md](docs/architecture.md) for the overview, [docs/architecture/backend_architecture.md](docs/architecture/backend_architecture.md) and [docs/architecture/frontend_architecture.md](docs/architecture/frontend_architecture.md) for implementation details, and [docs/adr/](docs/adr/) for architecture decision records.
 
 ```
 backend/


### PR DESCRIPTION
Adds a docs/adr/ link in the Architecture section of README.md and README.fr.md, aligning HexaRot with Portfolio-Engineering-Radar and Summit-Stats, which already surface this link at the README level.