### PR TITLE
fix(prisma): pin importFileExtension to js in generated client

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,7 +1,8 @@
 generator client {
-  provider     = "prisma-client"
-  output       = "../generated/prisma"
-  moduleFormat = "cjs"
+  provider            = "prisma-client"
+  output              = "../generated/prisma"
+  moduleFormat        = "cjs"
+  importFileExtension = "js"
 }
 
 datasource db {


### PR DESCRIPTION
## Summary
- The prisma-client generator (v7.10.0) nondeterministically emits internal client imports with a `.ts` extension instead of `.js` when `importFileExtension` is not set, which crashes the compiled backend in production with `MODULE_NOT_FOUND`
- Pins `importFileExtension = "js"` in the generator block to make the emitted extension deterministic

## Root cause
Confirmed by reproduction: three consecutive clean `--no-cache` Docker builds from the same commit currently deployed in production (c0069c4) produced inconsistent import extensions in the generated client without this setting. With the pin, all three builds were deterministic (`.js`) and the container booted the PrismaClient without error.

## Test plan
- [x] `npx prisma generate` locally confirms `.js` extension in generated client imports
- [x] `npm run typecheck` passes with exit code 0
- [x] Three consecutive clean Docker `--no-cache` builds from `origin/main` (c0069c4) produced a deterministic, working image
- [ ] Merge and redeploy to replace the crash-looping production image
