### PR TITLE
chore: add production Dockerfiles and docker-compose.prod.yml

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,30 @@
+# ─── base ────────────────────────────────────────────────────────────────
+FROM node:24-alpine AS base
+WORKDIR /app
+
+# ─── dev — hot reload via nest start --watch ───────────────────────────────
+FROM base AS dev
+COPY package*.json ./
+COPY prisma ./prisma
+RUN npm ci
+COPY . .
+CMD ["npm", "run", "start:dev"]
+
+# ─── build — compile TypeScript to dist/ ───────────────────────────────────
+FROM base AS build
+COPY package*.json ./
+COPY prisma ./prisma
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# ─── production — minimal runtime image ────────────────────────────────────
+FROM base AS production
+ENV NODE_ENV=production
+COPY package*.json ./
+COPY prisma ./prisma
+RUN npm ci --omit=dev
+COPY --from=build /app/dist ./dist
+COPY prisma.config.ts ./prisma.config.ts
+EXPOSE 3000
+CMD ["node", "dist/src/main"]

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -1,6 +1,0 @@
-FROM node:24-alpine
-WORKDIR /app
-COPY package*.json ./
-RUN npm ci
-COPY . .
-CMD ["npm", "run", "start:dev"]

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,7 +12,7 @@
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "node dist/main",
+    "start:prod": "node dist/src/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "typecheck": "tsc --noEmit --incremental false -p tsconfig.json",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,72 @@
+name: hexarot
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: hexarot-postgres
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+    networks:
+      - internal
+
+  backend:
+    image: ghcr.io/marvinlerouge/hexarot/backend:${IMAGE_TAG:-latest}
+    container_name: hexarot-backend
+    expose:
+      - "3000"
+    env_file:
+      - ../shared/env/app.env
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: unless-stopped
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=traefik-public"
+      - "traefik.http.routers.hexarot-api.rule=Host(`${DOMAIN}`) && PathPrefix(`/api`)"
+      - "traefik.http.routers.hexarot-api.entrypoints=websecure"
+      - "traefik.http.routers.hexarot-api.tls=true"
+      - "traefik.http.routers.hexarot-api.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.hexarot-api.middlewares=hexarot-strip-api"
+      - "traefik.http.routers.hexarot-api.service=hexarot-backend"
+      - "traefik.http.middlewares.hexarot-strip-api.stripprefix.prefixes=/api"
+      - "traefik.http.services.hexarot-backend.loadbalancer.server.port=3000"
+    networks:
+      - traefik-public
+      - internal
+
+  frontend:
+    image: ghcr.io/marvinlerouge/hexarot/frontend:${IMAGE_TAG:-latest}
+    container_name: hexarot-frontend
+    expose:
+      - "80"
+    restart: unless-stopped
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=traefik-public"
+      - "traefik.http.routers.hexarot-frontend.rule=Host(`${DOMAIN}`)"
+      - "traefik.http.routers.hexarot-frontend.entrypoints=websecure"
+      - "traefik.http.routers.hexarot-frontend.tls=true"
+      - "traefik.http.routers.hexarot-frontend.tls.certresolver=letsencrypt"
+      - "traefik.http.services.hexarot-frontend.loadbalancer.server.port=80"
+    networks:
+      - traefik-public
+
+volumes:
+  postgres_data:
+
+networks:
+  internal:
+    driver: bridge
+  traefik-public:
+    external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,8 @@ services:
   backend:
     build:
       context: ./backend
-      dockerfile: Dockerfile.dev
+      dockerfile: Dockerfile
+      target: dev
     volumes:
       - ./backend:/app
       - /app/node_modules
@@ -55,7 +56,8 @@ services:
   frontend:
     build:
       context: ./frontend
-      dockerfile: Dockerfile.dev
+      dockerfile: Dockerfile
+      target: dev
     volumes:
       - ./frontend:/app
       - /app/node_modules

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,25 @@
+# ─── base ────────────────────────────────────────────────────────────────
+FROM node:24-alpine AS base
+WORKDIR /app
+
+# ─── dev — Vite HMR ─────────────────────────────────────────────────────────
+FROM base AS dev
+COPY package*.json ./
+RUN npm ci
+COPY . .
+EXPOSE 5173
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]
+
+# ─── build — type-check and bundle static assets ───────────────────────────
+FROM base AS build
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# ─── production — Nginx serving static assets ──────────────────────────────
+FROM nginx:alpine AS production
+COPY --from=build /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,7 +1,0 @@
-FROM node:24-alpine
-WORKDIR /app
-COPY package*.json ./
-RUN npm ci
-COPY . .
-EXPOSE 5173
-CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,21 @@
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # SPA - fallback to index.html for client-side routing
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Cache static assets aggressively
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # Do not cache index.html
+    location = /index.html {
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+    }
+}


### PR DESCRIPTION
## Summary
- Add multi-stage Dockerfiles for backend and frontend (dev/build/production targets), replacing the standalone Dockerfile.dev files
- Add docker-compose.prod.yml pulling pre-built GHCR images with Traefik websecure/TLS/letsencrypt routing, matching the HiveMind production pattern
- Fix a latent bug: backend's start:prod pointed to dist/main but nest build actually outputs to dist/src/main (rootDir inference includes the sibling generated/ Prisma client dir)

## Test plan
- [x] Built both production images locally (backend, frontend)
- [x] Ran the full docker-compose.prod.yml stack locally against locally-built images with dummy env vars
- [x] Confirmed postgres starts healthy, backend connects and applies migrations, GET /api returns 200
- [x] Confirmed frontend serves the SPA correctly (200, index.html)
- [x] No production server or real deployment touched
