### PR TITLE
chore(ci): add type-checking to pre-commit and CI on both layers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Type check
+        run: npm run typecheck
+
       - name: Test
         run: npm run test:cov
 
@@ -104,6 +107,9 @@ jobs:
 
       - name: Lint
         run: npm run lint
+
+      - name: Type check
+        run: npm run typecheck
 
       - name: Test
         run: npm run test:cov

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,6 +13,7 @@
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "typecheck": "tsc --noEmit --incremental false -p tsconfig.json",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",

--- a/backend/src/cipher/preprocess.spec.ts
+++ b/backend/src/cipher/preprocess.spec.ts
@@ -14,7 +14,7 @@ const HEXAHUE_CHARS = [
   ' ',
 ];
 
-const mockAlphabet: Pick<VisualAlphabet, 'getSupportedChars'> = {
+const mockAlphabet: VisualAlphabet = {
   getSupportedChars: () => HEXAHUE_CHARS,
 } as VisualAlphabet;
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "build": "vue-tsc -b && vite build",
     "preview": "vite preview",
     "lint": "eslint .",
+    "typecheck": "vue-tsc -b",
     "test": "vitest run --passWithNoTests",
     "test:cov": "vitest run --passWithNoTests --coverage"
   },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,13 @@
     "lint-staged": "^16.4.0"
   },
   "lint-staged": {
-    "backend/src/**/*.ts": "backend/node_modules/.bin/eslint --fix --flag unstable_config_lookup_from_file",
-    "frontend/src/**/*.{ts,vue}": "frontend/node_modules/.bin/eslint --fix --no-warn-ignored --flag unstable_config_lookup_from_file"
+    "backend/src/**/*.ts": [
+      "backend/node_modules/.bin/eslint --fix --flag unstable_config_lookup_from_file",
+      "bash -c 'cd backend && npm run typecheck'"
+    ],
+    "frontend/src/**/*.{ts,vue}": [
+      "frontend/node_modules/.bin/eslint --fix --no-warn-ignored --flag unstable_config_lookup_from_file",
+      "bash -c 'cd frontend && npm run typecheck'"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- Add `typecheck` script to backend (`tsc --noEmit`) and frontend (`vue-tsc -b`)
- Run typecheck in lint-staged (pre-commit) for both layers
- Add a "Type check" step to both CI jobs, right after lint
- Fix a mock type annotation in preprocess.spec.ts that the new typecheck step surfaced (test was passing at runtime but type-unsafe)

## Test plan
- [x] `npm run typecheck` passes in backend
- [x] `npm run typecheck` passes in frontend
- [x] `npx jest src/cipher/preprocess.spec.ts` still passes (21/21) after the mock fix
- [x] Pre-commit hook exercised end-to-end on this branch (eslint + typecheck both ran and passed)
