### PR TITLE
fix(backlog): correct FEAT-023 status to a valid sync value

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -2147,7 +2147,7 @@ changes (out of scope, doesn't construct `KeyParams` literals).
 - **type:** feat
 - **id:** FEAT-023
 - **milestone:** v2
-- **status:** in-progress
+- **status:** done
 - **priority:** medium
 - **domain:** frontend
 - **complexity:** XL


### PR DESCRIPTION
## Summary

sync-backlog.yml failed on PR #191's merge with "Invalid status: in-progress" - BACKLOG.md's FEAT-023 entry used a hyphen (in-progress) instead of the sync script's expected in_progress/done values. Since FEAT-023 is now merged to main, set it to done.

## Test plan

- [x] Confirmed no other BACKLOG.md entries have an invalid status value
