### PR TITLE
docs(roadmap): mark auth done, note pre-rotation display idea

### DIFF
--- a/docs/roadmap.fr.md
+++ b/docs/roadmap.fr.md
@@ -24,7 +24,13 @@
 - ⬜ Mode de décodage animé
 - ⬜ Ordre de lecture en spirale
 - ⬜ Score de corrélation
-- ⬜ Authentification utilisateur
+- ✅ Authentification utilisateur
+
+## Idées pour plus tard (pas encore cadrées)
+
+- Montrer l'encodage avant rotation à certains endroits (par exemple à
+  côté du score de corrélation) : pourrait rendre l'efficacité du
+  cryptogramme plus tangible, mais aucun item de backlog pour l'instant
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -24,7 +24,13 @@
 - ⬜ Animated decoding mode
 - ⬜ Spiral reading order
 - ⬜ Correlation score
-- ⬜ User authentication
+- ✅ User authentication
+
+## Ideas for later (not yet scoped)
+
+- Show the pre-rotation encoding at relevant points (e.g. alongside the
+  correlation score) - could make cryptogram effectiveness more tangible,
+  but no backlog item yet
 
 ---
 


### PR DESCRIPTION
## Summary
- `docs/roadmap.md`/`.fr.md` still listed "User authentication" as unchecked despite FEAT-021 and FEAT-023 having shipped
- While fixing that, captures an idea raised during FEAT-018 (correlation score) planning: showing the pre-rotation encoding alongside the score could make cryptogram effectiveness more tangible - explicitly kept out of FEAT-018's scope (backend-only, score value only), not yet a backlog item, recorded here so it isn't lost
