### PR TITLE
fix(traefik): stop stripping the /api prefix for the prod backend router

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -38,9 +38,7 @@ services:
       - "traefik.http.routers.hexarot-api.entrypoints=websecure"
       - "traefik.http.routers.hexarot-api.tls=true"
       - "traefik.http.routers.hexarot-api.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.hexarot-api.middlewares=hexarot-strip-api"
       - "traefik.http.routers.hexarot-api.service=hexarot-backend"
-      - "traefik.http.middlewares.hexarot-strip-api.stripprefix.prefixes=/api"
       - "traefik.http.services.hexarot-backend.loadbalancer.server.port=3000"
     networks:
       - traefik-public


### PR DESCRIPTION
## Summary
- NestJS registers every backend route under /api (app.setGlobalPrefix in main.ts), matching dev where Traefik forwards the full path unchanged
- In prod, the hexarot-strip-api middleware stripped /api before forwarding to the backend, so incoming requests lost the prefix the backend's routes require, producing a 404 on every endpoint
- Removes the middleware and its stripprefix rule so prod Traefik behavior matches dev

## Test plan
- [x] Confirmed on the running prod backend: `GET /api` returned
  `Cannot GET /` and `POST /api/key/generate` returned
  `Cannot POST /key/generate` (prefix stripped before reaching backend)
- [ ] After deploy, confirm `GET /api` and `POST /api/key/generate`
  return the expected NestJS responses instead of 404
