### PR TITLE
fix(ci): only create a label in sync-backlog when it truly doesn't exist

### DIFF
--- a/.github/scripts/sync-backlog.js
+++ b/.github/scripts/sync-backlog.js
@@ -188,7 +188,8 @@ async function ensureLabel(name, color) {
   const labelColor = color || 'ededed';
   try {
     await octokit.issues.getLabel({ owner: OWNER, repo: REPO, name });
-  } catch (_e) {
+  } catch (e) {
+    if (e.status !== 404) throw e;
     await octokit.issues.createLabel({ owner: OWNER, repo: REPO, name, color: labelColor });
     console.log('Created label: ' + name);
   }


### PR DESCRIPTION
ensureLabel() caught every error from getLabel and unconditionally tried to create the label. A transient non-404 error (observed: a 500 on GET /labels/refactor, label confirmed to already exist) collided with createLabel's 422 already_exists response and failed the entire sync job.

Now only a 404 triggers creation; any other error propagates instead of being silently misinterpreted as "label doesn't exist".
