### PR TITLE
fix(deploy): seed the admin account during production deployment

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -116,6 +116,13 @@ jobs:
             DOMAIN="$DOMAIN" docker compose -f docker-compose.prod.yml run --rm --no-deps backend \
               npx prisma migrate deploy
 
+            echo "==> Seed reference data and admin account"
+            # seed.ts idempotently upserts the alphabet data and the single admin
+            # account (update: {} on conflict) - safe to run on every deploy, never
+            # overwrites an existing account's password, role, or status.
+            DOMAIN="$DOMAIN" docker compose -f docker-compose.prod.yml run --rm --no-deps backend \
+              npx prisma db seed
+
             echo "==> Start all services"
             DOMAIN="$DOMAIN" docker compose -f docker-compose.prod.yml up -d --remove-orphans
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1374,7 +1374,7 @@ Docker itself:
 - **type:** ci
 - **id:** CI-004
 - **milestone:** v1
-- **status:** ready
+- **status:** done
 - **priority:** medium
 - **domain:** infra
 - **complexity:** M
@@ -1406,6 +1406,22 @@ direct SSH access to the production server is performed outside of this pipeline
   images, runs `prisma migrate deploy`, then restarts the stack
 - Required secrets are documented in `CONTRIBUTING.md` (names only, no values)
 - Workflow fails loudly (non-zero exit) if any step fails, with no partial silent state
+
+#### Resolution (2026-09-10)
+
+`build-deploy.yml` merged via PR #185 (2026-09-09), covering the build, push, and
+migration-deploy steps against all five acceptance criteria above.
+
+The first real deploy surfaced a gap not covered by those criteria: the admin account
+was never created in production, because the pipeline never ran `prisma db seed`, and
+`tsx` (which executes `backend/prisma/seed.ts` per `prisma.config.ts`) was a
+`devDependency`, unavailable in the `--omit=dev` production image. Fixed by moving
+`tsx` to `dependencies` and adding a seed step to the deploy workflow, right after
+`prisma migrate deploy`, using the same `run --rm --no-deps backend` pattern. The seed
+is idempotent by design (`upsert` with `update: {}` on conflict in `seedAdminUser()`),
+so running it on every deploy never overwrites an existing account. The two VPS-side
+variables it needs (`SEED_ADMIN_EMAIL`, `SEED_ADMIN_PASSWORD`) are documented in
+`CONTRIBUTING.md` alongside the existing repository-secrets table.
 <!-- ITEM:END -->
 
 <!-- ITEM:BEGIN -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,3 +155,14 @@ Go to **repo GitHub → Settings → Secrets and variables → Actions → Repos
 ### Security
 
 These secrets grant SSH access to the production server and control public routing. Never commit them to the codebase. Rotate the SSH key immediately if compromised.
+
+### VPS environment files
+
+Separately from the repository secrets above, the deploy step's seed run (`npx prisma db seed`, see `backend/prisma/seed.ts`) reads two variables from the backend service's own env files on the VPS. Add them to `shared/env/secrets.env` (never `app.env`, since these are credentials):
+
+| Variable | Purpose |
+|---|---|
+| `SEED_ADMIN_EMAIL` | Email of the single admin account |
+| `SEED_ADMIN_PASSWORD` | Its password, hashed at seed time - never store the plaintext elsewhere |
+
+The seed step is idempotent (`upsert` with `update: {}` on conflict): it creates the admin account once and never touches it again on later deploys, even if these values change afterwards.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -26,7 +26,8 @@
         "prisma": "^7.10.0",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
-        "sharp": "^0.35.4"
+        "sharp": "^0.35.4",
+        "tsx": "^4.23.13"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.7",
@@ -51,7 +52,6 @@
         "ts-loader": "^9.6.2",
         "ts-node": "^10.9.2",
         "tsconfig-paths": "^4.2.0",
-        "tsx": "^4.23.13",
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.69.0"
       }
@@ -1186,7 +1186,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1203,7 +1202,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1220,7 +1218,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1237,7 +1234,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1254,7 +1250,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1271,7 +1266,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1288,7 +1282,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1305,7 +1298,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1322,7 +1314,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1339,7 +1330,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1356,7 +1346,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1373,7 +1362,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1390,7 +1378,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1407,7 +1394,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1424,7 +1410,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1441,7 +1426,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1458,7 +1442,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1475,7 +1458,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1492,7 +1474,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1509,7 +1490,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1526,7 +1506,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1543,7 +1522,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1560,7 +1538,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1577,7 +1554,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1594,7 +1570,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1611,7 +1586,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7940,7 +7914,6 @@
       "version": "0.28.2",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
       "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -8825,7 +8798,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -13084,7 +13056,6 @@
       "version": "4.23.13",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.13.tgz",
       "integrity": "sha512-BL5MGkRln6aDYhb0xbQlEAGw743BaZYWdbWtdJOBriYJboKgUUYCadFp2/FpBBZquBC/ezNBn7wMMPx7FDZUDw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.28.0"

--- a/backend/package.json
+++ b/backend/package.json
@@ -39,7 +39,8 @@
     "prisma": "^7.10.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
-    "sharp": "^0.35.4"
+    "sharp": "^0.35.4",
+    "tsx": "^4.23.13"
   },
   "overrides": {
     "@nestjs/throttler": {
@@ -70,7 +71,6 @@
     "ts-loader": "^9.6.2",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
-    "tsx": "^4.23.13",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.69.0"
   },


### PR DESCRIPTION
## Summary
- The production deploy pipeline ran `prisma migrate deploy` but never seeded data, so the admin account (and the Hexahue alphabet) never existed in the
production database, even after PR #185 shipped the pipeline.
- The seed also could not have run as-is: `tsx`, which executes `prisma/seed.ts`, was a devDependency and is absent from the `--omit=dev` production image.

## Changes
- `backend/package.json` / `package-lock.json`: move `tsx` from `devDependencies` to `dependencies`
- `.github/workflows/build-deploy.yml`: add a `prisma db seed` step after migrations, same `run --rm --no-deps backend` pattern as the existing migration step
- `CONTRIBUTING.md`: document the two VPS-side env vars the seed step needs (`SEED_ADMIN_EMAIL`, `SEED_ADMIN_PASSWORD`), to be added to `shared/env/secrets.env`
- `BACKLOG.md`: mark CI-004 done with a resolution note covering both PR #185 and this fix

## Idempotency
`seedAdminUser()` already upserts with `update: {}` on conflict — running the seed on every deploy creates the account once and never touches it again, even if the email/password values change afterwards.

## Test plan
- [x] Backend typecheck clean
- [x] Backend lint clean (0 errors, pre-existing warnings only)
- [x] Backend test suite passes (429 tests)
- [x] Workflow YAML validated
- [x] BACKLOG.md status values re-checked against sync-backlog.js's allowlist
- [ ] After merge and adding `SEED_ADMIN_EMAIL`/`SEED_ADMIN_PASSWORD` to `shared/env/secrets.env` on the VPS, verify the deploy workflow creates the admin account and login succeeds
