### PR TITLE
fix: set valid milestone on CHORE-010

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -2146,7 +2146,7 @@ changes (out of scope, doesn't construct `KeyParams` literals).
 
 - **type:** chore
 - **id:** CHORE-010
-- **milestone:** ~
+- **milestone:** v2
 - **status:** backlog
 - **priority:** low
 - **domain:** backend


### PR DESCRIPTION
## Summary
- CHORE-010's milestone was left as `~` (unset) when the item was created during CHORE-008's audit
- The sync-backlog workflow requires milestone to be v1 or v2, so every sync run since has aborted validation with "Invalid milestone: ~"
- Set to v2, matching CHORE-008 (the parent audit it was deferred from)

## Test plan
- [x] Ran sync-backlog.js locally against the fixed BACKLOG.md — validation passes (no "Invalid milestone" error)
- N/A beyond that, documentation-only change
